### PR TITLE
Fixed compilation halt on case senstive compilers

### DIFF
--- a/src/hx/Date.cpp
+++ b/src/hx/Date.cpp
@@ -4,7 +4,7 @@
 
 #ifdef HX_WINDOWS
    #include <windows.h>
-   #include <Shlobj.h>
+   #include <shlobj.h>
 #else
    #ifdef EPPC
       #include <time.h>


### PR DESCRIPTION
The case sensitivity of Mingw in Fedora and Ubuntu version prevents successful cross-compilation of Win Executable in Linux hosts.

In comparison, Windows sdk and Mingw (Windows version) got a noncap first letter for shlobj.h.