### PR TITLE
Topic string churn

### DIFF
--- a/include/hxString.h
+++ b/include/hxString.h
@@ -149,6 +149,8 @@ public:
 
    inline bool operator==(const ::String &inRHS) const
                      { return length==inRHS.length && compare(inRHS)==0; }
+   inline bool operator==(const char *other) const
+      { return other ? __s ? (strcmp(other, __s) == 0) : false : !__s; }
    inline bool operator!=(const ::String &inRHS) const
                      { return length != inRHS.length || compare(inRHS)!=0; }
    inline bool operator<(const ::String &inRHS) const { return compare(inRHS)<0; }

--- a/src/Enum.cpp
+++ b/src/Enum.cpp
@@ -12,12 +12,12 @@ Dynamic EnumBase_obj::__CreateEmpty() { return new hx::EnumBase_obj; }
 
 int EnumBase_obj::__FindIndex(String inName)
 {
-   if (inName==HX_CSTRING("__")) return 1;
+   if (inName=="__") return 1;
    return -1;
 }
 int EnumBase_obj::__FindArgCount(String inName)
 {
-   if (inName==HX_CSTRING("__")) return 0;
+   if (inName=="__") return 0;
    return -1;
 }
 Dynamic EnumBase_obj::__Field(const String &inString, hx::PropertyAccess inCallProp) { return null(); }

--- a/src/Math.cpp
+++ b/src/Math.cpp
@@ -67,34 +67,34 @@ STATIC_HX_DEFINE_DYNAMIC_FUNC1(Math_obj,isFinite,return);
 
 Dynamic Math_obj::__Field(const String &inString, hx::PropertyAccess inCallProp)
 {
-   if (inString==HX_CSTRING("floor")) return floor_dyn();
-   if (inString==HX_CSTRING("ffloor")) return ffloor_dyn();
-   if (inString==HX_CSTRING("ceil")) return ceil_dyn();
-   if (inString==HX_CSTRING("fceil")) return fceil_dyn();
-   if (inString==HX_CSTRING("round")) return round_dyn();
-   if (inString==HX_CSTRING("fround")) return fround_dyn();
-   if (inString==HX_CSTRING("random")) return random_dyn();
-   if (inString==HX_CSTRING("sqrt")) return sqrt_dyn();
-   if (inString==HX_CSTRING("cos")) return cos_dyn();
-   if (inString==HX_CSTRING("sin")) return sin_dyn();
-   if (inString==HX_CSTRING("tan")) return tan_dyn();
-   if (inString==HX_CSTRING("atan2")) return atan2_dyn();
-   if (inString==HX_CSTRING("abs")) return abs_dyn();
-   if (inString==HX_CSTRING("pow")) return pow_dyn();
-   if (inString==HX_CSTRING("log")) return log_dyn();
-   if (inString==HX_CSTRING("min")) return min_dyn();
-   if (inString==HX_CSTRING("max")) return max_dyn();
-   if (inString==HX_CSTRING("atan")) return atan_dyn();
-   if (inString==HX_CSTRING("acos")) return acos_dyn();
-   if (inString==HX_CSTRING("asin")) return asin_dyn();
-   if (inString==HX_CSTRING("exp")) return exp_dyn();
-   if (inString==HX_CSTRING("isNaN")) return isNaN_dyn();
-   if (inString==HX_CSTRING("isFinite")) return isFinite_dyn();
+   if (inString=="floor") return floor_dyn();
+   if (inString=="ffloor") return ffloor_dyn();
+   if (inString=="ceil") return ceil_dyn();
+   if (inString=="fceil") return fceil_dyn();
+   if (inString=="round") return round_dyn();
+   if (inString=="fround") return fround_dyn();
+   if (inString=="random") return random_dyn();
+   if (inString=="sqrt") return sqrt_dyn();
+   if (inString=="cos") return cos_dyn();
+   if (inString=="sin") return sin_dyn();
+   if (inString=="tan") return tan_dyn();
+   if (inString=="atan2") return atan2_dyn();
+   if (inString=="abs") return abs_dyn();
+   if (inString=="pow") return pow_dyn();
+   if (inString=="log") return log_dyn();
+   if (inString=="min") return min_dyn();
+   if (inString=="max") return max_dyn();
+   if (inString=="atan") return atan_dyn();
+   if (inString=="acos") return acos_dyn();
+   if (inString=="asin") return asin_dyn();
+   if (inString=="exp") return exp_dyn();
+   if (inString=="isNaN") return isNaN_dyn();
+   if (inString=="isFinite") return isFinite_dyn();
 
-   if (inString==HX_CSTRING("NEGATIVE_INFINITY")) return NEGATIVE_INFINITY;
-   if (inString==HX_CSTRING("POSITIVE_INFINITY")) return POSITIVE_INFINITY;
-   if (inString==HX_CSTRING("PI")) return PI;
-   if (inString==HX_CSTRING("NaN")) return NaN;
+   if (inString=="NEGATIVE_INFINITY") return NEGATIVE_INFINITY;
+   if (inString=="POSITIVE_INFINITY") return POSITIVE_INFINITY;
+   if (inString=="PI") return PI;
+   if (inString=="NaN") return NaN;
    return null();
 }
 

