### PR TITLE
Make StdLibs.cpp compile under MinGW

### DIFF
--- a/include/hx/Thread.h
+++ b/include/hx/Thread.h
@@ -10,7 +10,7 @@
 #elif defined(_WIN32)
 
 #undef _WIN32_WINNT
-#define _WIN32_WINNT 0x0400
+#define _WIN32_WINNT 0x0501
 
 #include <windows.h>
 #include <process.h>

--- a/src/hx/StdLibs.cpp
+++ b/src/hx/StdLibs.cpp
@@ -2,6 +2,8 @@
 #include <hxMath.h>
 
 #ifdef HX_WINDOWS
+#undef _WIN32_WINNT
+#define _WIN32_WINNT 0x0501
 #include <windows.h>
 #include <stdio.h>
 #include <io.h>


### PR DESCRIPTION
Using the MinGW compiler, the macro `_WIN32_WINNT` needs to be defined as 0x0501 or higher to get the `AllocConsole` function. Without this, it just won't compile at all.