### PR TITLE
Topic hxcpp visit allocs

### DIFF
--- a/include/hx/Anon.h
+++ b/include/hx/Anon.h
@@ -22,9 +22,10 @@ HXCPP_EXTERN_CLASS_ATTRIBUTES
 void FieldMapAppendFields(Dynamic *inMap,::Array< ::String> &outFields);
 HXCPP_EXTERN_CLASS_ATTRIBUTES
 void FieldMapMark(Dynamic *inMap,hx::MarkContext *__inCtx);
+#ifdef HXCPP_VISIT_ALLOCS
 HXCPP_EXTERN_CLASS_ATTRIBUTES
 void FieldMapVisit(Dynamic **inMap,hx::VisitContext *__inCtx);
-
+#endif
 
 } // end namespace hx
 

--- a/include/hx/Functions.h
+++ b/include/hx/Functions.h
@@ -8,7 +8,9 @@ namespace hx
    {
       int __GetType() const { return vtFunction; }
       inline void DoMarkThis(hx::MarkContext *__inCtx) { }
+#ifdef HXCPP_VISIT_ALLOCS
       inline void DoVisitThis(hx::VisitContext *__inCtx) { }
+#endif
    };
 
    struct HXCPP_EXTERN_CLASS_ATTRIBUTES LocalThisFunc : public LocalFunc
@@ -16,7 +18,9 @@ namespace hx
       Dynamic __this;
 		void __SetThis(Dynamic inThis) { __this = inThis; }
       inline void DoMarkThis(hx::MarkContext *__inCtx) { HX_MARK_MEMBER(__this); }
+#ifdef HXCPP_VISIT_ALLOCS
       inline void DoVisitThis(hx::VisitContext *__inCtx) { HX_VISIT_MEMBER(__this); }
+#endif
    };
 
 }

--- a/include/hx/GC.h
+++ b/include/hx/GC.h
@@ -7,8 +7,13 @@
 #define HX_MARK_PARAMS hx::MarkContext *__inCtx
 //#define HX_MARK_ADD_PARAMS ,hx::MarkContext *__inCtx
 
+#ifdef HXCPP_VISIT_ALLOCS
 #define HX_VISIT_ARG __inCtx
 #define HX_VISIT_PARAMS hx::VisitContext *__inCtx
+#else
+#define HX_VISIT_ARG
+#define HX_VISIT_PARAMS
+#endif
 
 // Tell compiler the extra functions are supported
 #define HXCPP_GC_FUNCTIONS_1

--- a/include/hx/GCTemplates.h
+++ b/include/hx/GCTemplates.h
@@ -36,7 +36,7 @@ template<> inline void MarkMember<String>(String &outT,hx::MarkContext *__inCtx)
 template<> inline void MarkMember<Void>(Void &outT,hx::MarkContext *__inCtx) {  }
 
 
-
+#ifdef HXCPP_VISIT_ALLOCS
 template<typename T> inline void VisitMember(T &outT,hx::VisitContext *__inCtx) { }
 
 template<typename T> inline void VisitMember(hx::ObjectPtr<T> &outT,hx::VisitContext *__inCtx)
@@ -64,7 +64,7 @@ template<> inline void VisitMember<String>(String &outT,hx::VisitContext *__inCt
    HX_VISIT_STRING(outT.__s);
 }
 template<> inline void VisitMember<Void>(Void &outT,hx::VisitContext *__inCtx) {  }
-
+#endif
 
 
 

--- a/include/hx/Macros.h
+++ b/include/hx/Macros.h
@@ -55,7 +55,15 @@
 
 #define HX_MARK_DYNAMIC HX_MARK_MEMBER(__mDynamicFields)
 
+
+#ifdef HX_VISIT_ALLOCS
+
 #define HX_VISIT_DYNAMIC HX_VISIT_MEMBER(__mDynamicFields);
+#else
+
+#define HX_VISIT_DYNAMIC do { } while (0);
+
+#endif
 
 #define HX_CHECK_DYNAMIC_GET_FIELD(inName) \
    { Dynamic d;  if (hx::FieldMapGet(&__mDynamicFields,inName,d)) return d; }
@@ -483,108 +491,168 @@ static Dynamic Create##enum_obj(::String inName,hx::DynamicArray inArgs) \
 #define HX_DYNAMIC_CALL19(ret,func) HX_DYNAMIC_CALL(ret,func,HX_ARR_LIST19,HX_DYNAMIC_ARG_LIST19,HX_ARG_LIST19)
 #define HX_DYNAMIC_CALL20(ret,func) HX_DYNAMIC_CALL(ret,func,HX_ARR_LIST20,HX_DYNAMIC_ARG_LIST20,HX_ARG_LIST20)
 
