### PR TITLE
Fixes crashes when compiling for Blackberry 10.3

### DIFF
--- a/include/hx/CFFI.h
+++ b/include/hx/CFFI.h
@@ -16,12 +16,9 @@ typedef struct _buffer  *buffer;
 #include <stdio.h>
 #include <stdlib.h>
 #include <memory.h>
-
-
-
-
-
-
+#if defined(BLACKBERRY)
+using namespace std;
+#endif
 // --- Register functions (primitives) ----
 
 #ifdef STATIC_LINK

--- a/include/hx/CFFILoader.h
+++ b/include/hx/CFFILoader.h
@@ -67,8 +67,9 @@
 
 
 #endif
-
-
+#if defined(BLACKBERRY)
+using namespace std;
+#endif
 typedef void *(*ResolveProc)(const char *inName);
 static ResolveProc sResolveProc = 0;
 

--- a/src/String.cpp
+++ b/src/String.cpp
@@ -5,6 +5,10 @@
 
 using namespace hx;
 
+#if defined(BLACKBERRY)
+using namespace std;
+#endif
+
 // -------- String ----------------------------------------
 
 

--- a/src/hx/Lib.cpp
+++ b/src/hx/Lib.cpp
@@ -15,9 +15,9 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #endif
-
-
-
+#if defined(BLACKBERRY)
+using namespace std;
+#endif
 #ifdef HXCPP_LOAD_DEBUG
 bool gLoadDebug = true;
 #else

--- a/src/hx/StdLibs.cpp
+++ b/src/hx/StdLibs.cpp
@@ -22,10 +22,9 @@ typedef int64_t __int64;
 #ifdef TIZEN
 extern "C" EXPORT_EXTRA void AppLogInternal(const char* pFunction, int lineNumber, const char* pFormat, ...);
 #endif
-#ifdef GCW0
+#if defined(BLACKBERRY) || defined(GCW0)
 #include <unistd.h>
 #endif
-
 #include <string>
 #include <vector>
 #include <map>

--- a/toolchain/blackberry-toolchain.xml
+++ b/toolchain/blackberry-toolchain.xml
@@ -7,12 +7,14 @@
 	<set name="ARCH" value="-x86" />
 	<set name="PLATFORM_ARCH" value="x86" />
 	<set name="EXEPREFIX" value="ntox86" />
+	<set name="QCC_TARGET" value="gcc_ntox86" />
 </section>
 
 <section unless="HXCPP_X86">
 	<set name="ARCH" value="-v7" />
 	<set name="PLATFORM_ARCH" value="armle-v7" />
 	<set name="EXEPREFIX" value="ntoarmv7" />
+	<set name="QCC_TARGET" value="gcc_ntoarmv7le" />
 </section>
 
 <setup name="blackberry" />
@@ -23,7 +25,8 @@
 
 <!-- BLACKBERRY TOOLS -------------------------------------------------->
 	
-<compiler id="blackberry" exe="${EXEPREFIX}-g++" if="blackberry">
+<compiler id="blackberry" exe="qcc" if="blackberry">
+	<flag value="-V${QCC_TARGET}" />
 	<flag value="-c"/>
 	<flag value="-g" if="debug"/>
 	<flag value="-O2" unless="debug"/>
@@ -32,6 +35,8 @@
 	<flag value="-DBLACKBERRY=BLACKBERRY"/>
 	<flag value="-fvisibility=hidden"/>
 	<flag value="-fdollars-in-identifiers"/>
+	<!--<flag value="-fpermissive"/>-->
+	<cppflag value="-lang-c++"/>
 	<include name="toolchain/common-defines.xml" />
 	<flag value="-DHXCPP_LOAD_DEBUG" if="HXCPP_LOAD_DEBUG"/>
 	<flag value="-DHXCPP_MULTI_THREADED" if="HXCPP_MULTI_THREADED"/>
@@ -43,24 +48,33 @@
 </compiler>
 
 
-<linker id="exe" exe="${EXEPREFIX}-g++" if="blackberry">
+<linker id="exe" exe="qcc" if="blackberry">
+	<fromfile value="-filelist " />
+	<flag value="-V${QCC_TARGET}" />
 	<flag value="-g" if="debug"/>
 	<flag value="-O2" unless="debug"/>
 	<flag value="-s" unless="debug"/>
+	<flag value="-lang-c++"/>
+	<flag value="-Wl,-z,relro,-z,now"/>
 	<!-- <flag value="-rdynamic"/> -->
 	<flag value="-L${QNX_TARGET}/${PLATFORM_ARCH}/lib"/>
 	<ext value=""/>
 	<outflag value="-o"/>
+	<lib name="-lm"/>
 	<!-- <lib name="-lpthread"/> -->
 	<!-- <lib name="-ldl"/> -->
 </linker>
 	
-<linker id="dll" exe="${EXEPREFIX}-g++" if="blackberry">
+<linker id="dll" exe="qcc" if="blackberry">
+	<fromfile value="-filelist " />
+	<flag value="-V${QCC_TARGET}" />
 	<flag value="-shared"/>
 	<flag value="-g" if="debug"/>
 	<flag value="-O2" unless="debug"/>
 	<flag value="-s" unless="debug"/>
 	<flag value="-L${QNX_TARGET}/${PLATFORM_ARCH}/lib"/>
+	<flag value="-lang-c++"/>
+	<flag value="-Wl,-z,relro,-z,now"/>
 	<cppflag value="-frtti"/>
 	<!-- <lib name="-lpthread"/> -->
 	<flag value="-fpic"/>


### PR DESCRIPTION
This PR setups hxcpp to use qcc instead of g++ when compiling for Blackberry. Modified to match the compiler calls that Blackberry Momentics IDE does as best as possible.

Some modifications to the source files of hxcpp were made too, mostly adding:
```
#if defined(BLACKBERRY)
using namespace std;
#endif
```
to files that required it.
