### PR TITLE
Win path fixes

### DIFF
--- a/src/hx/Lib.cpp
+++ b/src/hx/Lib.cpp
@@ -217,7 +217,7 @@ String FindHaxelib(String inLib)
    if (haxepath.length==0)
    {
        #ifdef _WIN32
-	   String home = GetEnv("HOMEDRIVE") + GetEnv("HOMEPATH") + HX_CSTRING("/.haxelib");
+       String home = GetEnv("HOMEDRIVE") + GetEnv("HOMEPATH") + HX_CSTRING("/.haxelib");
        #else
        String home = GetEnv("HOME") + HX_CSTRING("/.haxelib");
        #endif


### PR DESCRIPTION
Use HOMEDRIVE + HOMEPATH on Windows instead of HOME to find .haxelib. This is what haxelib does too.

Also updates the default haxelib repository path to `C:\HaxeToolkit\haxe\lib".