+#ifdef HXCPP_VISIT_ALLOCS
+#define HX_DEFAULT_VISIT_FUNC \
+    void __Visit(hx::VisitContext *__inCtx) { HX_VISIT_MEMBER(__this); }
+#else
+#define HX_DEFAULT_VISIT_FUNC
+#endif
+
 #define HX_BEGIN_DEFAULT_FUNC(name,t0) \
 	namespace { \
    struct name : public hx::Object { int __GetType() const { return vtFunction; } \
    hx::ObjectPtr<t0> __this; \
    name(hx::ObjectPtr<t0> __0 = null()) : __this(__0) {} \
    void __Mark(hx::MarkContext *__inCtx) { HX_MARK_MEMBER(__this); } \
-   void __Visit(hx::VisitContext *__inCtx) { HX_VISIT_MEMBER(__this); }
+   HX_DEFAULT_VISIT_FUNC
 
 
 #define HX_END_DEFAULT_FUNC \
 }
 
+#ifdef HXCPP_VISIT_ALLOCS
+#define HX_LOCAL_VISIT_FUNC \
+    void __Visit(hx::VisitContext *__inCtx) { DoVisitThis(__inCtx); }
+#else
+#define HX_LOCAL_VISIT_FUNC
+#endif
+
 #define HX_BEGIN_LOCAL_FUNC_S0(SUPER,name) \
    struct name : public SUPER { \
    void __Mark(hx::MarkContext *__inCtx) { DoMarkThis(__inCtx); } \
-   void __Visit(hx::VisitContext *__inCtx) { DoVisitThis(__inCtx); } \
+   HX_LOCAL_VISIT_FUNC \
    name() {}
+
+#ifdef HXCPP_VISIT_ALLOCS
+#define HX_LOCAL_VISIT_0(v0) \
+    void __Visit(hx::VisitContext *__inCtx) { DoVisitThis(__inCtx); HX_VISIT_MEMBER(v0); }
+#define HX_LOCAL_VISIT_1(v0, v1) \
+    void __Visit(hx::VisitContext *__inCtx) { DoVisitThis(__inCtx); HX_VISIT_MEMBER(v0); HX_VISIT_MEMBER(v1); }
+#define HX_LOCAL_VISIT_2(v0, v1, v2) \
+    void __Visit(hx::VisitContext *__inCtx) { DoVisitThis(__inCtx); HX_VISIT_MEMBER(v0); HX_VISIT_MEMBER(v1); HX_VISIT_MEMBER(v2); }
+#define HX_LOCAL_VISIT_3(v0, v1, v2, v3) \
+    void __Visit(hx::VisitContext *__inCtx) { DoVisitThis(__inCtx); HX_VISIT_MEMBER(v0); HX_VISIT_MEMBER(v1); HX_VISIT_MEMBER(v2); HX_VISIT_MEMBER(v3); }
+#define HX_LOCAL_VISIT_4(v0, v1, v2, v3, v4) \
+    void __Visit(hx::VisitContext *__inCtx) { DoVisitThis(__inCtx); HX_VISIT_MEMBER(v0); HX_VISIT_MEMBER(v1); HX_VISIT_MEMBER(v2); HX_VISIT_MEMBER(v3); HX_VISIT_MEMBER(v4); }
+#define HX_LOCAL_VISIT_5(v0, v1, v2, v3, v4, v5) \
+    void __Visit(hx::VisitContext *__inCtx) { DoVisitThis(__inCtx); HX_VISIT_MEMBER(v0); HX_VISIT_MEMBER(v1); HX_VISIT_MEMBER(v2); HX_VISIT_MEMBER(v3); HX_VISIT_MEMBER(v4); HX_VISIT_MEMBER(v5); }
+#define HX_LOCAL_VISIT_6(v0, v1, v2, v3, v4, v5, v6) \
+    void __Visit(hx::VisitContext *__inCtx) { DoVisitThis(__inCtx); HX_VISIT_MEMBER(v0); HX_VISIT_MEMBER(v1); HX_VISIT_MEMBER(v2); HX_VISIT_MEMBER(v3); HX_VISIT_MEMBER(v4); HX_VISIT_MEMBER(v5); HX_VISIT_MEMBER(v6); }
+#define HX_LOCAL_VISIT_7(v0, v1, v2, v3, v4, v5, v6, v7) \
+    void __Visit(hx::VisitContext *__inCtx) { DoVisitThis(__inCtx); HX_VISIT_MEMBER(v0); HX_VISIT_MEMBER(v1); HX_VISIT_MEMBER(v2); HX_VISIT_MEMBER(v3); HX_VISIT_MEMBER(v4); HX_VISIT_MEMBER(v5); HX_VISIT_MEMBER(v6); HX_VISIT_MEMBER(v7); }
+#define HX_LOCAL_VISIT_8(v0, v1, v2, v3, v4, v5, v6, v7, v8) \
+    void __Visit(hx::VisitContext *__inCtx) { DoVisitThis(__inCtx); HX_VISIT_MEMBER(v0); HX_VISIT_MEMBER(v1); HX_VISIT_MEMBER(v2); HX_VISIT_MEMBER(v3); HX_VISIT_MEMBER(v4); HX_VISIT_MEMBER(v5); HX_VISIT_MEMBER(v6); HX_VISIT_MEMBER(v7); HX_VISIT_MEMBER(v8); }
+#define HX_LOCAL_VISIT_9(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9) \
+    void __Visit(hx::VisitContext *__inCtx) { DoVisitThis(__inCtx); HX_VISIT_MEMBER(v0); HX_VISIT_MEMBER(v1); HX_VISIT_MEMBER(v2); HX_VISIT_MEMBER(v3); HX_VISIT_MEMBER(v4); HX_VISIT_MEMBER(v5); HX_VISIT_MEMBER(v6); HX_VISIT_MEMBER(v7); HX_VISIT_MEMBER(v8); HX_VISIT_MEMBER(v9); }
+#define HX_LOCAL_VISIT_10(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10) \
+    void __Visit(hx::VisitContext *__inCtx) { DoVisitThis(__inCtx); HX_VISIT_MEMBER(v0); HX_VISIT_MEMBER(v1); HX_VISIT_MEMBER(v2); HX_VISIT_MEMBER(v3); HX_VISIT_MEMBER(v4); HX_VISIT_MEMBER(v5); HX_VISIT_MEMBER(v6); HX_VISIT_MEMBER(v7); HX_VISIT_MEMBER(v8); HX_VISIT_MEMBER(v9); HX_VISIT_MEMBER(v10); }
+#define HX_LOCAL_VISIT_11(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11) \
+    void __Visit(hx::VisitContext *__inCtx) { DoVisitThis(__inCtx); HX_VISIT_MEMBER(v0); HX_VISIT_MEMBER(v1); HX_VISIT_MEMBER(v2); HX_VISIT_MEMBER(v3); HX_VISIT_MEMBER(v4); HX_VISIT_MEMBER(v5); HX_VISIT_MEMBER(v6); HX_VISIT_MEMBER(v7); HX_VISIT_MEMBER(v8); HX_VISIT_MEMBER(v9); HX_VISIT_MEMBER(v10); HX_VISIT_MEMBER(v11); }
+#define HX_LOCAL_VISIT_12(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12) \
+    void __Visit(hx::VisitContext *__inCtx) { DoVisitThis(__inCtx); HX_VISIT_MEMBER(v0); HX_VISIT_MEMBER(v1); HX_VISIT_MEMBER(v2); HX_VISIT_MEMBER(v3); HX_VISIT_MEMBER(v4); HX_VISIT_MEMBER(v5); HX_VISIT_MEMBER(v6); HX_VISIT_MEMBER(v7); HX_VISIT_MEMBER(v8); HX_VISIT_MEMBER(v9); HX_VISIT_MEMBER(v10); HX_VISIT_MEMBER(v11); HX_VISIT_MEMBER(v12); }
+#define HX_LOCAL_VISIT_13(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13) \
+    void __Visit(hx::VisitContext *__inCtx) { DoVisitThis(__inCtx); HX_VISIT_MEMBER(v0); HX_VISIT_MEMBER(v1); HX_VISIT_MEMBER(v2); HX_VISIT_MEMBER(v3); HX_VISIT_MEMBER(v4); HX_VISIT_MEMBER(v5); HX_VISIT_MEMBER(v6); HX_VISIT_MEMBER(v7); HX_VISIT_MEMBER(v8); HX_VISIT_MEMBER(v9); HX_VISIT_MEMBER(v10); HX_VISIT_MEMBER(v11); HX_VISIT_MEMBER(v12); HX_VISIT_MEMBER(v13); }
+#else
+#define HX_LOCAL_VISIT_0(v0)
+#define HX_LOCAL_VISIT_1(v0, v1)
+#define HX_LOCAL_VISIT_2(v0, v1, v2)
+#define HX_LOCAL_VISIT_3(v0, v1, v2, v3)
+#define HX_LOCAL_VISIT_4(v0, v1, v2, v3, v4)
+#define HX_LOCAL_VISIT_5(v0, v1, v2, v3, v4, v5)
+#define HX_LOCAL_VISIT_6(v0, v1, v2, v3, v4, v5, v6)
+#define HX_LOCAL_VISIT_7(v0, v1, v2, v3, v4, v5, v6, v7)
+#define HX_LOCAL_VISIT_8(v0, v1, v2, v3, v4, v5, v6, v7, v8)
+#define HX_LOCAL_VISIT_9(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9)
+#define HX_LOCAL_VISIT_10(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10)
+#define HX_LOCAL_VISIT_11(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11)
+#define HX_LOCAL_VISIT_12(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12)
+#define HX_LOCAL_VISIT_13(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13)
+#endif
 
 
 #define HX_BEGIN_LOCAL_FUNC_S1(SUPER,name,t0,v0) \
    struct name : public SUPER { \
    t0 v0; \
    void __Mark(hx::MarkContext *__inCtx) { DoMarkThis(__inCtx); HX_MARK_MEMBER(v0); } \
-   void __Visit(hx::VisitContext *__inCtx) { DoVisitThis(__inCtx); HX_VISIT_MEMBER(v0); } \
+   HX_LOCAL_VISIT_0(v0) \
    name(t0 __0) : v0(__0) {}
 #define HX_BEGIN_LOCAL_FUNC_S2(SUPER,name,t0,v0,t1,v1) \
    struct name : public SUPER { \
    t0 v0;t1 v1; \
    void __Mark(hx::MarkContext *__inCtx) { DoMarkThis(__inCtx); HX_MARK_MEMBER(v0); HX_MARK_MEMBER(v1); } \
-   void __Visit(hx::VisitContext *__inCtx) { DoVisitThis(__inCtx); HX_VISIT_MEMBER(v0); HX_VISIT_MEMBER(v1); } \
+   HX_LOCAL_VISIT_1(v0, v1) \
    name(t0 __0,t1 __1) : v0(__0),v1(__1) {}
 #define HX_BEGIN_LOCAL_FUNC_S3(SUPER,name,t0,v0,t1,v1,t2,v2) \
    struct name : public SUPER { \
    t0 v0;t1 v1;t2 v2; \
    void __Mark(hx::MarkContext *__inCtx) { DoMarkThis(__inCtx); HX_MARK_MEMBER(v0); HX_MARK_MEMBER(v1); HX_MARK_MEMBER(v2); } \
-   void __Visit(hx::VisitContext *__inCtx) { DoVisitThis(__inCtx); HX_VISIT_MEMBER(v0); HX_VISIT_MEMBER(v1); HX_VISIT_MEMBER(v2); } \
+   HX_LOCAL_VISIT_2(v0, v1, v2) \
    name(t0 __0,t1 __1,t2 __2) : v0(__0),v1(__1),v2(__2) {}
 #define HX_BEGIN_LOCAL_FUNC_S4(SUPER,name,t0,v0,t1,v1,t2,v2,t3,v3) \
    struct name : public SUPER { \
    t0 v0;t1 v1;t2 v2;t3 v3; \
    void __Mark(hx::MarkContext *__inCtx) { DoMarkThis(__inCtx); HX_MARK_MEMBER(v0); HX_MARK_MEMBER(v1); HX_MARK_MEMBER(v2); HX_MARK_MEMBER(v3); } \
-   void __Visit(hx::VisitContext *__inCtx) { DoVisitThis(__inCtx); HX_VISIT_MEMBER(v0); HX_VISIT_MEMBER(v1); HX_VISIT_MEMBER(v2); HX_VISIT_MEMBER(v3); } \
+   HX_LOCAL_VISIT_3(v0, v1, v2, v3) \
    name(t0 __0,t1 __1,t2 __2,t3 __3) : v0(__0),v1(__1),v2(__2),v3(__3) {}
 #define HX_BEGIN_LOCAL_FUNC_S5(SUPER,name,t0,v0,t1,v1,t2,v2,t3,v3,t4,v4) \
    struct name : public SUPER { \
    t0 v0;t1 v1;t2 v2;t3 v3;t4 v4; \
    void __Mark(hx::MarkContext *__inCtx) { DoMarkThis(__inCtx); HX_MARK_MEMBER(v0); HX_MARK_MEMBER(v1); HX_MARK_MEMBER(v2); HX_MARK_MEMBER(v3); HX_MARK_MEMBER(v4); } \
-   void __Visit(hx::VisitContext *__inCtx) { DoVisitThis(__inCtx); HX_VISIT_MEMBER(v0); HX_VISIT_MEMBER(v1); HX_VISIT_MEMBER(v2); HX_VISIT_MEMBER(v3); HX_VISIT_MEMBER(v4); } \
+   HX_LOCAL_VISIT_4(v0, v1, v2, v3, v4) \
    name(t0 __0,t1 __1,t2 __2,t3 __3,t4 __4) : v0(__0),v1(__1),v2(__2),v3(__3),v4(__4) {}
 #define HX_BEGIN_LOCAL_FUNC_S6(SUPER,name,t0,v0,t1,v1,t2,v2,t3,v3,t4,v4,t5,v5) \
    struct name : public SUPER { \
    t0 v0;t1 v1;t2 v2;t3 v3;t4 v4;t5 v5; \
    void __Mark(hx::MarkContext *__inCtx) { DoMarkThis(__inCtx); HX_MARK_MEMBER(v0); HX_MARK_MEMBER(v1); HX_MARK_MEMBER(v2); HX_MARK_MEMBER(v3); HX_MARK_MEMBER(v4); HX_MARK_MEMBER(v5); } \
-   void __Visit(hx::VisitContext *__inCtx) { DoVisitThis(__inCtx); HX_VISIT_MEMBER(v0); HX_VISIT_MEMBER(v1); HX_VISIT_MEMBER(v2); HX_VISIT_MEMBER(v3); HX_VISIT_MEMBER(v4); HX_VISIT_MEMBER(v5); } \
+   HX_LOCAL_VISIT_5(v0, v1, v2, v3, v4, v5) \
    name(t0 __0,t1 __1,t2 __2,t3 __3,t4 __4,t5 __5) : v0(__0),v1(__1),v2(__2),v3(__3),v4(__4),v5(__5) {}
 #define HX_BEGIN_LOCAL_FUNC_S7(SUPER,name,t0,v0,t1,v1,t2,v2,t3,v3,t4,v4,t5,v5,t6,v6) \
    struct name : public SUPER { \
    t0 v0;t1 v1;t2 v2;t3 v3;t4 v4;t5 v5;t6 v6; \
    void __Mark(hx::MarkContext *__inCtx) { DoMarkThis(__inCtx); HX_MARK_MEMBER(v0); HX_MARK_MEMBER(v1); HX_MARK_MEMBER(v2); HX_MARK_MEMBER(v3); HX_MARK_MEMBER(v4); HX_MARK_MEMBER(v5); HX_MARK_MEMBER(v6); } \
-   void __Visit(hx::VisitContext *__inCtx) { DoVisitThis(__inCtx); HX_VISIT_MEMBER(v0); HX_VISIT_MEMBER(v1); HX_VISIT_MEMBER(v2); HX_VISIT_MEMBER(v3); HX_VISIT_MEMBER(v4); HX_VISIT_MEMBER(v5); HX_VISIT_MEMBER(v6); } \
+   HX_LOCAL_VISIT_6(v0, v1, v2, v3, v4, v5, v6) \
    name(t0 __0,t1 __1,t2 __2,t3 __3,t4 __4,t5 __5,t6 __6) : v0(__0),v1(__1),v2(__2),v3(__3),v4(__4),v5(__5),v6(__6) {}
 #define HX_BEGIN_LOCAL_FUNC_S8(SUPER,name,t0,v0,t1,v1,t2,v2,t3,v3,t4,v4,t5,v5,t6,v6,t7,v7) \
    struct name : public SUPER { \
    t0 v0;t1 v1;t2 v2;t3 v3;t4 v4;t5 v5;t6 v6;t7 v7; \
    void __Mark(hx::MarkContext *__inCtx) { DoMarkThis(__inCtx); HX_MARK_MEMBER(v0); HX_MARK_MEMBER(v1); HX_MARK_MEMBER(v2); HX_MARK_MEMBER(v3); HX_MARK_MEMBER(v4); HX_MARK_MEMBER(v5); HX_MARK_MEMBER(v6); HX_MARK_MEMBER(v7); } \
-   void __Visit(hx::VisitContext *__inCtx) { DoVisitThis(__inCtx); HX_VISIT_MEMBER(v0); HX_VISIT_MEMBER(v1); HX_VISIT_MEMBER(v2); HX_VISIT_MEMBER(v3); HX_VISIT_MEMBER(v4); HX_VISIT_MEMBER(v5); HX_VISIT_MEMBER(v6); HX_VISIT_MEMBER(v7); } \
+   HX_LOCAL_VISIT_7(v0, v1, v2, v3, v4, v5, v6, v7) \
    name(t0 __0,t1 __1,t2 __2,t3 __3,t4 __4,t5 __5,t6 __6,t7 __7) : v0(__0),v1(__1),v2(__2),v3(__3),v4(__4),v5(__5),v6(__6),v7(__7) {}
 #define HX_BEGIN_LOCAL_FUNC_S9(SUPER,name,t0,v0,t1,v1,t2,v2,t3,v3,t4,v4,t5,v5,t6,v6,t7,v7,t8,v8) \
    struct name : public SUPER { \
    t0 v0;t1 v1;t2 v2;t3 v3;t4 v4;t5 v5;t6 v6;t7 v7;t8 v8; \
    void __Mark(hx::MarkContext *__inCtx) { DoMarkThis(__inCtx); HX_MARK_MEMBER(v0); HX_MARK_MEMBER(v1); HX_MARK_MEMBER(v2); HX_MARK_MEMBER(v3); HX_MARK_MEMBER(v4); HX_MARK_MEMBER(v5); HX_MARK_MEMBER(v6); HX_MARK_MEMBER(v7); HX_MARK_MEMBER(v8); } \
-   void __Visit(hx::VisitContext *__inCtx) { DoVisitThis(__inCtx); HX_VISIT_MEMBER(v0); HX_VISIT_MEMBER(v1); HX_VISIT_MEMBER(v2); HX_VISIT_MEMBER(v3); HX_VISIT_MEMBER(v4); HX_VISIT_MEMBER(v5); HX_VISIT_MEMBER(v6); HX_VISIT_MEMBER(v7); HX_VISIT_MEMBER(v8); } \
+   HX_LOCAL_VISIT_8(v0, v1, v2, v3, v4, v5, v6, v7, v8) \
    name(t0 __0,t1 __1,t2 __2,t3 __3,t4 __4,t5 __5,t6 __6,t7 __7,t8 __8) : v0(__0),v1(__1),v2(__2),v3(__3),v4(__4),v5(__5),v6(__6),v7(__7),v8(__8) {}
 #define HX_BEGIN_LOCAL_FUNC_S10(SUPER,name,t0,v0,t1,v1,t2,v2,t3,v3,t4,v4,t5,v5,t6,v6,t7,v7,t8,v8,t9,v9) \
    struct name : public SUPER { \
    t0 v0;t1 v1;t2 v2;t3 v3;t4 v4;t5 v5;t6 v6;t7 v7;t8 v8;t9 v9; \
    void __Mark(hx::MarkContext *__inCtx) { DoMarkThis(__inCtx); HX_MARK_MEMBER(v0); HX_MARK_MEMBER(v1); HX_MARK_MEMBER(v2); HX_MARK_MEMBER(v3); HX_MARK_MEMBER(v4); HX_MARK_MEMBER(v5); HX_MARK_MEMBER(v6); HX_MARK_MEMBER(v7); HX_MARK_MEMBER(v8); HX_MARK_MEMBER(v9); } \
-   void __Visit(hx::VisitContext *__inCtx) { DoVisitThis(__inCtx); HX_VISIT_MEMBER(v0); HX_VISIT_MEMBER(v1); HX_VISIT_MEMBER(v2); HX_VISIT_MEMBER(v3); HX_VISIT_MEMBER(v4); HX_VISIT_MEMBER(v5); HX_VISIT_MEMBER(v6); HX_VISIT_MEMBER(v7); HX_VISIT_MEMBER(v8); HX_VISIT_MEMBER(v9); } \
+   HX_LOCAL_VISIT_9(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9) \
    name(t0 __0,t1 __1,t2 __2,t3 __3,t4 __4,t5 __5,t6 __6,t7 __7,t8 __8,t9 __9) : v0(__0),v1(__1),v2(__2),v3(__3),v4(__4),v5(__5),v6(__6),v7(__7),v8(__8),v9(__9) {}
 #define HX_BEGIN_LOCAL_FUNC_S11(SUPER,name,t0,v0,t1,v1,t2,v2,t3,v3,t4,v4,t5,v5,t6,v6,t7,v7,t8,v8,t9,v9,t10,v10) \
    struct name : public SUPER { \
    t0 v0;t1 v1;t2 v2;t3 v3;t4 v4;t5 v5;t6 v6;t7 v7;t8 v8;t9 v9;t10 v10; \
    void __Mark(hx::MarkContext *__inCtx) { DoMarkThis(__inCtx); HX_MARK_MEMBER(v0); HX_MARK_MEMBER(v1); HX_MARK_MEMBER(v2); HX_MARK_MEMBER(v3); HX_MARK_MEMBER(v4); HX_MARK_MEMBER(v5); HX_MARK_MEMBER(v6); HX_MARK_MEMBER(v7); HX_MARK_MEMBER(v8); HX_MARK_MEMBER(v9); HX_MARK_MEMBER(v10); } \
-   void __Visit(hx::VisitContext *__inCtx) { DoVisitThis(__inCtx); HX_VISIT_MEMBER(v0); HX_VISIT_MEMBER(v1); HX_VISIT_MEMBER(v2); HX_VISIT_MEMBER(v3); HX_VISIT_MEMBER(v4); HX_VISIT_MEMBER(v5); HX_VISIT_MEMBER(v6); HX_VISIT_MEMBER(v7); HX_VISIT_MEMBER(v8); HX_VISIT_MEMBER(v9); HX_VISIT_MEMBER(v10); } \
+   HX_LOCAL_VISIT_10(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10) \
    name(t0 __0,t1 __1,t2 __2,t3 __3,t4 __4,t5 __5,t6 __6,t7 __7,t8 __8,t9 __9,t10 __10) : v0(__0),v1(__1),v2(__2),v3(__3),v4(__4),v5(__5),v6(__6),v7(__7),v8(__8),v9(__9),v10(__10) {}
 #define HX_BEGIN_LOCAL_FUNC_S12(SUPER,name,t0,v0,t1,v1,t2,v2,t3,v3,t4,v4,t5,v5,t6,v6,t7,v7,t8,v8,t9,v9,t10,v10,t11,v11) \
    struct name : public SUPER { \
    t0 v0;t1 v1;t2 v2;t3 v3;t4 v4;t5 v5;t6 v6;t7 v7;t8 v8;t9 v9;t10 v10;t11 v11; \
    void __Mark(hx::MarkContext *__inCtx) { DoMarkThis(__inCtx); HX_MARK_MEMBER(v0); HX_MARK_MEMBER(v1); HX_MARK_MEMBER(v2); HX_MARK_MEMBER(v3); HX_MARK_MEMBER(v4); HX_MARK_MEMBER(v5); HX_MARK_MEMBER(v6); HX_MARK_MEMBER(v7); HX_MARK_MEMBER(v8); HX_MARK_MEMBER(v9); HX_MARK_MEMBER(v10); HX_MARK_MEMBER(v11); } \
-   void __Visit(hx::VisitContext *__inCtx) { DoVisitThis(__inCtx); HX_VISIT_MEMBER(v0); HX_VISIT_MEMBER(v1); HX_VISIT_MEMBER(v2); HX_VISIT_MEMBER(v3); HX_VISIT_MEMBER(v4); HX_VISIT_MEMBER(v5); HX_VISIT_MEMBER(v6); HX_VISIT_MEMBER(v7); HX_VISIT_MEMBER(v8); HX_VISIT_MEMBER(v9); HX_VISIT_MEMBER(v10); HX_VISIT_MEMBER(v11); } \
+   HX_LOCAL_VISIT_11(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11) \
    name(t0 __0,t1 __1,t2 __2,t3 __3,t4 __4,t5 __5,t6 __6,t7 __7,t8 __8,t9 __9,t10 __10,t11 __11) : v0(__0),v1(__1),v2(__2),v3(__3),v4(__4),v5(__5),v6(__6),v7(__7),v8(__8),v9(__9),v10(__10),v11(__11) {}
 #define HX_BEGIN_LOCAL_FUNC_S13(SUPER,name,t0,v0,t1,v1,t2,v2,t3,v3,t4,v4,t5,v5,t6,v6,t7,v7,t8,v8,t9,v9,t10,v10,t11,v11,t12,v12) \
    struct name : public SUPER { \
    t0 v0;t1 v1;t2 v2;t3 v3;t4 v4;t5 v5;t6 v6;t7 v7;t8 v8;t9 v9;t10 v10;t11 v11;t12 v12; \
    void __Mark(hx::MarkContext *__inCtx) { DoMarkThis(__inCtx); HX_MARK_MEMBER(v0); HX_MARK_MEMBER(v1); HX_MARK_MEMBER(v2); HX_MARK_MEMBER(v3); HX_MARK_MEMBER(v4); HX_MARK_MEMBER(v5); HX_MARK_MEMBER(v6); HX_MARK_MEMBER(v7); HX_MARK_MEMBER(v8); HX_MARK_MEMBER(v9); HX_MARK_MEMBER(v10); HX_MARK_MEMBER(v11); HX_MARK_MEMBER(v12); } \
-   void __Visit(hx::VisitContext *__inCtx) { DoVisitThis(__inCtx); HX_VISIT_MEMBER(v0); HX_VISIT_MEMBER(v1); HX_VISIT_MEMBER(v2); HX_VISIT_MEMBER(v3); HX_VISIT_MEMBER(v4); HX_VISIT_MEMBER(v5); HX_VISIT_MEMBER(v6); HX_VISIT_MEMBER(v7); HX_VISIT_MEMBER(v8); HX_VISIT_MEMBER(v9); HX_VISIT_MEMBER(v10); HX_VISIT_MEMBER(v11); HX_VISIT_MEMBER(v12); } \
+   HX_LOCAL_VISIT_12(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12) \
    name(t0 __0,t1 __1,t2 __2,t3 __3,t4 __4,t5 __5,t6 __6,t7 __7,t8 __8,t9 __9,t10 __10,t11 __11,t12 __12) : v0(__0),v1(__1),v2(__2),v3(__3),v4(__4),v5(__5),v6(__6),v7(__7),v8(__8),v9(__9),v10(__10),v11(__11),v12(__12) {}
 #define HX_BEGIN_LOCAL_FUNC_S14(SUPER,name,t0,v0,t1,v1,t2,v2,t3,v3,t4,v4,t5,v5,t6,v6,t7,v7,t8,v8,t9,v9,t10,v10,t11,v11,t12,v12,t13,v13) \
    struct name : public SUPER { \
    t0 v0;t1 v1;t2 v2;t3 v3;t4 v4;t5 v5;t6 v6;t7 v7;t8 v8;t9 v9;t10 v10;t11 v11;t12 v12;t13 v13; \
    void __Mark(hx::MarkContext *__inCtx) { DoMarkThis(__inCtx); HX_MARK_MEMBER(v0); HX_MARK_MEMBER(v1); HX_MARK_MEMBER(v2); HX_MARK_MEMBER(v3); HX_MARK_MEMBER(v4); HX_MARK_MEMBER(v5); HX_MARK_MEMBER(v6); HX_MARK_MEMBER(v7); HX_MARK_MEMBER(v8); HX_MARK_MEMBER(v9); HX_MARK_MEMBER(v10); HX_MARK_MEMBER(v11); HX_MARK_MEMBER(v12); HX_MARK_MEMBER(v13); } \
-   void __Visit(hx::VisitContext *__inCtx) { DoVisitThis(__inCtx); HX_VISIT_MEMBER(v0); HX_VISIT_MEMBER(v1); HX_VISIT_MEMBER(v2); HX_VISIT_MEMBER(v3); HX_VISIT_MEMBER(v4); HX_VISIT_MEMBER(v5); HX_VISIT_MEMBER(v6); HX_VISIT_MEMBER(v7); HX_VISIT_MEMBER(v8); HX_VISIT_MEMBER(v9); HX_VISIT_MEMBER(v10); HX_VISIT_MEMBER(v11); HX_VISIT_MEMBER(v12); HX_VISIT_MEMBER(v13); } \
+   HX_LOCAL_VISIT_13(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13) \
    name(t0 __0,t1 __1,t2 __2,t3 __3,t4 __4,t5 __5,t6 __6,t7 __7,t8 __8,t9 __9,t10 __10,t11 __11,t12 __12,t13 __13) : v0(__0),v1(__1),v2(__2),v3(__3),v4(__4),v5(__5),v6(__6),v7(__7),v8(__8),v9(__9),v10(__10),v11(__11),v12(__12),v13(__13) {}
 
 

--- a/include/hx/Macros.tpl
+++ b/include/hx/Macros.tpl
@@ -47,7 +47,16 @@
 
 #define HX_MARK_DYNAMIC HX_MARK_MEMBER(__mDynamicFields)
 
+
+#ifdef HX_VISIT_ALLOCS
+
 #define HX_VISIT_DYNAMIC HX_VISIT_MEMBER(__mDynamicFields);
+
+#else
+
+#define HX_VISIT_DYNAMIC do { } while (0);
+
+#endif
 
 #define HX_CHECK_DYNAMIC_GET_FIELD(inName) \
    { Dynamic d;  if (hx::FieldMapGet(&__mDynamicFields,inName,d)) return d; }

--- a/include/hx/Scriptable.h
+++ b/include/hx/Scriptable.h
@@ -267,24 +267,37 @@ void __scriptable_load_abc(Array<unsigned char> inBytes);
    int __GetType() const { return hx::ScriptableGetType(__scriptVTable[-1]); } \
 
 
+#ifdef HXCPP_VISIT_ALLOCS
+#define SCRIPTABLE_VISIT_FUNCTION \
+void __Visit(HX_VISIT_PARAMS) { HX_VISIT_OBJECT(mDelegate.mPtr); }
+#else
+#define SCRIPTABLE_VISIT_FUNCTION
+#endif
+
 #define HX_DEFINE_SCRIPTABLE_INTERFACE \
    void **__scriptVTable; \
    Dynamic mDelegate; \
    hx::Object *__GetRealObject() { return mDelegate.mPtr; } \
-   void __Visit(HX_VISIT_PARAMS) { HX_VISIT_OBJECT(mDelegate.mPtr); } \
+   SCRIPTABLE_VISIT_FUNCTION \
    void ** __GetScriptVTable() { return __scriptVTable; } \
    public: \
    static hx::Object *__script_create(void **inVTable,hx::Object *inDelegate) { \
     __ME *result = new __ME(); \
     result->__scriptVTable = inVTable; \
     result->mDelegate = inDelegate; \
-    return result; } \
+    return result; }
 
 
+#ifdef HXCPP_VISIT_ALLOCS
+#define SCRIPTABLE_DYNAMIC_VISIT_FUNCTION \
+void __Visit(HX_VISIT_PARAMS) { super::__Visit(HX_VISIT_ARG); hx::ScriptableVisit(__scriptVTable[-1],this,HX_VISIT_ARG); }
+#else
+#define SCRIPTABLE_DYNAMIC_VISIT_FUNCTION
+#endif
 
 #define HX_DEFINE_SCRIPTABLE_DYNAMIC \
 	void __Mark(HX_MARK_PARAMS) { super::__Mark(HX_MARK_ARG); hx::ScriptableMark(__scriptVTable[-1],this,HX_MARK_ARG); } \
-   void __Visit(HX_VISIT_PARAMS) { super::__Visit(HX_VISIT_ARG); hx::ScriptableVisit(__scriptVTable[-1],this,HX_VISIT_ARG); } \
+   SCRIPTABLE_DYNAMIC_VISIT_FUNCTION \
  \
 	Dynamic __Field(const ::String &inName,hx::PropertyAccess inCallProp) \
       { Dynamic result; if (hx::ScriptableField(this,inName,inCallProp,result)) return result; return super::__Field(inName,inCallProp); } \

--- a/src/Array.cpp
+++ b/src/Array.cpp
@@ -334,6 +334,13 @@ void ArrayBase::safeSort(Dynamic inSorter, bool inIsString)
 
 
 
+#ifdef HXCPP_VISIT_ALLOCS
+#define ARRAY_VISIT_FUNC \
+    void __Visit(hx::VisitContext *__inCtx) { HX_VISIT_MEMBER(mThis); }
+#else
+#define ARRAY_VISIT_FUNC
+#endif
+
 #define DEFINE_ARRAY_FUNC(func,array_list,dynamic_arg_list,arg_list,ARG_C) \
 struct ArrayBase_##func : public hx::Object \
 { \
@@ -346,7 +353,7 @@ struct ArrayBase_##func : public hx::Object \
    void *__GetHandle() const { return mThis; } \
    int __ArgCount() const { return ARG_C; } \
    void __Mark(hx::MarkContext *__inCtx) { HX_MARK_MEMBER(mThis); } \
-   void __Visit(hx::VisitContext *__inCtx) { HX_VISIT_MEMBER(mThis); } \
+   ARRAY_VISIT_FUNC \
    Dynamic __Run(const Array<Dynamic> &inArgs) \
    { \
       return mThis->__##func(array_list); return Dynamic(); \

--- a/src/String.cpp
+++ b/src/String.cpp
@@ -972,6 +972,12 @@ String &String::operator+=(String inRHS)
    return *this;
 }
 
+#ifdef HXCPP_VISIT_ALLOCS
+#define STRING_VISIT_FUNC \
+    void __Visit(hx::VisitContext *__inCtx) { HX_VISIT_STRING(mThis.__s); }
+#else
+#define STRING_VISIT_FUNC
+#endif
 
 #define DEFINE_STRING_FUNC(func,array_list,dynamic_arg_list,arg_list,ARG_C) \
 struct __String_##func : public hx::Object \
@@ -993,7 +999,7 @@ struct __String_##func : public hx::Object \
       return mThis.func(arg_list); return Dynamic(); \
    } \
 	void __Mark(hx::MarkContext *__inCtx) { HX_MARK_STRING(mThis.__s); } \
-	void __Visit(hx::VisitContext *__inCtx) { HX_VISIT_STRING(mThis.__s); } \
+	STRING_VISIT_FUNC \
 	void  __SetThis(Dynamic inThis) { mThis = inThis; } \
 }; \
 Dynamic String::func##_dyn()  { return new __String_##func(*this);  }

--- a/src/hx/Hash.h
+++ b/src/hx/Hash.h
@@ -586,6 +586,7 @@ struct Hash : public HashBase< typename ELEMENT::Key >
       iterate(marker);
    }
 
+#ifdef HXCPP_VISIT_ALLOCS
    // Vist ...
    struct HashVisitor
    {
@@ -609,6 +610,7 @@ struct Hash : public HashBase< typename ELEMENT::Key >
       HashVisitor vistor(__inCtx);
       iterateAddr(vistor);
    }
+#endif
 };
 
 
@@ -823,6 +825,7 @@ struct TinyHash : public HashBase< typename ELEMENT::Key >
       }
    }
 
+#ifdef HXCPP_VISIT_ALLOCS
    void __Visit(hx::VisitContext *__inCtx)
    {
       HX_VISIT_ARRAY(element);
@@ -835,6 +838,7 @@ struct TinyHash : public HashBase< typename ELEMENT::Key >
          }
       }
    }
+#endif
 };
 
 } // end namespace hx

--- a/src/hx/Scriptable.cpp
+++ b/src/hx/Scriptable.cpp
@@ -594,6 +594,7 @@ public:
       }
    }
 
+#ifdef HXCPP_VISIT_ALLOCS
    void visitFields(unsigned char *inData, HX_VISIT_PARAMS)
    {
       for(int i=0;i<mFields.size();i++)
@@ -611,6 +612,7 @@ public:
          inData += field.mBytes;
       }
    }
+#endif
 
    int findVTableSlot(const std::string &inName)
    {
@@ -733,6 +735,7 @@ public:
    {
    }
 
+#ifdef HXCPP_VISIT_ALLOCS
    void __Visit(hx::VisitContext *__inCtx)
    {
       hx::Class_obj::__Visit(__inCtx);
@@ -741,6 +744,7 @@ public:
    void VisitStatics(hx::VisitContext *__inCtx)
    {
    }
+#endif
 
    Dynamic ConstructEmpty()
    {
@@ -1422,11 +1426,13 @@ void ScriptableMark(ScriptHandler *inHandler, unsigned char *inInstanceData, HX_
    inHandler->markFields(inInstanceData,HX_MARK_ARG);
 }
 
+#ifdef HXCPP_VISIT_ALLOCS
 void ScriptableVisit(ScriptHandler *inHandler, unsigned char **inInstanceDataPtr, HX_VISIT_PARAMS)
 {
    HX_VISIT_ARRAY(inInstanceDataPtr);
    inHandler->visitFields(*inInstanceDataPtr,HX_VISIT_ARG);
 }
+#endif
 
 bool ScriptableField(hx::Object *, const ::String &,bool inCallProp,Dynamic &outResult)
 {

--- a/src/hx/cppia/Cppia.cpp
+++ b/src/hx/cppia/Cppia.cpp
@@ -55,6 +55,8 @@ void TypeData::mark(hx::MarkContext *__inCtx)
    if (cppiaClass)
       cppiaClassMark(cppiaClass,__inCtx);
 }
+
+#ifdef HXCPP_VISIT_ALLOCS
 void TypeData::visit(hx::VisitContext *__inCtx)
 {
    HX_VISIT_MEMBER(name);
@@ -62,6 +64,7 @@ void TypeData::visit(hx::VisitContext *__inCtx)
    if (cppiaClass)
       cppiaClassVisit(cppiaClass,__inCtx);
 }
+#endif
 
 
 struct StackLayout;
@@ -1492,6 +1495,7 @@ struct CppiaClassInfo
       for(int i=0;i<staticDynamicFunctions.size();i++)
          staticDynamicFunctions[i]->mark(__inCtx);
    }
+#ifdef HXCPP_VISIT_ALLOCS
    void visit(hx::VisitContext *__inCtx)
    {
       HX_VISIT_MEMBER(mClass);
@@ -1505,6 +1509,7 @@ struct CppiaClassInfo
       for(int i=0;i<staticDynamicFunctions.size();i++)
          staticDynamicFunctions[i]->visit(__inCtx);
    }
+#endif
 
 
 
@@ -2244,6 +2249,7 @@ struct CppiaClassInfo
          memberVars[i]->mark(inThis, __inCtx);
    }
 
+#ifdef HXCPP_VISIT_ALLOCS
    inline void visitInstance(hx::Object *inThis, hx::VisitContext *__inCtx)
    {
       if (dynamicMapOffset)
@@ -2254,6 +2260,7 @@ struct CppiaClassInfo
       for(int i=0;i<memberVars.size();i++)
          memberVars[i]->visit(inThis, __inCtx);
    }
+#endif
 };
 
 
@@ -2267,10 +2274,12 @@ void cppiaClassMark(CppiaClassInfo *inClass,hx::MarkContext *__inCtx)
 {
    inClass->mark(__inCtx);
 }
+#ifdef HXCPP_VISIT_ALLOCS
 void cppiaClassVisit(CppiaClassInfo *inClass,hx::VisitContext *__inCtx)
 {
    inClass->visit(__inCtx);
 }
+#endif
 
 // --- Enum Base ---
 ::hx::ObjectPtr<hx::Class_obj > CppiaEnumBase::__GetClass() const
@@ -2628,6 +2637,7 @@ public:
       for(int i=0;i<function->captureVars.size();i++)
          function->captureVars[i]->markClosure(base,__inCtx);
    }
+#ifdef HXCPP_VISIT_ALLOCS
    void __Visit(hx::VisitContext *__inCtx)
    {
       HX_VISIT_MEMBER(*getThis());
@@ -2635,6 +2645,7 @@ public:
       for(int i=0;i<function->captureVars.size();i++)
          function->captureVars[i]->visitClosure(base,__inCtx);
    }
+#endif
    virtual void *__GetHandle() const { return *getThis(); }
 
    int __Compare(const hx::Object *inRHS) const
@@ -3226,7 +3237,9 @@ struct CppiaExprWithValue : public CppiaDynamicExpr
 
    hx::Object *runObject(CppiaCtx *ctx) { return value.mPtr; }
    void mark(hx::MarkContext *__inCtx) { HX_MARK_MEMBER(value); }
+#ifdef HXCPP_VISIT_ALLOCS
    void visit(hx::VisitContext *__inCtx) { HX_VISIT_MEMBER(value); }
+#endif
 
    const char *getName() { return "CppiaExprWithValue"; }
    CppiaExpr *link(CppiaModule &inModule)
@@ -4286,12 +4299,13 @@ struct FieldByName : public CppiaDynamicExpr
       HX_MARK_MEMBER(name);
       HX_MARK_MEMBER(staticClass);
    }
+#ifdef HXCPP_VISIT_ALLOCS
    void visit(hx::VisitContext *__inCtx)
    {
       HX_VISIT_MEMBER(name);
       HX_VISIT_MEMBER(staticClass);
    }
-
+#endif
 
 };
 
