### PR TITLE
Fixed `haxelib path ...` parsing.

### DIFF
--- a/tools/hxcpp/PathManager.hx
+++ b/tools/hxcpp/PathManager.hx
@@ -106,7 +106,7 @@ class PathManager
          
          try
          {
-            output = ProcessManager.runProcess(Sys.getEnv ("HAXEPATH"), "haxelib", [ "path", name ], true, false);  
+            output = ProcessManager.runProcess(Sys.getEnv ("HAXEPATH"), "haxelib", [ "path", name ], true, false);
          }
          catch (e:Dynamic) {}
          
@@ -117,7 +117,7 @@ class PathManager
          
          for (i in 1...lines.length)
          {
-            if (StringTools.trim(lines[i]) == "-D " + haxelib)
+            if (StringTools.startsWith(StringTools.trim(lines[i]), "-D " + haxelib))
             {
                result = StringTools.trim(lines[i - 1]);
             }


### PR DESCRIPTION
Currently `haxelib path hxcpp` gives:

```
path/to/hxcpp/
-D hxcpp=3.1.0
```

Notice there is version number at the end of `-D`.

I discovered this on Windows, when I `haxelib dev hxcpp ...` and `haxelib run hxcpp` (with no arg).
Not sure why it worked on Mac and Linux...
