### PR TITLE
Bug in MySemaphore.WaitSeconds leads to 100% cpu on windows

### DIFF
--- a/include/hx/Thread.h
+++ b/include/hx/Thread.h
@@ -240,9 +240,9 @@ struct MySemaphore
    bool WaitSeconds(double inSeconds)
    {
       #ifdef HX_WINRT
-      return WaitForSingleObjectEx(mSemaphore,inSeconds*0.001,false) != WAIT_TIMEOUT;
+      return WaitForSingleObjectEx(mSemaphore,inSeconds*1000.0,false) != WAIT_TIMEOUT;
       #else
-      return WaitForSingleObject(mSemaphore,inSeconds*0.001) != WAIT_TIMEOUT;
+      return WaitForSingleObject(mSemaphore,inSeconds*1000.0) != WAIT_TIMEOUT;
       #endif
    }
    void Reset() { ResetEvent(mSemaphore); }


### PR DESCRIPTION
I was wondering, why following code using cpp.vm.Lock was leading to 100% cpu utilization of a single core on windows: https://gist.github.com/ZuBsPaCe/3ab1302f981be2ea4c55

The reason was simple: Method MySemaphore.WaitSeconds in Thread.h uses WaitForSingleObject of the windows api, which expects milliseconds. But currently the inSeconds parameter gets divided by 0.001 instead of multiplied with 1000.0. cpp.vm.Lock is not broken because of this, because it starts looping until the time's up, but this loop leads to the performance issue.

Only windows builds seem to be affected.

WaitForSingleObject: http://msdn.microsoft.com/en-us/library/windows/desktop/ms687032(v=vs.85).aspx
WaitForSingleObjectEx: http://msdn.microsoft.com/en-us/library/windows/desktop/ms687036(v=vs.85).aspx