@@ -4433,12 +4447,13 @@ struct GetFieldByName : public CppiaDynamicExpr
       HX_MARK_MEMBER(name);
       HX_MARK_MEMBER(staticClass);
    }
+#ifdef HXCPP_VISIT_ALLOCS
    void visit(hx::VisitContext *__inCtx)
    {
       HX_VISIT_MEMBER(name);
       HX_VISIT_MEMBER(staticClass);
    }
-
+#endif
 };
 
 
@@ -4821,7 +4836,9 @@ struct MemReference : public CppiaExpr
    }
 
    void mark(hx::MarkContext *__inCtx) { HX_MARK_MEMBER( *pointer ); }
+#ifdef HXCPP_VISIT_ALLOCS
    void visit(hx::VisitContext *__inCtx) { HX_VISIT_MEMBER( *pointer ); }
+#endif
 
 
    void        runVoid(CppiaCtx *ctx) { }
@@ -4943,7 +4960,9 @@ struct MemReferenceSetter : public CppiaExpr
    }
 
    void mark(hx::MarkContext *__inCtx) { HX_MARK_MEMBER( *pointer ); }
+#ifdef HXCPP_VISIT_ALLOCS
    void visit(hx::VisitContext *__inCtx) { HX_VISIT_MEMBER( *pointer ); }
