### PR TITLE
Topic hxcpp api level

### DIFF
--- a/src/hx/StdLibs.cpp
+++ b/src/hx/StdLibs.cpp
@@ -98,7 +98,7 @@ String __hxcpp_resource_string(String inName)
    for(Resource *reso  = sgResources; reso->mData; reso++)
    {
       if (reso->mName == inName)
-      #if (HXCPP_API_LEVEL > 0)
+      #if ((defined HXCPP_API_LEVEL) && (HXCPP_API_LEVEL > 0))
           return String((const char *) reso->mData, reso->mDataLength );
       #else
           return String((const char *) reso->mData, reso->mDataLength ).dup();


### PR DESCRIPTION
If HXCPP_API_LEVEL is not defined at all, this code would fail to compile. I don't recall when this would happen, but regardless, the change here is simple and guards against that.
