### PR TITLE
use OBJDIR from env to configure .o output dir

### DIFF
--- a/toolchain/finish-setup.xml
+++ b/toolchain/finish-setup.xml
@@ -59,6 +59,8 @@
 <set name="DESTDIR" value="lib" if="static_link" unless="HXCPP_IOS_STDCPP"/>
 <set name="NDLLDIR" value="ndll" />
 <set name="NDLLDIR" value="lib" if="static_link" />
+<set name="BUILDDIR" value="obj" unless="BUILDDIR" />
+<set name="BUILDDIR" value="${BUILDDIR}" if="BUILDDIR" />
 
 
 <set name="IPHONE_VER" value="4.2" unless="IPHONE_VER" />

--- a/toolchain/linux-toolchain.xml
+++ b/toolchain/linux-toolchain.xml
@@ -50,7 +50,7 @@
   <flag value="-m64" if="HXCPP_M64"/>
   <flag value="-DHXCPP_M64" if="HXCPP_M64"/>
   <flag value="-I${HXCPP}/include"/>
-  <objdir value="obj/linux${OBJEXT}/"/>
+  <objdir value="${BUILDDIR}/linux${OBJEXT}/"/>
   <outflag value="-o"/>
   <ext value=".o"/>
 </compiler>

--- a/toolchain/mac-toolchain.xml
+++ b/toolchain/mac-toolchain.xml
@@ -32,7 +32,7 @@
   <flag value="-Wno-bool-conversion" if="HXCPP_CLANG"/>
   <flag value="-fobjc-arc" if="OBJC_ARC" />
   <include name="toolchain/common-defines.xml" />
-  <objdir value="obj/darwin${OBJEXT}/" />
+  <objdir value="${BUILDDIR}/darwin${OBJEXT}/" />
   <outflag value="-o"/>
   <ext value=".o"/>
   <getversion value="xcrun --sdk macosx${MACOSX_VER} clang++ -v" if="HXCPP_CLANG" />


### PR DESCRIPTION
This is a change we made to hxcpp to allow specifying the .o output dir. We can change the `BUILDDIR` name to something else.

It's only implemented for the targets we use (linux and macos), but I can implement it for the other targets if you're interested in this change.