+#endif
 
    CppiaExpr *link(CppiaModule &inModule)
    {
@@ -5043,7 +5062,9 @@ struct MemReferenceCrement : public CppiaExpr
 
 
    void mark(hx::MarkContext *__inCtx) { HX_MARK_MEMBER( *pointer ); }
+#ifdef HXCPP_VISIT_ALLOCS
    void visit(hx::VisitContext *__inCtx) { HX_VISIT_MEMBER( *pointer ); }
+#endif
 
    CppiaExpr *link(CppiaModule &inModule)
    {
@@ -5234,12 +5255,13 @@ struct StringVal : public CppiaExprWithValue
       HX_MARK_MEMBER(value);
       HX_MARK_MEMBER(strVal);
    }
+#ifdef HXCPP_VISIT_ALLOCS
    void visit(hx::VisitContext *__inCtx)
    {
       HX_VISIT_MEMBER(value);
       HX_VISIT_MEMBER(strVal);
    }
-
+#endif
 };
 
 
@@ -6669,12 +6691,13 @@ struct EnumField : public CppiaDynamicExpr
       HX_MARK_MEMBER(enumName);
       HX_MARK_MEMBER(enumClass);
    }
+#ifdef HXCPP_VISIT_ALLOCS
    void visit(hx::VisitContext *__inCtx)
    {
       HX_VISIT_MEMBER(enumName);
       HX_VISIT_MEMBER(enumClass);
    }
