### PR TITLE
Topic no pcre debug

### DIFF
--- a/project/thirdparty/pcre-7.8/pcre_internal.h
+++ b/project/thirdparty/pcre-7.8/pcre_internal.h
@@ -49,6 +49,8 @@ functions whose names all begin with "_pcre_". */
 
 #if 0
 #define DEBUG
+#else
+#undef DEBUG
 #endif
 
 /* Use a macro for debugging printing, 'cause that eliminates the use of #ifdef


### PR DESCRIPTION
When we define DEBUG, which we do for our own purposes, the PCRE library was emitting tons of debugging stuff.  So make the pcre library's debug output not turned on just by DEBUG being defined; it has to be turned on explicitly by modifying this file (which was apparently the intention anyway since it already had the #if 0 clause there, it just didn't protect itself against someone else defining DEBUG for their own purposes).
