### PR TITLE
Added missing #includes to make it compatible with libc++

### DIFF
--- a/src/String.cpp
+++ b/src/String.cpp
@@ -2,6 +2,7 @@
 #include <ctype.h>
 #include <stdio.h>
 #include <set>
+#include <cstdlib>
 
 using namespace hx;
 

--- a/src/hx/Lib.cpp
+++ b/src/hx/Lib.cpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <map>
 #include <vector>
+#include <cstdlib>
 
 #ifdef ANDROID
 #include <android/log.h>


### PR DESCRIPTION
String.cpp uses `atoi` (from `<cstdlib>`)
Lib.cpp uses `getenv` (from `<cstdlib>`)
