### PR TITLE
Fix debugger bug: when the debugger thread itself experiences a critical...

### DIFF
--- a/include/hx/Debug.h
+++ b/include/hx/Debug.h
@@ -545,6 +545,8 @@ inline void __hxcpp_dbg_setAddStackFrameToThreadInfoFunction(Dynamic) { }
 // created and terminated
 inline void __hxcpp_dbg_threadCreatedOrTerminated(int, bool) { }
 
+inline Dynamic __hxcpp_dbg_checkedThrow(Dynamic toThrow) { return hx::Throw(toThrow); }
+
 #endif // HXCPP_DEBUGGER
 
 

--- a/include/hxcpp.h
+++ b/include/hxcpp.h
@@ -200,8 +200,8 @@ class String;
 
 // Use an external routine to throw to avoid sjlj overhead on iphone.
 namespace hx { HXCPP_EXTERN_CLASS_ATTRIBUTES Dynamic Throw(Dynamic inDynamic); }
-namespace hx { extern void CriticalError(const String &inError); }
-namespace hx { extern void NullReference(const char *type, bool allowFixup); }
+namespace hx { HXCPP_EXTERN_CLASS_ATTRIBUTES void CriticalError(const String &inError); }
+namespace hx { HXCPP_EXTERN_CLASS_ATTRIBUTES void NullReference(const char *type, bool allowFixup); }
 namespace hx { extern String sNone[]; }
 void __hxcpp_check_overflow(int inVal);
 


### PR DESCRIPTION
... error, do not attempt to break into the debugger as this will deadlock.