-
+#endif
 };
 
 struct CrementExpr : public CppiaExpr 
@@ -7235,6 +7258,7 @@ void CppiaModule::mark(hx::MarkContext *__inCtx)
       }
 }
 
+#ifdef HXCPP_VISIT_ALLOCS
 void CppiaModule::visit(hx::VisitContext *__inCtx)
 {
    HX_VISIT_MEMBER(strings);
@@ -7246,6 +7270,7 @@ void CppiaModule::visit(hx::VisitContext *__inCtx)
       if (classes[i])
          classes[i]->visit(__inCtx);
 }
+#endif
 
 // TODO  - more than one
 //static hx::Object *currentCppia = 0;
@@ -7268,7 +7293,9 @@ public:
       delete ((CppiaObject *)inObj)->data;
    }
    void __Mark(hx::MarkContext *ctx) { data->mark(ctx); }
+#ifdef HXCPP_VISIT_ALLOCS
    void __Visit(hx::VisitContext *ctx) { data->visit(ctx); }
+#endif
 };
 
 
@@ -7449,10 +7476,12 @@ void ScriptableMark(void *inClass, hx::Object *inThis, hx::MarkContext *__inCtx)
    ((CppiaClassInfo *)inClass)->markInstance(inThis, __inCtx);
 }
 
+#ifdef HXCPP_VISIT_ALLOCS
 void ScriptableVisit(void *inClass, hx::Object *inThis, hx::VisitContext *__inCtx)
 {
    ((CppiaClassInfo *)inClass)->visitInstance(inThis, __inCtx);
 }
+#endif
 
 bool ScriptableField(hx::Object *inObj, const ::String &inName,hx::PropertyAccess  inCallProp,Dynamic &outResult)
 {


### PR DESCRIPTION
This change makes the code that is emitted when HXCPP_VISIT_ALLOCS is not defined (which we do not define, because we want the binary to be as small as possible, and we don't use the "visit allocs" functionality) smaller, by conditionally dis-including more unneeded functions.
