### PR TITLE
Resolve haxelib directory in the following order

### DIFF
--- a/src/hx/Lib.cpp
+++ b/src/hx/Lib.cpp
@@ -244,21 +244,29 @@ String FindHaxelib(String inLib)
 
    if (haxepath.length==0)
    {
+      haxepath = GetEnv("HAXELIB_PATH");
+      if (loadDebug)
+         printf("HAXELIB_PATH env:%s\n", haxepath.__s);
+   }
+
+   if (haxepath.length==0)
+   {
+       #ifdef _WIN32
+       String home = GetEnv("HOMEDRIVE") + GetEnv("HOMEPATH") + HX_CSTRING("/.haxelib");
+       #else
+       String home = GetEnv("HOME") + HX_CSTRING("/.haxelib");
+       #endif
+       haxepath = GetFileContents(home);
+       if (loadDebug)
+          printf("HAXEPATH home:%s\n", haxepath.__s);
+   }
+
+   if (haxepath.length==0)
+   {
       haxepath = GetEnv("HAXEPATH");
       if (loadDebug)
          printf("HAXEPATH env:%s\n", haxepath.__s);
-      if (haxepath.length==0)
-      {
-          #ifdef _WIN32
-          String home = GetEnv("HOMEDRIVE") + GetEnv("HOMEPATH") + HX_CSTRING("/.haxelib");
-          #else
-          String home = GetEnv("HOME") + HX_CSTRING("/.haxelib");
-          #endif
-          haxepath = GetFileContents(home);
-          if (loadDebug)
-             printf("HAXEPATH home:%s\n", haxepath.__s);
-      }
-      else
+      if (haxepath.length>0)
       {
          haxepath += HX_CSTRING("/lib");
       }


### PR DESCRIPTION
1. `./.haxelib` - local haxelib repository
2. `$HAXELIB_PATH` - environment variable supported by haxelib*
3. `~/.haxelib` - globally defined haxelib repository
4. `$HAXEPATH/lib`
5. `/etc/.haxepath` - apparently this is a thing too
6. `$DEFAULT_HAXEPATH/lib` - assume default install location

The issue I have currently is that `$HAXEPATH` is set but my haxelib repository is in another castle.

* see https://github.com/HaxeFoundation/haxelib/blob/4fefbd17a2d9a98200b621de801018af3896d68a/src/tools/haxelib/Main.hx#L949