### PR TITLE
Add implicit conversion to T& from cpp::Reference

### DIFF
--- a/include/cpp/Pointer.h
+++ b/include/cpp/Pointer.h
@@ -236,6 +236,8 @@ public:
 
 
    inline T *operator->() { return ptr; }
+   
+   inline operator T &() { return *ptr; }
 
 };
 


### PR DESCRIPTION
Helps a lot when dealing with native C++ libraries.