### PR TITLE
Add Tizen Support

### DIFF
--- a/build-tool/BuildTool.hx
+++ b/build-tool/BuildTool.hx
@@ -1552,6 +1552,19 @@ class BuildTool
          defines.set("webos","webos");
          defines.set("BINDIR","webOS");
       }
+      else if (defines.exists("tizen"))
+      {
+         if (defines.exists ("simulator"))
+         {
+            defines.set("toolchain","tizen-x86");
+         }
+         else
+         {
+            defines.set("toolchain","tizen");
+         }
+         defines.set("tizen","tizen");
+         defines.set("BINDIR","Tizen");
+      }
 	  else if (defines.exists("blackberry"))
       {
 		 if (defines.exists("simulator"))

--- a/build-tool/gcc-toolchain.xml
+++ b/build-tool/gcc-toolchain.xml
@@ -33,6 +33,8 @@
   <exe name ="arm-linux-androideabi-strip" if="android" />
   <exe name ="ntox86-strip" if="blackberry" />
   <exe name ="ntoarmv7-strip" if="blackberry" unless="simulator" />
+  <exe name ="i386-linux-gnueabi-strip" if="tizen" />
+  <exe name ="arm-linux-gnueabi-strip" if="tizen" unless="simulator" />
   <exe name ="${HXCPP_STRIP}" if="HXCPP_STRIP" />
   <flag value="-u" if="macos"/>
   <flag value="-r" if="macos"/>

--- a/build-tool/tizen-toolchain.xml
+++ b/build-tool/tizen-toolchain.xml
@@ -1,0 +1,98 @@
+<xml>
+
+
+<error name="Error: TIZEN_SDK must be defined to build for Tizen" unless="TIZEN_SDK" />
+
+<set name="TIZEN_PLATFORM" value="${TIZEN_SDK}/platforms/tizen2.2/rootstraps/tizen-device-2.2.native" />
+
+
+<path name="${TIZEN_SDK}/tools/arm-linux-gnueabi-gcc-4.5/bin" />
+ 
+<include name="gcc-toolchain.xml"/>
+
+
+<!-- TIZEN TOOLS -------------------------------------------------->
+	
+<compiler id="tizen" exe="arm-linux-gnueabi-g++" if="tizen">
+	<flag value="-c"/>
+	<flag value="-g" if="debug"/>
+	<flag value="-O2" unless="debug"/>
+	<flag value="-I${HXCPP}/include"/>
+	<flag value="-I${TIZEN_PLATFORM}/usr/include"/>
+	<flag value="-DTIZEN"/>
+	<flag value="-D_APP_LOG"/>
+	<flag value="-march=armv7-a"/>
+	<flag value="-mfloat-abi=softfp"/>
+	<flag value="-mfpu=vfpv3-d16"/>
+	<flag value="-mtune=cortex-a8"/>
+	<include name="common-defines.xml" />
+	<flag value="-fvisibility=hidden"/>
+	<flag value="-fdollars-in-identifiers"/>
+	<flag value="-fpic"/>
+	<flag value="-fPIC"/>
+	<cppflag value="-frtti"/>
+	<!-- <flag value="-fPIE" /> -->
+	<flag value="--sysroot=${TIZEN_PLATFORM}" />
+	<outflag value="-o"/>
+	<objdir value="./obj/tizen${OBJEXT}" />
+</compiler>
+
+<linker id="exe" exe="arm-linux-gnueabi-g++" if="tizen">
+	<flag value="-g" if="debug"/>
+	<flag value="-O2" unless="debug"/>
+	<flag value="-s" unless="debug"/>
+	<!-- <flag value="-rdynamic"/> -->
+	<flag value="-pie" />
+	<lib name="-lpthread" />
+	<flag value="-march=armv7-a"/>
+	<flag value="-mfloat-abi=softfp"/>
+	<flag value="-mfpu=vfpv3-d16"/>
+	<flag value="-mtune=cortex-a8"/>
+	<flag value="-Xlinker" />
+	<flag value="--as-needed" />
+	<flag value="-Xlinker" />
+	<flag value="-rpath=/opt/usr/apps/${APP_ID}/lib" />
+	<flag value="-Xlinker" />
+	<flag value="-rpath=/home/developer/sdk_tools/lib" />
+	<flag value="--sysroot=${TIZEN_PLATFORM}" />
+	<flag value="-L${TIZEN_PLATFORM}/usr/lib" />
+	<flag value="-L${TIZEN_PLATFORM}/usr/lib/osp" />
+	<lib name="-losp-appfw" />
+	<!-- <flag value="-fpic"/>
+	<flag value="-fPIC"/> -->
+	<ext value=".exe"/>
+	<outflag value="-o"/>
+	<lib name="-ldl"/>
+</linker>
+	
+<linker id="dll" exe="arm-linux-gnueabi-g++" if="tizen">
+	<flag value="-shared"/>
+	<flag value="-g" if="debug"/>
+	<flag value="-O2" unless="debug"/>
+	<flag value="-s" unless="debug"/>
+	<!-- <flag value="-pie" /> -->
+	<lib name="-lpthread" />
+	<flag value="-march=armv7-a"/>
+	<flag value="-mfloat-abi=softfp"/>
+	<flag value="-mfpu=vfpv3-d16"/>
+	<flag value="-mtune=cortex-a8"/>
+	<flag value="-Xlinker" />
+	<flag value="--as-needed" />
+	<!--<flag value="-Xlinker" />
+	<flag value="-rpath=/opt/usr/apps/DugJgh8Hxl/lib" /> -->
+	<flag value="-Xlinker" />
+	<flag value="-rpath=/home/developer/sdk_tools/lib" />
+	<flag value="--sysroot=${TIZEN_PLATFORM}" />
+	<flag value="-L${TIZEN_PLATFORM}/usr/lib" />
+	<flag value="-L${TIZEN_PLATFORM}/usr/lib/osp" />
+	<cppflag value="-frtti"/>
+	<!-- <flag value="-fpic"/>
+	<flag value="-fPIC"/> -->
+	<!-- <flag value="-pie" /> -->
+	<lib name="-ldl"/>
+	<ext value=".so"/>
+	<outflag value="-o"/>
+</linker>
+
+
+</xml>

--- a/build-tool/tizen-x86-toolchain.xml
+++ b/build-tool/tizen-x86-toolchain.xml
@@ -1,0 +1,86 @@
+<xml>
+
+
+<error name="Error: TIZEN_SDK must be defined to build for Tizen" unless="TIZEN_SDK" />
+
+<set name="TIZEN_PLATFORM" value="${TIZEN_SDK}/platforms/tizen2.2/rootstraps/tizen-emulator-2.2.native" />
+
+
+<path name="${TIZEN_SDK}/tools/i386-linux-gnueabi-gcc-4.5/bin" />
+ 
+<include name="gcc-toolchain.xml"/>
+
+
+<!-- TIZEN TOOLS -------------------------------------------------->
+	
+<compiler id="tizen" exe="i386-linux-gnueabi-g++" if="tizen">
+	<flag value="-c"/>
+	<flag value="-g" if="debug"/>
+	<flag value="-O2" unless="debug"/>
+	<flag value="-I${HXCPP}/include"/>
+	<flag value="-I${TIZEN_PLATFORM}/usr/include"/>
+	<flag value="-DTIZEN"/>
+	<flag value="-D_APP_LOG"/>
+	<include name="common-defines.xml" />
+	<flag value="-fvisibility=hidden"/>
+	<flag value="-fdollars-in-identifiers"/>
+	<flag value="-fpic"/>
+	<flag value="-fPIC"/>
+	<cppflag value="-frtti"/>
+	<!-- <flag value="-fPIE" /> -->
+	<flag value="--sysroot=${TIZEN_PLATFORM}" />
+	<outflag value="-o"/>
+	<objdir value="./obj/tizensim${OBJEXT}" />
+</compiler>
+
+<linker id="exe" exe="i386-linux-gnueabi-g++" if="tizen">
+	<flag value="-g" if="debug"/>
+	<flag value="-O2" unless="debug"/>
+	<flag value="-s" unless="debug"/>
+	<!-- <flag value="-rdynamic"/> -->
+	<flag value="-pie" />
+	<lib name="-lpthread" />
+	<flag value="-Xlinker" />
+	<flag value="--as-needed" />
+	<flag value="-Xlinker" />
+	<flag value="-rpath=/opt/usr/apps/${APP_ID}/lib" />
+	<flag value="-Xlinker" />
+	<flag value="-rpath=/home/developer/sdk_tools/lib" />
+	<flag value="--sysroot=${TIZEN_PLATFORM}" />
+	<flag value="-L${TIZEN_PLATFORM}/usr/lib" />
+	<flag value="-L${TIZEN_PLATFORM}/usr/lib/osp" />
+	<lib name="-losp-appfw" />
+	<!-- <flag value="-fpic"/>
+	<flag value="-fPIC"/> -->
+	<ext value=".exe"/>
+	<outflag value="-o"/>
+	<lib name="-ldl"/>
+</linker>
+	
+<linker id="dll" exe="i386-linux-gnueabi-g++" if="tizen">
+	<flag value="-shared"/>
+	<flag value="-g" if="debug"/>
+	<flag value="-O2" unless="debug"/>
+	<flag value="-s" unless="debug"/>
+	<!-- <flag value="-pie" /> -->
+	<lib name="-lpthread" />
+	<flag value="-Xlinker" />
+	<flag value="--as-needed" />
+	<!--<flag value="-Xlinker" />
+	<flag value="-rpath=/opt/usr/apps/DugJgh8Hxl/lib" /> -->
+	<flag value="-Xlinker" />
+	<flag value="-rpath=/home/developer/sdk_tools/lib" />
+	<flag value="--sysroot=${TIZEN_PLATFORM}" />
+	<flag value="-L${TIZEN_PLATFORM}/usr/lib" />
+	<flag value="-L${TIZEN_PLATFORM}/usr/lib/osp" />
+	<cppflag value="-frtti"/>
+	<!-- <flag value="-fpic"/>
+	<flag value="-fPIC"/> -->
+	<!-- <flag value="-pie" /> -->
+	<lib name="-ldl"/>
+	<ext value=".so"/>
+	<outflag value="-o"/>
+</linker>
+
+
+</xml>

--- a/include/hx/Macros.h
+++ b/include/hx/Macros.h
@@ -760,6 +760,27 @@ int __stdcall WinMain( void * hInstance, void * hPrevInstance, const char *lpCmd
 }
 
 
+#elif defined(TIZEN)
+
+
+#define HX_BEGIN_MAIN \
+\
+extern "C" EXPORT_EXTRA int OspMain (int argc, char* pArgv[]){ \
+        HX_TOP_OF_STACK \
+        hx::Boot(); \
+        try{ \
+                __boot_all();
+
+#define HX_END_MAIN \
+        } \
+        catch (Dynamic e){ \
+                __hx_dump_stack(); \
+                printf("Error : %s\n",e->toString().__CStr()); \
+        } \
+        return 0; \
+}
+
+
 #else
 // Console Main ...
 

--- a/runtime/BuildLibs.xml
+++ b/runtime/BuildLibs.xml
@@ -9,6 +9,8 @@
 <set name="LIBEXTRA" value=".iphonesim" if="iphonesim"/>
 <set name="LIBEXTRA" value="-x86" if="blackberry"/>
 <set name="LIBEXTRA" value="" if="blackberry" unless="simulator" />
+<set name="LIBEXTRA" value="-x86" if="tizen"/>
+<set name="LIBEXTRA" value="" if="tizen" unless="simulator" />
 <set name="LIBPREFIX" value="lib" if="iphoneos"/>
 <set name="LIBPREFIX" value="lib" if="iphonesim"/>
 

--- a/src/hx/Lib.cpp
+++ b/src/hx/Lib.cpp
@@ -328,7 +328,7 @@ void *__hxcpp_get_proc_address(String inLib, String full_name,bool inNdllProc)
     HX_CSTRING(".sim.dylib");
 #elif defined(__APPLE__)
     HX_CSTRING(".dylib");
-#elif defined(ANDROID) || defined(GPH) || defined(WEBOS)  || defined(BLACKBERRY) || defined(EMSCRIPTEN)
+#elif defined(ANDROID) || defined(GPH) || defined(WEBOS)  || defined(BLACKBERRY) || defined(EMSCRIPTEN) || defined(TIZEN)
     HX_CSTRING(".so");
 #else
     HX_CSTRING(".dso");
@@ -356,6 +356,8 @@ void *__hxcpp_get_proc_address(String inLib, String full_name,bool inNdllProc)
     HX_CSTRING("RPi");
 #elif defined(EMSCRIPTEN)
 	HX_CSTRING("Emscripten");
+#elif defined(TIZEN)
+    HX_CSTRING("Tizen");
 #elif defined(IPHONESIM)
     HX_CSTRING("IPhoneSim");
 #elif defined(IPHONEOS)

--- a/src/hx/StdLibs.cpp
+++ b/src/hx/StdLibs.cpp
@@ -19,6 +19,9 @@ typedef int64_t __int64;
 #ifdef WEBOS
 #include <syslog.h>
 #endif
+#ifdef TIZEN
+extern "C" EXPORT_EXTRA void AppLogInternal(const char* pFunction, int lineNumber, const char* pFormat, ...);
+#endif
 
 #include <string>
 #include <vector>
@@ -151,6 +154,11 @@ void __hxcpp_stdlibs_boot()
 
 void __trace(Dynamic inObj, Dynamic inData)
 {
+#ifdef TIZEN
+   AppLogInternal(inData==null() ? "?" : inData->__Field( HX_CSTRING("fileName") , true) ->toString().__s,
+      inData==null() ? 0 : inData->__Field( HX_CSTRING("lineNumber") , true)->__ToInt(),
+      "%s\n", inObj.GetPtr() ? inObj->toString().__s : "null" );
+#else
 #ifdef HX_UTF8_STRINGS
    #ifdef ANDROID
    __android_log_print(ANDROID_LOG_INFO, "trace","%s:%d: %s",
@@ -167,6 +175,7 @@ void __trace(Dynamic inObj, Dynamic inData)
                inData->__Field( HX_CSTRING("fileName") , true)->__ToString().__s,
                inData->__Field( HX_CSTRING("lineNumber") , true)->__ToInt(),
                inObj.GetPtr() ? inObj->toString().__s : L"null" );
+#endif
 #endif
 }
 


### PR DESCRIPTION
This should add Tizen support, for emulator and device. trace() should go through the proper logging, and it should use the Tizen toolchain. The location of the Tizen SDK cannot (necessarily) be found automatically, so currently the toolchain should throw an error if you have not defined TIZEN_SDK
