### PR TITLE
Improve msvc cl.exe version checking for non-English environments

### DIFF
--- a/tools/hxcpp/Setup.hx
+++ b/tools/hxcpp/Setup.hx
@@ -540,7 +540,7 @@ class Setup
          proc.close();
          if (str>"")
          {
-            var reg = ~/Version\s+(\d+)/i;
+            var reg = ~/(\d{2})\.\d+/i;
             if (reg.match(str))
             {
                var cl_version = Std.parseInt(reg.matched(1));


### PR DESCRIPTION
Related issue https://github.com/HaxeFoundation/hxcpp/issues/280