### PR TITLE
Topic unload prims

### DIFF
--- a/include/hx/StdLibs.h
+++ b/include/hx/StdLibs.h
@@ -47,6 +47,7 @@ HXCPP_EXTERN_CLASS_ATTRIBUTES void __hxcpp_print(Dynamic &inV);
 HXCPP_EXTERN_CLASS_ATTRIBUTES void __hxcpp_println(Dynamic &inV);
 HXCPP_EXTERN_CLASS_ATTRIBUTES void __trace(Dynamic inPtr, Dynamic inData);
 void           __hxcpp_stdlibs_boot();
+HXCPP_EXTERN_CLASS_ATTRIBUTES void __hxcpp_sys_exit(Dynamic ecode);
 
 // --- Maths ---------------------------------------------------------
 double __hxcpp_drand();
@@ -71,6 +72,9 @@ HXCPP_EXTERN_CLASS_ATTRIBUTES int           __hxcpp_register_prim(const HX_CHAR 
 
 // Get function pointer from dll file
 HXCPP_EXTERN_CLASS_ATTRIBUTES Dynamic __loadprim(String inLib, String inPrim,int inArgCount);
+// Unload all dll files loaded via __loadprim.  Necessary before program
+// exit to ensure clean shutdown.
+HXCPP_EXTERN_CLASS_ATTRIBUTES void __unload_all();
 HXCPP_EXTERN_CLASS_ATTRIBUTES void *__hxcpp_get_proc_address(String inLib, String inPrim,bool inNdll, bool inQuietFail=false);
 HXCPP_EXTERN_CLASS_ATTRIBUTES void __hxcpp_run_dll(String inLib, String inPrim);
 // Can assign to function pointer without error

--- a/src/hx/Lib.cpp
+++ b/src/hx/Lib.cpp
@@ -312,7 +312,7 @@ typedef std::map<std::string,void *> RegistrationMap;
 void __unload_all()
 {
 #ifdef HX_WINRT
-#elif (defined (IPHONE) || defined(EMSCRIPTEN)) && !defined(HXCPP_DLL_IMPORT) && !defined(HXCPP_DLL_EXPORT)
+#elif (defined (IPHONE) || defined(EMSCRIPTEN) || defined(STATIC_LINK)) && !defined(HXCPP_DLL_IMPORT) && !defined(HXCPP_DLL_EXPORT)
 #else
     /* Unload all loaded libraries so that any atexit() that they
        registered runs as well.  Unload in the reverse order of loading */

--- a/src/hx/StdLibs.cpp
+++ b/src/hx/StdLibs.cpp
@@ -341,6 +341,11 @@ void __hxcpp_println(Dynamic &inV)
    #endif
 }
 
+void __hxcpp_sys_exit(Dynamic ecode)
+{
+   exit((int) ecode);
+}
+
 
 // --- Casting/Converting ---------------------------------------------------------
 


### PR DESCRIPTION
We found that the primitives loaded by __loadprim must be unloaded sometimes for proper shutdown.  So this code enables this.  A separate change in the haxe std library will use these functions to ensure that shutdown goes smoothly.
