### PR TITLE
Mark "void Boot()" as exported

### DIFF
--- a/include/hx/Boot.h
+++ b/include/hx/Boot.h
@@ -8,7 +8,7 @@ namespace hx
 {
 
 // Initializer the hxcpp runtime system
-void Boot();
+HXCPP_EXTERN_CLASS_ATTRIBUTES void Boot();
 
 }
 

--- a/include/hx/StdLibs.h
+++ b/include/hx/StdLibs.h
@@ -49,7 +49,7 @@ void           __hxcpp_stdlibs_boot();
 
 // --- Maths ---------------------------------------------------------
 double __hxcpp_drand();
-int __hxcpp_irand(int inMax);
+HXCPP_EXTERN_CLASS_ATTRIBUTES int __hxcpp_irand(int inMax);
 
 // --- Casting/Converting ---------------------------------------------------------
 HXCPP_EXTERN_CLASS_ATTRIBUTES bool  __instanceof(const Dynamic &inValue, const Dynamic &inType);


### PR DESCRIPTION
This marks two functions with HXCPP_EXTERN_CLASS_ATTRIBUTES to make it
easier to use hxcpp as a DLL in Windows. Currently it almost is as
simple as just building all of hxcpp with HXCPP_DLL_EXPORT and defining
HXCPP_DLL_IMPORT when using it, except that there are linker errors
involving "void Boot()" and "int __hxcpp_irand(int inMax)" since they
lack the necessary declspec attributes.
