### PR TITLE
fixing cygwin/mingw toolchain configuration to hide console window when no_console was specified

### DIFF
--- a/toolchain/cygwin-toolchain.xml
+++ b/toolchain/cygwin-toolchain.xml
@@ -2,6 +2,8 @@
 <xml>
 <include name="toolchain/gcc-toolchain.xml"/>
 
+<set name="SUBSYSTEMWINDOWS" value="1" if="no_console" unless="HXCPP_DEBUGGER" />
+
 <compiler id="cygwin" exe="env g++" if="cygwin">
   <flag value="-c"/>
   <cppflag value="-frtti"/>
@@ -35,6 +37,7 @@
   <flag value="-debug" if="debug"/>
   <flag value="-m32" unless="HXCPP_M64"/>
   <flag value="-m64" if="HXCPP_M64"/>
+  <flag value="-mwindows" if="SUBSYSTEMWINDOWS" />
   <lib name="-ldl"/>
   <ext value=".exe"/>
   <outflag value="-o "/>

--- a/toolchain/mingw-toolchain.xml
+++ b/toolchain/mingw-toolchain.xml
@@ -10,6 +10,8 @@
 
 <unset name="USE_PRECOMPILED_HEADERS"/>
 
+<set name="SUBSYSTEMWINDOWS" value="1" if="no_console" unless="HXCPP_DEBUGGER" />
+
 <compiler id="mingw" exe="gcc">
   <exe name="g++.exe"/>
   <flag value="-c"/>
@@ -46,6 +48,7 @@
   <exe name="g++.exe"/>
   <flag value="-debug" if="debug"/>
   <flag value="-Wl,--enable-auto-import"/>
+  <flag value="-mwindows" if="SUBSYSTEMWINDOWS" />
   <flag value="-m32" unless="HXCPP_M64"/>
   <flag value="-static" if="no_shared_libs"/>
   <flag value="-static-libgcc" if="no_shared_libs"/>


### PR DESCRIPTION
fixing cygwin/mingw toolchain configuration to hide console window when no_console was specified