### PR TITLE
If Log.error() is called, we should always show an error message rather than failing silently.

### DIFF
--- a/tools/run/Log.hx
+++ b/tools/run/Log.hx
@@ -31,16 +31,20 @@ class Log
    
    public static function error(message:String, verboseMessage:String = "", e:Dynamic = null, terminate:Bool = true):Void
    {
-      if (message != "" && !mute)
+      if (!mute)
       {
          var output;
          if (verbose && verboseMessage != "")
          {
             output = "\x1b[31;1mError:\x1b[0m\x1b[1m " + verboseMessage + "\x1b[0m\n";
          }
-         else
+         else if (message != "")
          {
             output = "\x1b[31;1mError:\x1b[0m \x1b[1m" + message + "\x1b[0m\n";  
+         }
+         else
+         {
+            output = "\x1b[31;1mError\x1b[0m\n";  
          }
          if (printMutex!=null)
             printMutex.acquire();


### PR DESCRIPTION
On a couple of occasions, I've had hxcpp encounter an error but not print anything to the terminal. This should never happen, it's a really bad experience!

If no error message is printed, the user assumes everything worked. So, we should always print an error message, even if Log.error() isn't passed one.
