### PR TITLE
Topic fix debugger breakpoint hash

### DIFF
--- a/include/hx/Debug.h
+++ b/include/hx/Debug.h
@@ -122,6 +122,9 @@ public:
          #ifdef HXCPP_DEBUG_HASHES
          classFuncHash(inClassFunctionHash),
          fileHash(inFileHash),
+         #else
+         classFuncHash(0),
+         fileHash(0),
          #endif
          fullName(inFullName), fileName(inFileName),
          #ifdef HXCPP_STACK_LINE
@@ -156,10 +159,9 @@ public:
     // Only updated if HXCPP_STACK_LINE is defined.
     int lineNumber;
 
-    #ifdef HXCPP_DEBUG_HASHES
+    // These are only used if HXCPP_DEBUG_HASHES is defined
     int fileHash;
     int classFuncHash;
-    #endif
 
     // Function arguments and local variables in reverse order of their
     // declaration.  If a variable name is in here twice, the first version is

--- a/src/hx/Debug.cpp
+++ b/src/hx/Debug.cpp
@@ -1043,12 +1043,15 @@ private:
 class Breakpoints
 {
 public:
+
+#ifdef HXCPP_DEBUG_HASHES
     static int Hash(int value, const char *inString)
     {
        while(*inString)
           value = value*223 + *inString++;
        return value;
     }
+#endif
 
     static int Add(String inFileName, int lineNumber)
     {
@@ -1352,7 +1355,9 @@ private:
     Breakpoints()
         : mRefCount(1), mBreakpointCount(0), mBreakpoints(0)
     {
+#ifdef HXCPP_DEBUG_HASHES
        calcCombinedHash();
+#endif
     }
 
     // Copies breakpoints from toCopy and adds a new file:line breakpoint
@@ -1369,8 +1374,13 @@ private:
         mBreakpoints[toCopy->mBreakpointCount].isFileLine = true;
         mBreakpoints[toCopy->mBreakpointCount].fileOrClassName = fileName;
         mBreakpoints[toCopy->mBreakpointCount].lineNumber = lineNumber;
-        mBreakpoints[toCopy->mBreakpointCount].hash = Hash(0, fileName);
+
+#ifdef HXCPP_DEBUG_HASHES
+        mBreakpoints[toCopy->mBreakpointCount].hash = Hash(lineNumber, fileName);
         calcCombinedHash();
+#else
+        mBreakpoints[toCopy->mBreakpointCount].hash = 0;
+#endif
     }
 
     // Copies breakpoints from toCopy and adds a new class:function breakpoint
@@ -1387,12 +1397,17 @@ private:
         mBreakpoints[toCopy->mBreakpointCount].isFileLine = false;
         mBreakpoints[toCopy->mBreakpointCount].fileOrClassName = className;
         mBreakpoints[toCopy->mBreakpointCount].functionName = functionName.c_str();
+
+#ifdef HXCPP_DEBUG_HASHES
         int hash = Hash(0,className);
         hash = Hash(hash,".");
         hash = Hash(hash,functionName.c_str());
         //printf("%s.%s -> %08x\n", className, functionName.c_str(), hash );
         mBreakpoints[toCopy->mBreakpointCount].hash = hash;
         calcCombinedHash();
+#else
+        mBreakpoints[toCopy->mBreakpointCount].hash = 0;
+#endif
    }
 
    // Copies breakpoints from toCopy except for number
@@ -1412,9 +1427,12 @@ private:
               mBreakpoints[d++] = toCopy->mBreakpoints[s];
          }
       }
+#ifdef HXCPP_DEBUG_HASHES
       calcCombinedHash();
+#endif
    }
 
+#ifdef HXCPP_DEBUG_HASHES
    void calcCombinedHash()
    {
       int allFileLine = 0;
@@ -1430,6 +1448,7 @@ private:
       mNotInAnyClassFunc = ~allClassFunc;
       //printf("Combined mask -> %08x %08x\n", mNotInAnyFileLine, mNotInAnyClassFunc);
    }
+#endif
 
    ~Breakpoints()
    {
@@ -1454,12 +1473,20 @@ private:
 
    inline bool QuickRejectClassFunc(int inHash)
    {
+#ifdef HXCPP_DEBUG_HASHES
       return inHash & mNotInAnyClassFunc;
+#else
+      return false;
+#endif
    }
 
    inline bool QuickRejectFileLine(int inHash)
    {
+#ifdef HXCPP_DEBUG_HASHES
       return inHash & mNotInAnyFileLine;
+#else
+      return false;
+#endif
    }
 
     bool HasBreakpoint(int number) const
@@ -1526,8 +1553,10 @@ private:
 
     int mRefCount;
     int mBreakpointCount;
+#ifdef HXCPP_DEBUG_HASHES
     int mNotInAnyClassFunc;
     int mNotInAnyFileLine;
+#endif
     Breakpoint *mBreakpoints;
 
     static MyMutex gMutex;


### PR DESCRIPTION
We found that the HXCPP_DEBUG_HASHES functionality wasn't working.  I would expect that if this is the case, you'd know about it already as others would have reported it.  So it's possible that this change is unnecessary.  At the very least, this change makes the code compile and work correctly when HXCPP_DEBUG_HASHES is not defined.  You can take out the part of the change that disables HXCPP_DEBUG_HASHES (which is the first diff listed below, that comments out #define HAXPP_DEBUG_HASHES) if you think that debug hashes really are working, but the rest of the change should be taken regardless.
