### PR TITLE
Toolchain XML improvements

### DIFF
--- a/build-tool/BuildCommon.xml
+++ b/build-tool/BuildCommon.xml
@@ -94,7 +94,7 @@
   <depend name="${HXCPP}/src/hx/RedBlack.h"/>
   <depend name="${HXCPP}/include/hx/Scriptable.h"/>
   <depend name="${HXCPP}/build-tool/BuildCommon.xml"/>
-  <depend name="${HXCPP}/build-tool/${toolchain}-toolchain.xml"/>
+  <depend name="${HXCPP}/build-tool/${toolchain}-toolchain.xml" ifExists="${HXCPP}/build-tool/${toolchain}-toolchain.xml"/>
   <depend name="${HXCPP}/run.n"/>
   <options name="Options.txt"/>
 
@@ -104,13 +104,13 @@
 <files id="__main__">
   <compilerflag value="-DHX_DECLARE_MAIN"/>
   <depend name="${HXCPP}/include/hx/Macros.h"/>
-  <depend name="${HXCPP}/build-tool/${toolchain}-toolchain.xml"/>
+  <depend name="${HXCPP}/build-tool/${toolchain}-toolchain.xml" ifExists="${HXCPP}/build-tool/${toolchain}-toolchain.xml"/>
 </files>
 
 <files id="__lib__">
   <compilerflag value="-DHX_DECLARE_MAIN"/>
   <depend name="${HXCPP}/include/hx/Macros.h"/>
-  <depend name="${HXCPP}/build-tool/${toolchain}-toolchain.xml"/>
+  <depend name="${HXCPP}/build-tool/${toolchain}-toolchain.xml" ifExists="${HXCPP}/build-tool/${toolchain}-toolchain.xml"/>
 </files>
 
 <files id="runtime" dir="${HXCPP}">
@@ -135,7 +135,7 @@
   <depend name="${HXCPP}/include/hx/OS.h"/>
   <depend name="${HXCPP}/src/hx/RedBlack.h"/>
   <depend name="${HXCPP}/build-tool/BuildCommon.xml"/>
-  <depend name="${HXCPP}/build-tool/${toolchain}-toolchain.xml"/>
+  <depend name="${HXCPP}/build-tool/${toolchain}-toolchain.xml" ifExists="${HXCPP}/build-tool/${toolchain}-toolchain.xml"/>
   <depend name="${HXCPP}/run.n"/>
   <options name="Options.txt"/>
 

--- a/build-tool/emscripten-toolchain.xml
+++ b/build-tool/emscripten-toolchain.xml
@@ -1,5 +1,9 @@
 <xml>
 
+<path name="${EMSCRIPTEN_SDK}" />
+
+<setenv name="EMCC_LLVM_TARGET" value="i386-pc-linux-gnu" />
+
 <!-- EMCC TOOLS -------------------------------------->
 
 <include name="gcc-toolchain.xml"/>
@@ -9,6 +13,8 @@
   <flag value="-c"/>
   <flag value="-fvisibility=hidden"/>
   <cppflag value="-frtti"/>
+  <pchflag value="-x" />
+  <pchflag value="c++-header" />
   <flag value="-g" if="debug"/>
   <!-- <flag value="-O2" unless="debug"/> -->
   <flag value="-fpic"/>
@@ -21,6 +27,7 @@
   <flag value="-Wno-unused-value" />
   <flag value="-Wno-format-extra-args" />
   <flag value="-Wno-bool-conversion" />
+  <flag value="-Wno-warn-absolute-paths" />
   <include name="common-defines.xml" />
   <flag value="-I${HXCPP}/include"/>
   <objdir value="obj/emscripten${OBJEXT}"/>

--- a/build-tool/iphoneos-toolchain.xml
+++ b/build-tool/iphoneos-toolchain.xml
@@ -50,7 +50,7 @@
   <cppflag value="-frtti"/>
   <outflag value="-o"/>
   <ext value=".o"/>
-  <objdir value="obj/iphonesim${OBJGCC}${OBJDBG}${ARCH}/" />
+  <objdir value="obj/iphoneos${OBJGCC}${OBJDBG}${ARCH}/" />
 </compiler>
 
 <linker id="dll" exe="g++" >