--- a/src/hx/Class.cpp
+++ b/src/hx/Class.cpp
@@ -179,7 +179,7 @@ Class Class_obj::Resolve(String inName)
    if (i==sClassMap->end())
    {
       // Class class...
-      if (inName==HX_CSTRING("Enum"))
+      if (inName=="Enum")
          return Class_obj__mClass;
       return null();
    }
@@ -231,7 +231,7 @@ Array<String> Class_obj::GetClassFields()
 
 bool Class_obj::__HasField(const String &inString)
 {
-   if (__rtti__.__s && inString==HX_CSTRING("__rtti"))
+   if (__rtti__.__s && inString=="__rtti")
       return true;
 
    if (mStatics.mPtr)
@@ -245,10 +245,10 @@ bool Class_obj::__HasField(const String &inString)
 
 Dynamic Class_obj::__Field(const String &inString, hx::PropertyAccess inCallProp)
 {
-   if (inString==HX_CSTRING("__meta__"))
+   if (inString=="__meta__")
       return __meta__;
    #if (HXCPP_API_LEVEL>320)
-   if (inString==HX_CSTRING("__rtti"))
+   if (inString=="__rtti")
       return __rtti__;
    #endif
 

--- a/src/hx/cppia/Cppia.cpp
+++ b/src/hx/cppia/Cppia.cpp
@@ -2049,7 +2049,7 @@ struct CppiaClassInfo
          for(int i=0;i<staticVars.size();i++)
          {
             staticVars[i]->runInit(ctx);
-            if (staticVars[i]->name==HX_CSTRING("__meta__"))
+            if (staticVars[i]->name=="__meta__")
             {
                // Todo - delete/clean value
                mClass->__meta__ = staticVars[i]->objVal;
@@ -2383,7 +2383,7 @@ public:
 
    Dynamic __Field(const String &inName,hx::PropertyAccess inCallProp)
    {
-      if (inName==HX_CSTRING("__meta__"))
+      if (inName=="__meta__")
          return __meta__;
       return info->getStaticValue(inName,inCallProp);
    }
@@ -3878,7 +3878,7 @@ struct CallStatic : public CppiaExpr
       }
 
       // TODO - optimise...
-      if (!replace && type->name==HX_CSTRING("String") && field==HX_CSTRING("fromCharCode"))
+      if (!replace && type->name=="String" && field=="fromCharCode")
          replace = new CallDynamicFunction(inModule, this, String::fromCharCode_dyn(), args );
          
 
@@ -4688,16 +4688,16 @@ struct CallMember : public CppiaExpr
          }
       }
 
-      if (!replace && type->name==HX_CSTRING("String"))
+      if (!replace && type->name=="String")
       {
          replace = createStringBuiltin(this, thisExpr, field, args);
       }
 
-      if (!replace && field==HX_CSTRING("__Index"))
+      if (!replace && field=="__Index")
          replace = new CallGetIndex(this, thisExpr);
-      if (!replace && field==HX_CSTRING("__SetField") && args.size()==3)
+      if (!replace && field=="__SetField" && args.size()==3)
          replace = new CallSetField(this, thisExpr, args[0], args[1], args[2]);
-      if (!replace && field==HX_CSTRING("__Field") && args.size()==2)
+      if (!replace && field=="__Field" && args.size()==2)
          replace = new CallGetField(this, thisExpr, args[0], args[1]);
 
 
@@ -5122,7 +5122,7 @@ struct GetFieldByLinkage : public CppiaExpr
          }
       }
 
-      if (!replace && type->arrayType!=arrNotArray && field==HX_CSTRING("length"))
+      if (!replace && type->arrayType!=arrNotArray && field=="length")
       {
          int offset = (int) offsetof( Array_obj<int>, length );
          replace = object ?
@@ -5130,7 +5130,7 @@ struct GetFieldByLinkage : public CppiaExpr
              (CppiaExpr*)new MemReference<int,locThis>(this,offset);
       }
 
