### PR TITLE
Update hxString.h

### DIFF
--- a/include/hxString.h
+++ b/include/hxString.h
@@ -93,6 +93,8 @@ public:
    const char *__CStr() const;
    const wchar_t *__WCStr() const;
    inline operator const char *() { return __s; }
+   inline operator unsigned char*() { return (unsigned char*)__s; }
+   inline operator char*() { return (char*)__s; }
 
    static  ::String fromCharCode(int inCode);
 


### PR DESCRIPTION
Added cast's to `unsigned char*` and `char*`
When using @:native on some functions that require this types.