--- a/build-tool/msvc-setup.bat
+++ b/build-tool/msvc-setup.bat
@@ -5,22 +5,22 @@ setlocal enabledelayedexpansion
 	@set
 ) else if exist "%VS120COMNTOOLS%\vsvars32.bat" (
 	@call "%VS120COMNTOOLS%\vsvars32.bat"
-   @if defined HXCPP_WINXP_COMPAT (
-     @set "INCLUDE=%ProgramFiles(x86)%\Microsoft SDKs\Windows\7.1A\Include;!INCLUDE!"
-     @set "PATH=%ProgramFiles(x86)%\Microsoft SDKs\Windows\7.1A\Bin;!PATH!"
-     @set "LIB=%ProgramFiles(x86)%\Microsoft SDKs\Windows\7.1A\Lib;!LIB!"
-     @set HXCPP_XP_DEFINE=_USING_V120_SDK71_
-   )
+	@if defined HXCPP_WINXP_COMPAT (
+		@set "INCLUDE=%ProgramFiles(x86)%\Microsoft SDKs\Windows\7.1A\Include;!INCLUDE!"
+		@set "PATH=%ProgramFiles(x86)%\Microsoft SDKs\Windows\7.1A\Bin;!PATH!"
+		@set "LIB=%ProgramFiles(x86)%\Microsoft SDKs\Windows\7.1A\Lib;!LIB!"
+		@set HXCPP_XP_DEFINE=_USING_V120_SDK71_
+	)
 	@echo HXCPP_VARS
 	@set
 ) else if exist "%VS110COMNTOOLS%\vsvars32.bat" (
 	@call "%VS110COMNTOOLS%\vsvars32.bat"
-   @if defined HXCPP_WINXP_COMPAT (
-     @set "INCLUDE=%ProgramFiles(x86)%\Microsoft SDKs\Windows\7.1A\Include;!INCLUDE!"
-     @set "PATH=%ProgramFiles(x86)%\Microsoft SDKs\Windows\7.1A\Bin;!PATH!"
-     @set "LIB=%ProgramFiles(x86)%\Microsoft SDKs\Windows\7.1A\Lib;!LIB!"
-     @set HXCPP_XP_DEFINE=_USING_V110_SDK71_
-   )
+	@if defined HXCPP_WINXP_COMPAT (
+		@set "INCLUDE=%ProgramFiles(x86)%\Microsoft SDKs\Windows\7.1A\Include;!INCLUDE!"
+		@set "PATH=%ProgramFiles(x86)%\Microsoft SDKs\Windows\7.1A\Bin;!PATH!"
+		@set "LIB=%ProgramFiles(x86)%\Microsoft SDKs\Windows\7.1A\Lib;!LIB!"
+		@set HXCPP_XP_DEFINE=_USING_V110_SDK71_
+	)
 	@echo HXCPP_VARS
 	@set
 ) else if exist "%VS100COMNTOOLS%\vsvars32.bat" (


### PR DESCRIPTION
This is a pass to try and include any changes between the hxlibc and hxcpp toolchain XML, although I have not been able to fully test each target, this includes obvious differences I saw.

One of the changes in hxlibc was to allow for toolchain XML that is outside the HXCPP directory, using the include path. The previous pull request (I believe) makes a minor change to help allow for this.

Since an XML may not necessarily come from the build-tool directory, I've leveraged your new "ifExists" attribute to help it check the dependency only for core targets. It would be more ideal for this to be a little smarter, but for now, I believe it should resolve errors when using a toolchain that does not exist in HXCPP.

For reference, you would use a custom toolchain like this:

``` bash
haxelib run hxcpp Build.xml -Dtoolchain=newplatform -Ipath/to/other/dir
```

Similar to the core targets, it would search for "newplatform-toolchain.xml" under all the include directories, including the new one added. If I get a chance to test, I'll submit any minor tweaks if it still doesn't quite work as expected.

This resolves a typo in the iOS toolchain, and it makes some updates for Emscripten
