### PR TITLE
Topic enum constructor throw

### DIFF
--- a/include/hx/Debug.h
+++ b/include/hx/Debug.h
@@ -545,7 +545,11 @@ inline void __hxcpp_dbg_setAddStackFrameToThreadInfoFunction(Dynamic) { }
 // created and terminated
 inline void __hxcpp_dbg_threadCreatedOrTerminated(int, bool) { }
 
-Dynamic __hxcpp_dbg_checkedThrow(Dynamic toThrow);
+inline Dynamic __hxcpp_dbg_checkedThrow(Dynamic toThrow)
+{
+    hx::Throw(toThrow);
+    return null();
+}
 
 #endif // HXCPP_DEBUGGER
 

--- a/include/hx/Debug.h
+++ b/include/hx/Debug.h
@@ -545,6 +545,8 @@ inline void __hxcpp_dbg_setAddStackFrameToThreadInfoFunction(Dynamic) { }
 // created and terminated
 inline void __hxcpp_dbg_threadCreatedOrTerminated(int, bool) { }
 
+Dynamic __hxcpp_dbg_checkedThrow(Dynamic toThrow);
+
 #endif // HXCPP_DEBUGGER
 
 

--- a/include/hx/ErrorCodes.h
+++ b/include/hx/ErrorCodes.h
@@ -5,8 +5,22 @@
 #define HX_INVALID_CAST          Dynamic(HX_CSTRING("Invalid Cast"))
 #define HX_INDEX_OUT_OF_BOUNDS   Dynamic(HX_CSTRING("Index Out of Bounds"))
 #define HX_INVALID_CONSTRUCTOR   Dynamic(HX_CSTRING("Invalid constructor"))
+#define HX_INVALID_ENUM_CONSTRUCTOR(_enum_name, _constructor_name)      \
+    Dynamic(HX_CSTRING("Invalid enum constructor for ") +               \
+            HX_CSTRING(_enum_name) +                                    \
+            HX_CSTRING(": ") +                                          \
+            _constructor_name)
 #define HX_INVALID_OBJECT        Dynamic(HX_CSTRING("Invalid object"))
 #define HX_INVALID_ARG_COUNT     Dynamic(HX_CSTRING("Invalid Arg Count"))
+#define HX_INVALID_ENUM_ARG_COUNT(_enum_name, _constructor_name, _count, _expected) \
+    Dynamic(HX_CSTRING("Invalid enum arg count for ") +                 \
+            HX_CSTRING(_enum_name) +                                    \
+            HX_CSTRING(".") +                                           \
+            _constructor_name +                                         \
+            HX_CSTRING(": expected ") +                                 \
+            ::String(_expected) +                                       \
+            HX_CSTRING(", got ") +                                      \
+            ::String(_count))
 #define HX_NULL_FUNCTION_POINTER Dynamic(HX_CSTRING("Null Function Pointer"))
 
 #endif

--- a/include/hx/Macros.h
+++ b/include/hx/Macros.h
@@ -431,10 +431,10 @@ Dynamic class::func##_dyn() \
 static Dynamic Create##enum_obj(::String inName,hx::DynamicArray inArgs) \
 { \
    int idx =  enum_obj::__FindIndex(inName); \
-   if (idx<0) hx::Throw(HX_INVALID_CONSTRUCTOR); \
+   if (idx<0) __hxcpp_dbg_checkedThrow(HX_INVALID_ENUM_CONSTRUCTOR(#enum_obj, inName)); \
    int count =  enum_obj::__FindArgCount(inName); \
    int args = inArgs.GetPtr() ? inArgs.__length() : 0; \
-   if (args!=count)  hx::Throw(HX_INVALID_ARG_COUNT); \
+   if (args!=count) __hxcpp_dbg_checkedThrow(HX_INVALID_ENUM_ARG_COUNT(#enum_obj, inName, count, args)); \
    if (args==0) { Dynamic result =(new enum_obj())->__Field(inName,HX_PROP_DYNAMIC); if (result!=null()) return result; } \
    return hx::CreateEnum<enum_obj >(inName,idx,inArgs); \
 }

--- a/include/hx/Macros.tpl
+++ b/include/hx/Macros.tpl
@@ -177,10 +177,10 @@ Dynamic class::func##_dyn() \
 static Dynamic Create##enum_obj(::String inName,hx::DynamicArray inArgs) \
 { \
    int idx =  enum_obj::__FindIndex(inName); \
-   if (idx<0) hx::Throw(HX_INVALID_CONSTRUCTOR); \
+   if (idx<0) __hxcpp_dbg_checkedThrow(HX_INVALID_ENUM_CONSTRUCTOR(#enum_obj, inName)); \
    int count =  enum_obj::__FindArgCount(inName); \
    int args = inArgs.GetPtr() ? inArgs.__length() : 0; \
-   if (args!=count)  hx::Throw(HX_INVALID_ARG_COUNT); \
+   if (args!=count) __hxcpp_dbg_checkedThrow(HX_INVALID_ENUM_ARG_COUNT(#enum_obj, inName, count, args)); \
    if (args==0) { Dynamic result =(new enum_obj())->__Field(inName,HX_PROP_DYNAMIC); if (result!=null()) return result; } \
    return hx::CreateEnum<enum_obj >(inName,idx,inArgs); \
 }


### PR DESCRIPTION
Causes code which creates enums at runtime (using reflection I think, it's been a while since this change was made, and I can't remember the details) to throw a runtime exception that is more useful than the one that it was throwing previously.  Also breaks into the debugger if it's running.