-      if (!replace && type->name==HX_CSTRING("String") && field==HX_CSTRING("length"))
+      if (!replace && type->name=="String" && field=="length")
       {
          int offset = (int) offsetof( Array_obj<int>, length );
          replace = object ?
@@ -5523,7 +5523,7 @@ struct ArrayIExpr : public CppiaExpr
 
       CppiaExpr *replace = 0;
 
-      if (type->name==HX_CSTRING("Dynamic"))
+      if (type->name=="Dynamic")
       {
          replace = new DynamicArrayI(this, thisExpr, iExpr);
       }
@@ -7012,17 +7012,17 @@ void TypeData::link(CppiaModule &inModule)
          haxeClass.mPtr = 0;
       }
       DBGLOG("Link %s, haxe=%s\n", name.__s, haxeClass.mPtr ? haxeClass.mPtr->mName.__s : "?" );
-      if (!haxeClass.mPtr && !cppiaClass && name==HX_CSTRING("int"))
+      if (!haxeClass.mPtr && !cppiaClass && name=="int")
       {
          name = HX_CSTRING("Int");
          haxeClass = hx::Class_obj::Resolve(name);
       }
-      if (!haxeClass.mPtr && !cppiaClass && name==HX_CSTRING("bool"))
+      if (!haxeClass.mPtr && !cppiaClass && name=="bool")
       {
          name = HX_CSTRING("Bool");
          haxeClass = hx::Class_obj::Resolve(name);
       }
-      if (!haxeClass.mPtr && !cppiaClass && (name==HX_CSTRING("float") || name==HX_CSTRING("double")))
+      if (!haxeClass.mPtr && !cppiaClass && (name=="float" || name=="double"))
       {
          name = HX_CSTRING("Float");
          haxeClass = hx::Class_obj::Resolve(name);
@@ -7032,7 +7032,7 @@ void TypeData::link(CppiaModule &inModule)
       interfaceBase = HaxeNativeInterface::findInterface(name.__s);
       isInterface = interfaceBase || (cppiaClass && cppiaClass->isInterface);
 
-      if (!haxeClass.mPtr && name.substr(0,6)==HX_CSTRING("Array.") || name==HX_CSTRING("Array") )
+      if (!haxeClass.mPtr && name.substr(0,6)=="Array." || name=="Array" )
       {
          haxeClass = hx::Class_obj::Resolve(HX_CSTRING("Array"));
          if (name.length==5)
@@ -7041,19 +7041,19 @@ void TypeData::link(CppiaModule &inModule)
          {
             String t = name.substr(6,null());
 
-            if (t==HX_CSTRING("int"))
+            if (t=="int")
                arrayType = arrInt;
-            else if (t==HX_CSTRING("bool"))
+            else if (t=="bool")
                arrayType = arrBool;
-            else if (t==HX_CSTRING("Float"))
+            else if (t=="Float")
                arrayType = arrFloat;
-            else if (t==HX_CSTRING("String"))
+            else if (t=="String")
                arrayType = arrString;
-            else if (t==HX_CSTRING("unsigned char"))
+            else if (t=="unsigned char")
                arrayType = arrUnsignedChar;
-            else if (t==HX_CSTRING("Any"))
+            else if (t=="Any")
                arrayType = arrAny;
-            else if (t==HX_CSTRING("Object"))
+            else if (t=="Object")
                arrayType = arrObject;
             else
                throw "Unknown array type";
@@ -7103,15 +7103,15 @@ void TypeData::link(CppiaModule &inModule)
          }
       }
 
-      if (name==HX_CSTRING("Void"))
+      if (name=="Void")
          expressionType = etVoid;
-      else if (name==HX_CSTRING("Null"))
+      else if (name=="Null")
          expressionType = etNull;
-      else if (name==HX_CSTRING("String"))
+      else if (name=="String")
          expressionType = etString;
-      else if (name==HX_CSTRING("Float"))
+      else if (name=="Float")
          expressionType = etFloat;
-      else if (name==HX_CSTRING("Int") || name==HX_CSTRING("Bool"))
+      else if (name=="Int" || name=="Bool")
          expressionType = etInt;
       else
          expressionType = etObject;


### PR DESCRIPTION
Reduce string churn by adding a comparison function to the String class that compares directly against const char * strings.  Then, don't use HX_CSTRING(xxx) all over the code to compare against static string values, since that macro creates a String class on the stack.  Avoiding this object creation reduces churn.
