### PR TITLE
Working in Windows 8.1 and compiling with MinGW

### DIFF
--- a/toolchain/common-defines.xml
+++ b/toolchain/common-defines.xml
@@ -19,6 +19,6 @@
  <flag value="-DHXCPP_DLL_EXPORT" if="dll_export"/>
  <flag value="-DHXCPP_SCRIPTABLE" if="scriptable"/>
  <flag value='-DHXCPP_DEBUG_HOST="${HXCPP_DEBUG_HOST}"' if="HXCPP_DEBUG_HOST" />
- <flag value='-DHXCPP_API_LEVEL=${removeQuotes:hxcpp_api_level}' if="hxcpp_api_level" />
+ <flag value='-DHXCPP_API_LEVEL=${hxcpp_api_level}' if="hxcpp_api_level" />
  <flag value='-DHXCPP_API_LEVEL=0' unless="hxcpp_api_level" />
 </xml>


### PR DESCRIPTION
Original code

``` xml
<flag value='-DHXCPP_API_LEVEL=${removeQuotes:hxcpp_api_level}' if="hxcpp_api_level" />
```

generate

> haxelib run hxcpp Build.xml haxe -DHXCPP_M64="1" -DO3="1" -Dhaxe3="1" -Dhaxe_ver="3.2" **-Dhxcpp_api_level="312"** -Dmingw="1" -Dno_shared_libs="1" -I"src/" -I"...haxe\haxe\extraLibs/" -I"" -I"...haxe\haxe\std/cpp/_std/" -I"...haxe\haxe\std/"
> 
> > g++.exe -Iinclude -c -O3 -DHXCPP_M64 -DHXCPP_VISIT_ALLOCS **-DHXCPP_API_LEVEL=** -DHX_WINDOWS -DHXCPP_M64 -I.../haxe/haxe/lib/hxcpp/git/include -x c++ -frtti ./src/haxe/Log.cpp -oobj/mingw64/6ddce8a4_Log.o
> > ...

instead 

``` xml
<flag value='-DHXCPP_API_LEVEL=${hxcpp_api_level}' if="hxcpp_api_level" />
```

generate

> haxelib run hxcpp Build.xml haxe -DHXCPP_M64="1" -DO3="1" -Dhaxe3="1" -Dhaxe_ver="3.2" **-Dhxcpp_api_level="312"** -Dmingw="1" -Dno_shared_libs="1" -I"src/" -I"...\haxe\haxe\extraLibs/" -I"" -I"...\haxe\haxe\std/cpp/_std/" -I"...\haxe\haxe\std/"
> 
> > g++.exe -D_CRT_SECURE_NO_DEPRECATE -DHX_UNDEFINE_H -c -O3 -DHXCPP_M64 -DHXCPP_VISIT_ALLOCS **-DHXCPP_API_LEVEL=312** -DHX_WINDOWS -DHXCPP_M64 -IC:/lg/Dropbox/APPs/haxe/haxe/lib/hxcpp/git/include -x c++ -frtti C:/lg/Dropbox/APPs/haxe/haxe/lib/hxcpp/git/src/hx/StdLibs.cpp -oobj/mingw64/55e62088_StdLibs.o
> > ...

working code!!!
