### PR TITLE
[objc] Create Dynamic wrapper around Objective-C types

### DIFF
--- a/include/Dynamic.h
+++ b/include/Dynamic.h
@@ -30,7 +30,7 @@ public:
    explicit Dynamic(const HX_CHAR *inStr);
 #ifdef __OBJC__
 #ifdef HXCPP_OBJC
-   Dynamic(const NSObject *inObjc);
+   Dynamic(const id inObjc);
 #endif
 #endif
 
@@ -58,7 +58,7 @@ public:
    inline operator bool() const { return mPtr && mPtr->__ToInt(); }
 #ifdef __OBJC__
 #ifdef HXCPP_OBJC
-   inline operator NSObject * () const { return mPtr ? (NSObject *)mPtr->__GetHandle() : 0; }
+   inline operator id() const { return mPtr ? (id)mPtr->__GetHandle() : 0; }
 #endif
 #endif
    inline bool operator !() const { return !mPtr || !mPtr->__ToInt(); }

--- a/include/Dynamic.h
+++ b/include/Dynamic.h
@@ -28,6 +28,11 @@ public:
    Dynamic(const null &inNull) : super(0) { }
    Dynamic(const Dynamic &inRHS) : super(inRHS.mPtr) { }
    explicit Dynamic(const HX_CHAR *inStr);
+#ifdef __OBJC__
+#ifdef HXCPP_OBJC
+   Dynamic(const NSObject *inObjc);
+#endif
+#endif
 
    template<typename T,typename S>
    explicit Dynamic(const cpp::Struct<T,S> &inRHS) { *this = inRHS; }
@@ -51,6 +56,11 @@ public:
    inline operator char () const { return mPtr ? mPtr->__ToInt() : 0; }
    inline operator signed char () const { return mPtr ? mPtr->__ToInt() : 0; }
    inline operator bool() const { return mPtr && mPtr->__ToInt(); }
+#ifdef __OBJC__
+#ifdef HXCPP_OBJC
+   inline operator NSObject * () const { return mPtr ? (NSObject *)mPtr->__GetHandle() : 0; }
+#endif
+#endif
    inline bool operator !() const { return !mPtr || !mPtr->__ToInt(); }
 
    hx::IndexRef operator[](int inIndex);

--- a/include/hxcpp.h
+++ b/include/hxcpp.h
@@ -32,6 +32,12 @@
   #include <cstdlib>
 #endif
 
+#ifdef __OBJC__
+#ifdef HXCPP_OBJC
+  #import <Foundation/Foundation.h>
+#endif
+#endif
+
 
 #include <string.h>
 

--- a/src/Dynamic.cpp
+++ b/src/Dynamic.cpp
@@ -20,6 +20,9 @@ hx::Class __IntClass;
 hx::Class __FloatClass;
 hx::Class __PointerClass;
 hx::Class __VoidClass;
+#ifdef HXCPP_OBJC
+hx::Class __ObjcClass;
+#endif
 
 
 hx::Class &GetBoolClass() { return __BoolClass; }
@@ -417,6 +420,9 @@ static void sMarkStatics(HX_MARK_PARAMS) {
 	HX_MARK_MEMBER(Anon_obj::__mClass);
 	HX_MARK_MEMBER(hx::hxEnumBase_obj__mClass);
 	HX_MARK_MEMBER(hx::DynEmptyString);
+#ifdef HXCPP_OBJC
+	HX_MARK_MEMBER(__ObjcClass);
+#endif
 };
 
 
@@ -435,6 +441,9 @@ static void sVisitStatics(HX_VISIT_PARAMS) {
 	HX_VISIT_MEMBER(Anon_obj::__mClass);
 	HX_VISIT_MEMBER(hx::hxEnumBase_obj__mClass);
 	HX_VISIT_MEMBER(hx::DynEmptyString);
+#ifdef HXCPP_OBJC
+	HX_VISIT_MEMBER(__ObjcClass);
+#endif
 };
 
 #endif
@@ -454,6 +463,9 @@ void Dynamic::__boot()
    DynTrue = Dynamic( new (hx::NewObjConst) hx::BoolData(true) );
    DynFalse = Dynamic( new (hx::NewObjConst) hx::BoolData(false) );
    DynEmptyString = Dynamic(HX_CSTRING("").__ToObject());
+#ifdef HXCPP_OBJC
+   Static(__ObjcClass) = hx::RegisterClass(HX_CSTRING("objc::BoxedType"),IsPointer,sNone,sNone, 0,0,&__ObjcClass );
+#endif
 }
 
 

