### PR TITLE
Fixed setsockopt SO_NOSIGPIPE for Mac

### DIFF
--- a/project/libs/std/Socket.cpp
+++ b/project/libs/std/Socket.cpp
@@ -131,7 +131,8 @@ static value socket_new( value udp ) {
 	if( s == INVALID_SOCKET )
 		return alloc_null();
 #	ifdef NEKO_MAC
-	setsockopt(s,SOL_SOCKET,SO_NOSIGPIPE,NULL,0);
+	int set = 1;
+	setsockopt(s,SOL_SOCKET,SO_NOSIGPIPE,(void *)&set, sizeof(int));
 #	endif
 #	ifdef NEKO_POSIX
 	// we don't want sockets to be inherited in case of exec


### PR DESCRIPTION
hxtelemetry apps are crashing with SIGPIPE when hxscout is shut down. See [hxscout issue #60][https://github.com/jcward/hxScout/issues/60].

With the previous arguments, setsockopt was returning -1, error. I found this format on Stackoverflow, which returns 0 (success) and this causes my hxtelemetry apps not to crash when hxscout is shut down (closing the socket from the far end) on Mac.

I also wonder why the MSG_NOSIGNAL isn't stopping SIGPIPE on Mac/Win -- should it be? Or is #define MSG_NOSIGNAL = 0 disabling this behavior for win and mac? (line 32) I still need a fix for Windows...