### PR TITLE
Added support to search cross-compiler to build Windows-32bit from Linux-64bit

### DIFF
--- a/tools/hxcpp/Setup.hx
+++ b/tools/hxcpp/Setup.hx
@@ -114,7 +114,7 @@ class Setup
             return;
          }
 
-         var guesses = ["c:/MinGW"];
+         var guesses = ["c:/MinGW","/usr/i686-w64-mingw32"];
          for(guess in guesses )
          {
             if (FileSystem.exists(guess))


### PR DESCRIPTION
Added support to search on cross-compiler to build Windows-32bit executable from Linux-64bit, recompiling of hxcpp is required to take effect