### PR TITLE
Fixed cross compilation from Linux

### DIFF
--- a/toolchain/mingw-toolchain.xml
+++ b/toolchain/mingw-toolchain.xml
@@ -14,7 +14,8 @@
 
 <compiler id="mingw" exe="gcc">
   <exe name="g++.exe" unless="linux_host"/>
-  <exe name="i686-w64-mingw32-g++" if="linux_host"/>
+  <exe name="i686-w64-mingw32-g++" if="linux_host" unless="HXCPP_M64"/>
+  <exe name="x86_64-w64-mingw32-g++" if="linux_host" if="HXCPP_M64"/>
   <flag value="-c"/>
   <cppflag value="-frtti"/>
   <flag value="-g" if="HXCPP_DEBUG_LINK"/>
@@ -33,7 +34,8 @@
 
 <linker id="dll" exe="g++">
   <exe name="g++.exe" unless="linux_host"/>
-  <exe name="i686-w64-mingw32-g++" if="linux_host"/>
+  <exe name="i686-w64-mingw32-g++" if="linux_host" unless="HXCPP_M64"/>
+  <exe name="x86_64-w64-mingw32-g++" if="linux_host" if="HXCPP_M64"/>
   <flag value="-shared"/>
   <flag value="-debug" if="debug"/>
   <flag value="--enable-auto-import"/>
@@ -48,7 +50,8 @@
 
 <linker id="exe" exe="g++">
   <exe name="g++.exe" unless="linux_host"/>
-  <exe name="i686-w64-mingw32-g++" if="linux_host"/>
+  <exe name="i686-w64-mingw32-g++" if="linux_host" unless="HXCPP_M64"/>
+  <exe name="x86_64-w64-mingw32-g++" if="linux_host" if="HXCPP_M64"/>
   <flag value="-debug" if="debug"/>
   <flag value="-Wl,--enable-auto-import"/>
   <flag value="-mwindows" if="SUBSYSTEMWINDOWS" />

--- a/toolchain/mingw-toolchain.xml
+++ b/toolchain/mingw-toolchain.xml
@@ -14,8 +14,7 @@
 
 <compiler id="mingw" exe="gcc">
   <exe name="g++.exe" unless="linux_host"/>
-  <exe name="i686-w64-mingw32-g++" if="linux_host" unless="HXCPP_M64"/>
-  <exe name="x86_64-w64-mingw32-g++" if="linux_host" if="HXCPP_M64"/>
+  <exe name="i686-w64-mingw32-g++" if="linux_host"/>
   <flag value="-c"/>
   <cppflag value="-frtti"/>
   <flag value="-g" if="HXCPP_DEBUG_LINK"/>
@@ -34,8 +33,7 @@
 
 <linker id="dll" exe="g++">
   <exe name="g++.exe" unless="linux_host"/>
-  <exe name="i686-w64-mingw32-g++" if="linux_host" unless="HXCPP_M64"/>
-  <exe name="x86_64-w64-mingw32-g++" if="linux_host" if="HXCPP_M64"/>
+  <exe name="i686-w64-mingw32-g++" if="linux_host"/>
   <flag value="-shared"/>
   <flag value="-debug" if="debug"/>
   <flag value="--enable-auto-import"/>
@@ -50,8 +48,7 @@
 
 <linker id="exe" exe="g++">
   <exe name="g++.exe" unless="linux_host"/>
-  <exe name="i686-w64-mingw32-g++" if="linux_host" unless="HXCPP_M64"/>
-  <exe name="x86_64-w64-mingw32-g++" if="linux_host" if="HXCPP_M64"/>
+  <exe name="i686-w64-mingw32-g++" if="linux_host"/>
   <flag value="-debug" if="debug"/>
   <flag value="-Wl,--enable-auto-import"/>
   <flag value="-mwindows" if="SUBSYSTEMWINDOWS" />

--- a/toolchain/mingw-toolchain.xml
+++ b/toolchain/mingw-toolchain.xml
@@ -13,7 +13,8 @@
 <set name="SUBSYSTEMWINDOWS" value="1" if="no_console" unless="HXCPP_DEBUGGER" />
 
 <compiler id="mingw" exe="gcc">
-  <exe name="g++.exe"/>
+  <exe name="g++.exe" unless="linux_host"/>
+  <exe name="i686-w64-mingw32-g++" if="linux_host"/>
   <flag value="-c"/>
   <cppflag value="-frtti"/>
   <flag value="-g" if="HXCPP_DEBUG_LINK"/>
@@ -31,7 +32,8 @@
 </compiler>
 
 <linker id="dll" exe="g++">
-  <exe name="g++.exe"/>
+  <exe name="g++.exe" unless="linux_host"/>
+  <exe name="i686-w64-mingw32-g++" if="linux_host"/>
   <flag value="-shared"/>
   <flag value="-debug" if="debug"/>
   <flag value="--enable-auto-import"/>
@@ -45,14 +47,17 @@
 </linker>
 
 <linker id="exe" exe="g++">
-  <exe name="g++.exe"/>
+  <exe name="g++.exe" unless="linux_host"/>
+  <exe name="i686-w64-mingw32-g++" if="linux_host"/>
   <flag value="-debug" if="debug"/>
   <flag value="-Wl,--enable-auto-import"/>
   <flag value="-mwindows" if="SUBSYSTEMWINDOWS" />
   <flag value="-m32" unless="HXCPP_M64"/>
   <flag value="-static" if="no_shared_libs"/>
-  <flag value="-static-libgcc" if="no_shared_libs"/>
-  <flag value="-static-libstdc++" if="no_shared_libs"/>
+  <flag value="-static-libgcc" if="no_shared_libs" unless="linux_host"/>
+  <flag value="-static-libstdc++" if="no_shared_libs" unless="linux_host"/>
+  <flag value="-static-libgcc" if="linux_host"/>
+  <flag value="-static-libstdc++" if="linux_host"/>
   <flag value="-L${MINGW_ROOT}/lib/libs" />
   <ext value=".exe"/>
   <outflag value="-o "/>
@@ -60,6 +65,8 @@
 
 <copyFile toolId="exe" name="libgcc_s_dw2-1.dll" from="${MINGW_ROOT}/bin" allowMissing="true" unless="no_shared_libs"/>
 <copyFile toolId="exe" name="libstdc++-6.dll" from="${MINGW_ROOT}/bin" allowMissing="true" unless="no_shared_libs"/>
+<copyFile toolId="exe" name="libwinpthread-1.dll" from="${MINGW_ROOT}/sys-root/mingw/bin" allowMissing="true" unless="no_shared_libs"/>
+<copyFile toolId="exe" name="libwinpthread-1.dll" from="${MINGW_ROOT}/lib" allowMissing="true" unless="no_shared_libs"/>
 
 <linker id="static_link" exe="ar" >
   <ext value="${LIBEXT}"/>


### PR DESCRIPTION
This enables Linux machines (Ubuntu & Fedora) to cross compile Win32 binary using Mingw.

The resulting Windows app was fully functioning in Wine abstraction layer, Windows 7 and Windows 10 PCs.