### PR TITLE
Support for VS2015 64 Toolchain

### DIFF
--- a/toolchain/msvc-toolchain.xml
+++ b/toolchain/msvc-toolchain.xml
@@ -35,6 +35,7 @@
 <set name="MACHINE" value="x64" if="HXCPP_M64" />
 
 <compiler id="MSVC" exe="cl.exe" if="windows">
+  <flag value="-FS"/>
   <flag value="-nologo"/>
   <flag value="-Od" if="debug"/>
   <!-- -O2 is back ! -->

--- a/toolchain/msvc64-setup.bat
+++ b/toolchain/msvc64-setup.bat
@@ -8,6 +8,11 @@ setlocal enabledelayedexpansion
 		@echo HXCPP_VARS
 		@set
 	)
+) else if exist "%VS140COMNTOOLS%\..\..\VC\bin\amd64\vcvars64.bat" (
+	@echo "%VS140COMNTOOLS%"
+	@call "%VS140COMNTOOLS%\..\..\VC\bin\amd64\vcvars64.bat"
+	@echo HXCPP_VARS
+	@set
 ) else if exist "%VS120COMNTOOLS%\..\..\VC\bin\x86_amd64\vcvarsx86_amd64.bat" (
 	@echo "%VS120COMNTOOLS%"
 	@call "%VS120COMNTOOLS%\..\..\VC\bin\x86_amd64\vcvarsx86_amd64.bat"


### PR DESCRIPTION
The -FS option (Force Synchronous PDB Writes) is needed in order to allow multiple compile threads.
https://msdn.microsoft.com/en-us/library/dn502518.aspx
