### PR TITLE
getNumberOfProcesses() shouldn't die if it fails to get system info.

### DIFF
--- a/tools/run/BuildTool.hx
+++ b/tools/run/BuildTool.hx
@@ -681,10 +681,10 @@ class BuildTool
       }
       else if (isLinux)
       {
-         result = ProcessManager.runProcessLine("", "nproc", [], true, false);
+         result = ProcessManager.runProcessLine("", "nproc", [], true, false, true, true);
          if (result == null)
          {
-            var cpuinfo = ProcessManager.runProcess("", "cat", [ "/proc/cpuinfo" ], true, false);
+            var cpuinfo = ProcessManager.runProcess("", "cat", [ "/proc/cpuinfo" ], true, false, true, true);
             if (cpuinfo != null)
             {      
                var split = cpuinfo.split("processor");
@@ -695,7 +695,7 @@ class BuildTool
       else if (isMac)
       {
          var cores = ~/Total Number of Cores: (\d+)/;
-         var output = ProcessManager.runProcess("", "/usr/sbin/system_profiler", [ "-detailLevel", "full", "SPHardwareDataType" ], true, false);
+         var output = ProcessManager.runProcess("", "/usr/sbin/system_profiler", [ "-detailLevel", "full", "SPHardwareDataType" ], true, false, true, true);
          if (cores.match(output))
          {
             result = cores.matched(1); 


### PR DESCRIPTION
On my computer, `nproc` is not available. This should not be a fatal error, because we can try other ways to check the number of cores, and fall back to only using one thread if that fails too.

However, what actually happens is that `ProcessManager.runProcess` sees that we couldn't run `nproc`, and calls `Log.error()`, which terminates the program. We need to set the `ignoreErrors` flag to true to avoid this.
