### PR TITLE
Update mingw-toolchain.xml

### DIFF
--- a/toolchain/mingw-toolchain.xml
+++ b/toolchain/mingw-toolchain.xml
@@ -21,9 +21,6 @@
   <flag value="-DHX_WINDOWS"/>
   <flag value="-DHXCPP_BIG_ENDIAN" if="HXCPP_BIG_ENDIAN"/>
   <flag value="-m32" unless="HXCPP_M64"/>
-  <flag value="-static" if="no_shared_libs"/>
-  <flag value="-static-libgcc" if="no_shared_libs"/>
-  <flag value="-static-libstdc++" if="no_shared_libs"/>
   <flag value="-DHXCPP_M64" if="HXCPP_M64"/>
   <flag value="-I${HXCPP}/include"/>
   <objdir value="obj/mingw${OBJEXT}/"/>
@@ -34,10 +31,13 @@
 <linker id="dll" exe="g++">
   <exe name="g++.exe"/>
   <flag value="-shared"/>
+  <flag value="-debug" if="debug"/>
   <flag value="--enable-auto-import"/>
   <flag value="-m32" unless="HXCPP_M64"/>
+  <flag value="-static" if="no_shared_libs"/>
+  <flag value="-static-libgcc" if="no_shared_libs"/>
+  <flag value="-static-libstdc++" if="no_shared_libs"/>
   <!-- <flag value="-W,l--unresolved-symbols=report-all"/> -->
-  <flag value="-debug" if="debug"/>
   <ext value=".dll"/>
   <outflag value="-o "/>
 </linker>
@@ -47,6 +47,9 @@
   <flag value="-debug" if="debug"/>
   <flag value="-Wl,--enable-auto-import"/>
   <flag value="-m32" unless="HXCPP_M64"/>
+  <flag value="-static" if="no_shared_libs"/>
+  <flag value="-static-libgcc" if="no_shared_libs"/>
+  <flag value="-static-libstdc++" if="no_shared_libs"/>
   <ext value=".exe"/>
   <outflag value="-o "/>
 </linker>


### PR DESCRIPTION
Added "O3" define to change the compiler optimization flag
Added "no_shared_libs" define to static compile an executable that do not need mingw shared libs (libgcc, libstdc++)
