### PR TITLE
resolve Hash.cpp compile error on Android

### DIFF
--- a/src/hx/Hash.cpp
+++ b/src/hx/Hash.cpp
@@ -189,7 +189,7 @@ public:
    void __Mark(hx::MarkContext *__inCtx)
    {
       mFinalizer->Mark();
-      if (NeedsMarking<typename Hash::Key>::Yes || NeedsMarking<typename Hash::Value>::Yes)
+      if (NeedsMarking<Hash::Key>::Yes || NeedsMarking<Hash::Value>::Yes)
       {
          HashMarker<Hash> marker(__inCtx);
          hash.iterate(marker);
@@ -201,7 +201,7 @@ public:
    {
       if (mFinalizer)
          mFinalizer->Visit(__inCtx);
-      if (NeedsMarking<typename Hash::Key>::Yes || NeedsMarking<typename Hash::Value>::Yes)
+      if (NeedsMarking<Hash::Key>::Yes || NeedsMarking<Hash::Value>::Yes)
       {
         HashVisitor<Hash> vistor(__inCtx);
         hash.iterate(vistor);


### PR DESCRIPTION
Resolves these errors on Android:

```
Error: hxcpp/src/hx/Hash.cpp: In member function 'virtual void hx::IntHash::__Mark(hx::MarkContext*)':
hxcpp/src/hx/Hash.cpp:192: error: using 'typename' outside of template
hxcpp/src/hx/Hash.cpp:192: error: using 'typename' outside of template
hxcpp/src/hx/Hash.cpp: In member function 'virtual void hx::IntHash::__Visit(hx::VisitContext*)':
hxcpp/src/hx/Hash.cpp:204: error: using 'typename' outside of template
hxcpp/src/hx/Hash.cpp:204: error: using 'typename' outside of template
```
