### PR TITLE
explicit namespace references to avoid naming conflicts with iOS Objective C

### DIFF
--- a/include/Array.h
+++ b/include/Array.h
@@ -79,9 +79,9 @@ public:
 
    Dynamic __SetField(const String &inString,const Dynamic &inValue ,bool inCallProp) { return null(); }
 
-   static Class __mClass;
-   static Class &__SGetClass() { return __mClass; }
-   Class __GetClass() const { return __mClass; }
+   static hx::Class __mClass;
+   static hx::Class&__SGetClass() { return __mClass; }
+   hx::Class __GetClass() const { return __mClass; }
    String toString();
    String __ToString() const;
 

--- a/include/Class.h
+++ b/include/Class.h
@@ -111,8 +111,8 @@ public:
 
 
    // the "Class class"
-   Class              __GetClass() const;
-   static Class      & __SGetClass();
+   hx::Class              __GetClass() const;
+   static hx::Class      & __SGetClass();
 	static void       __boot();
 
    Dynamic __Field(const String &inString ,bool inCallProp);

--- a/include/hx/Anon.h
+++ b/include/hx/Anon.h
@@ -66,10 +66,10 @@ public:
    String __ToString() const;
    String toString();
 
-   static hx::ObjectPtr<Class_obj> __mClass; \
-   static hx::ObjectPtr<Class_obj> &__SGetClass() { return __mClass; }
+   static hx::Class __mClass;
+   static hx::Class &__SGetClass() { return __mClass; }
    bool __Is(hx::Object *inObj) const { return dynamic_cast<OBJ_ *>(inObj)!=0; }
-   hx::ObjectPtr<Class_obj > __GetClass() const { return __mClass; }
+   hx::Class __GetClass() const { return __mClass; }
 
    bool __Remove(String inKey);
 };

--- a/include/hx/Interface.h
+++ b/include/hx/Interface.h
@@ -25,7 +25,7 @@ public:
 	Dynamic __SetField(const ::String &,const Dynamic &, bool inCallProp);
 	void __SetThis(Dynamic);
 	void __GetFields(Array< ::String> &);
-	Class __GetClass() const;
+	::hx::Class __GetClass() const;
 	int __Compare(const hx::Object *) const;
 
    /* No need for enum options - not in interfaces */

--- a/include/hx/Object.h
+++ b/include/hx/Object.h
@@ -102,7 +102,7 @@ public:
    virtual Dynamic __Run(const Array<Dynamic> &inArgs);
    virtual hx::FieldMap *__GetFieldMap();
    virtual void __GetFields(Array<String> &outFields);
-   virtual Class __GetClass() const;
+   virtual ::hx::Class __GetClass() const;
 
    virtual int __Compare(const hx::Object *inRHS) const;
    virtual DynamicArray __EnumParams();
@@ -133,7 +133,7 @@ public:
    inline bool __compare( hx::Object *inRHS )
       { return __GetRealObject()!=inRHS->__GetRealObject(); }
 
-   static Class &__SGetClass();
+   static hx::Class &__SGetClass();
    static void __boot();
 };
 
@@ -252,7 +252,7 @@ public:
    // This is defined in the "FieldRef" class...
    inline class hx::FieldRef FieldRef(const String &inString);
    inline class hx::IndexRef IndexRef(int inString);
-   inline static Class &__SGetClass() { return OBJ_::__SGetClass(); }
+   inline static hx::Class &__SGetClass() { return OBJ_::__SGetClass(); }
 
    OBJ_ *mPtr;
 };

--- a/include/hxcpp.h
+++ b/include/hxcpp.h
@@ -189,6 +189,7 @@ template<typename ELEM_> class Array_obj;
 template<typename ELEM_> class Array;
 class Class_obj;
 typedef hx::ObjectPtr<Class_obj> Class;
+namespace hx { typedef ObjectPtr<Class_obj> Class; }
 class Dynamic;
 class String;
 


### PR DESCRIPTION
This allows hxcpp.h to be included in a .mm file.