### PR TITLE
Build.xml now supports "include" inside "files"

### DIFF
--- a/tools/run/BuildTool.hx
+++ b/tools/run/BuildTool.hx
@@ -458,6 +458,20 @@ class BuildTool
                   group.addCompilerFlag( substitute(el.att.value) );
                case "precompiledheader" : 
                   group.setPrecompiled( substitute(el.att.name), substitute(el.att.dir) );
+               case "include" : 
+                  var subbed_name = substitute(el.att.name);
+                  var full_name = findIncludeFile(subbed_name);
+                  if (full_name!="")
+                  {
+                     var make_contents = sys.io.File.getContent(full_name);
+                     var xml_slow = Xml.parse(make_contents);
+                     createFileGroup(new Fast(xml_slow.firstElement()), group, inName);
+                  } 
+                  else
+                  {
+                     Log.error("Could not find include file \"" + subbed_name + "\"");
+
+                  }
             }
       }
 


### PR DESCRIPTION
Hello,

I needed this because I want my native extensions to expose headers (or any other compile dependencies) that can be used in other native extensions, or even in haxe inline cpp code.

Basically now you can do something like:
somelib/native.xml:

```
<xml>
      <compilerflag value="-I${haxelib:somelib}/project/include" />
</xml>
```

anotherlib/File.hx:

```
(...)
@:buildXml('
    <files id="haxe">
        <include name="${haxelib:somelib}/native.xml" />
    </files>
')
(...)
```

evenanotherlib/project/Build.xml:

```
(...)
<files id="src">
        (...)
    <include name="${haxelib:somelib}/native.xml" />
        (...)
</files>
(...)
```

Maybe there is a better way of doing this... But still this works, and I think its a quite harmless addition to the BuildTool.

Thanks!