--- a/src/ObjcData.mm
+++ b/src/ObjcData.mm
@@ -6,7 +6,7 @@
 using namespace hx;
 
 namespace hx {
-extern hx::Class __PointerClass;
+extern hx::Class __ObjcClass;
 
 class ObjcData : public hx::Object
 {
@@ -33,7 +33,7 @@ public:
 	void __Visit(hx::VisitContext *__inCtx) { mFinalizer->Visit(__inCtx); }
    #endif
 
-   hx::Class __GetClass() const { return __PointerClass; }
+   hx::Class __GetClass() const { return __ObjcClass; }
    bool __Is(hx::Object *inClass) const { return dynamic_cast< ObjcData *>(inClass); }
 
    // k_cpp_objc
@@ -43,7 +43,7 @@ public:
    {
       return String(!mValue ? "null" : [[mValue description] UTF8String]);
    }
-   String __ToString() const { return String(!mValue ? "(null)" : [[mValue description] UTF8String]); }
+   String __ToString() const { return String(!mValue ? "null" : [[mValue description] UTF8String]); }
 
    int __Compare(const hx::Object *inRHS) const
    {

--- a/src/ObjcData.mm
+++ b/src/ObjcData.mm
@@ -14,7 +14,7 @@ public:
    inline void *operator new( size_t inSize, hx::NewObjectType inAlloc=NewObjAlloc,const char *inName="objc.BoxedType")
       { return hx::Object::operator new(inSize,inAlloc,inName); }
 
-   ObjcData(const NSObject *inValue) : mValue(inValue) 
+   ObjcData(const id inValue) : mValue(inValue) 
    {
       [ inValue retain ];
 		mFinalizer = new hx::InternalFinalizer(this);
@@ -60,12 +60,12 @@ public:
    }
 
 
-   const NSObject *mValue;
+   const id mValue;
    hx::InternalFinalizer *mFinalizer;
 };
 }
 
-Dynamic::Dynamic(const NSObject *inVal)
+Dynamic::Dynamic(const id inVal)
 {
    mPtr = inVal ? (hx::Object *)new ObjcData(inVal) : 0;
 }

--- a/src/ObjcData.mm
+++ b/src/ObjcData.mm
@@ -1,0 +1,71 @@
+#include <hxcpp.h>
+#include <math.h>
+#include <hxMath.h>
+#include <stdio.h>
+
+using namespace hx;
+
+namespace hx {
+extern hx::Class __PointerClass;
+
+class ObjcData : public hx::Object
+{
+public:
+   inline void *operator new( size_t inSize, hx::NewObjectType inAlloc=NewObjAlloc,const char *inName="objc.BoxedType")
+      { return hx::Object::operator new(inSize,inAlloc,inName); }
+
+   ObjcData(const NSObject *inValue) : mValue(inValue) 
+   {
+      [ inValue retain ];
+		mFinalizer = new hx::InternalFinalizer(this);
+		mFinalizer->mFinalizer = clean;
+   };
+
+	static void clean(hx::Object *inObj)
+	{
+		ObjcData *m = dynamic_cast<ObjcData *>(inObj);
+		if (m) [m->mValue release];
+	}
+
+	void __Mark(hx::MarkContext *__inCtx) { mFinalizer->Mark(); }
+
+   #ifdef HXCPP_VISIT_ALLOCS
+	void __Visit(hx::VisitContext *__inCtx) { mFinalizer->Visit(__inCtx); }
+   #endif
+
+   hx::Class __GetClass() const { return __PointerClass; }
+   bool __Is(hx::Object *inClass) const { return dynamic_cast< ObjcData *>(inClass); }
+
+   // k_cpp_objc
+   int __GetType() const { return vtAbstractBase + 4; }
+   void * __GetHandle() const { return (void *) mValue; }
+   String toString()
+   {
+      return String(!mValue ? "null" : [[mValue description] UTF8String]);
+   }
+   String __ToString() const { return String(!mValue ? "(null)" : [[mValue description] UTF8String]); }
+
+   int __Compare(const hx::Object *inRHS) const
+   {
+      if (!inRHS)
+        return mValue == 0 ? 0 : 1;
+      const ObjcData *data = dynamic_cast< const ObjcData *>(inRHS);
+      if (data) 
+      {
+         return [data->mValue isEqual:mValue] ? 0 : mValue < data->mValue ? -1 : 1;
+      } else {
+        void *r = inRHS->__GetHandle();
+        return mValue < r ? -1 : mValue==r ? 0 : 1;
+      }
+   }
+
+
+   const NSObject *mValue;
+   hx::InternalFinalizer *mFinalizer;
+};
+}
+
+Dynamic::Dynamic(const NSObject *inVal)
+{
+   mPtr = inVal ? (hx::Object *)new ObjcData(inVal) : 0;
+}

--- a/src/hx/CFFI.cpp
+++ b/src/hx/CFFI.cpp
@@ -108,7 +108,8 @@ vkind k_int32 = (vkind)vtAbstractBase;
 vkind k_hash = (vkind)(vtAbstractBase + 1);
 vkind k_cpp_pointer = (vkind)(vtAbstractBase + 2);
 vkind k_cpp_struct = (vkind)(vtAbstractBase + 3);
-static int sgKinds = (int)(vtAbstractBase + 4);
+vkind k_cpp_objc = (vkind)(vtAbstractBase + 4);
+static int sgKinds = (int)(vtAbstractBase + 5);
 
 typedef std::map<std::string,int> KindMap;
 typedef std::map<int,std::string> ReverseKindMap;

--- a/toolchain/common-defines.xml
+++ b/toolchain/common-defines.xml
@@ -25,4 +25,5 @@
  <flag value='-DHXCPP_DEBUG_HOST="${HXCPP_DEBUG_HOST}"' if="HXCPP_DEBUG_HOST" />
  <flag value='-DHXCPP_API_LEVEL=${removeQuotes:hxcpp_api_level}' if="hxcpp_api_level" />
  <flag value='-DHXCPP_API_LEVEL=0' unless="hxcpp_api_level" />
+ <flag value='-DHXCPP_OBJC' if="objc" />
 </xml>

--- a/toolchain/haxe-target.xml
+++ b/toolchain/haxe-target.xml
@@ -122,6 +122,7 @@
   <file name = "src/Array.cpp"/>
   <file name = "src/hx/Class.cpp"/>
   <file name = "src/Dynamic.cpp"/>
+  <file name = "src/ObjcData.mm" if="objc"/>
   <file name = "src/Enum.cpp"/>
   <file name = "src/Math.cpp"/>
   <file name = "src/String.cpp"/>


### PR DESCRIPTION
Related to HaxeFoundation/haxe#4350 : this adds an implicit operator
to convert from Dynamic to NSObject * and the other way around. The
changes are all guarded through the `-D objc` Haxe define