### PR TITLE
Added support to cross compile Windows application from Linux Host, fix HaxeFoundation/hxcpp#282

### DIFF
--- a/toolchain/mingw-toolchain.xml
+++ b/toolchain/mingw-toolchain.xml
@@ -2,6 +2,15 @@
 
 <!-- MINGW TOOLS -------------------------------------->
 
+<section if="xcompile" >
+   <section if="linux_host">
+      <set name="CXX" value="i686-w64-mingw32-g++"/>
+   </section>
+   <section if="windows_host">
+      <set name="CXX" value="g++.exe" />
+   </section>
+</section>
+
 <setup name="mingw" />
 
 <path name="${MINGW_ROOT}/bin"/>
@@ -13,8 +22,7 @@
 <set name="SUBSYSTEMWINDOWS" value="1" if="no_console" unless="HXCPP_DEBUGGER" />
 
 <compiler id="mingw" exe="gcc">
-  <exe name="g++.exe" unless="linux_host"/>
-  <exe name="i686-w64-mingw32-g++" if="linux_host"/>
+  <exe name="${CXX}" if="CXX"/>
   <flag value="-c"/>
   <cppflag value="-frtti"/>
   <flag value="-g" if="HXCPP_DEBUG_LINK"/>
@@ -32,8 +40,7 @@
 </compiler>
 
 <linker id="dll" exe="g++">
-  <exe name="g++.exe" unless="linux_host"/>
-  <exe name="i686-w64-mingw32-g++" if="linux_host"/>
+  <exe name="${CXX}" if="CXX"/>
   <flag value="-shared"/>
   <flag value="-debug" if="debug"/>
   <flag value="--enable-auto-import"/>
@@ -47,8 +54,7 @@
 </linker>
 
 <linker id="exe" exe="g++">
-  <exe name="g++.exe" unless="linux_host"/>
-  <exe name="i686-w64-mingw32-g++" if="linux_host"/>
+  <exe name="${CXX}" if="CXX"/>
   <flag value="-debug" if="debug"/>
   <flag value="-Wl,--enable-auto-import"/>
   <flag value="-mwindows" if="SUBSYSTEMWINDOWS" />

--- a/toolchain/mingw-toolchain.xml
+++ b/toolchain/mingw-toolchain.xml
@@ -13,7 +13,8 @@
 <set name="SUBSYSTEMWINDOWS" value="1" if="no_console" unless="HXCPP_DEBUGGER" />
 
 <compiler id="mingw" exe="gcc">
-  <exe name="g++.exe"/>
+  <exe name="g++.exe" unless="linux_host"/>
+  <exe name="i686-w64-mingw32-g++" if="linux_host"/>
   <flag value="-c"/>
   <cppflag value="-frtti"/>
   <flag value="-g" if="HXCPP_DEBUG_LINK"/>
@@ -31,7 +32,8 @@
 </compiler>
 
 <linker id="dll" exe="g++">
-  <exe name="g++.exe"/>
+  <exe name="g++.exe" unless="linux_host"/>
+  <exe name="i686-w64-mingw32-g++" if="linux_host"/>
   <flag value="-shared"/>
   <flag value="-debug" if="debug"/>
   <flag value="--enable-auto-import"/>
@@ -45,14 +47,17 @@
 </linker>
 
 <linker id="exe" exe="g++">
-  <exe name="g++.exe"/>
+  <exe name="g++.exe" unless="linux_host"/>
+  <exe name="i686-w64-mingw32-g++" if="linux_host"/>
   <flag value="-debug" if="debug"/>
   <flag value="-Wl,--enable-auto-import"/>
   <flag value="-mwindows" if="SUBSYSTEMWINDOWS" />
   <flag value="-m32" unless="HXCPP_M64"/>
   <flag value="-static" if="no_shared_libs"/>
-  <flag value="-static-libgcc" if="no_shared_libs"/>
-  <flag value="-static-libstdc++" if="no_shared_libs"/>
+  <flag value="-static-libgcc" if="no_shared_libs" unless="linux_host"/>
+  <flag value="-static-libstdc++" if="no_shared_libs" unless="linux_host"/>
+  <flag value="-static-libgcc" if="linux_host"/>
+  <flag value="-static-libstdc++" if="linux_host"/>
   <flag value="-L${MINGW_ROOT}/lib/libs" />
   <ext value=".exe"/>
   <outflag value="-o "/>
@@ -60,6 +65,8 @@
 
 <copyFile toolId="exe" name="libgcc_s_dw2-1.dll" from="${MINGW_ROOT}/bin" allowMissing="true" unless="no_shared_libs"/>
 <copyFile toolId="exe" name="libstdc++-6.dll" from="${MINGW_ROOT}/bin" allowMissing="true" unless="no_shared_libs"/>
+<copyFile toolId="exe" name="libwinpthread-1.dll" from="${MINGW_ROOT}/sys-root/mingw/bin" allowMissing="true" unless="no_shared_libs"/>
+<copyFile toolId="exe" name="libwinpthread-1.dll" from="${MINGW_ROOT}/lib" allowMissing="true" unless="no_shared_libs"/>
 
 <linker id="static_link" exe="ar" >
   <ext value="${LIBEXT}"/>


### PR DESCRIPTION
 HaxeFoundation/hxcpp#282

ABOUT THE PULL:

The Mingw compiler for Linux (Ubuntu and Fedora) is located in bin directory with the same name

   i686-w64-mingw32-g++

by adding a flag

   -Dlinux_host (linux_host)

will trigger the Linux Mingw (i686-w64-mingw32-g++) compilation.

During the last stage of compilation (production of EXE), the resulting Windows application looks for a file named 

   libgcc_s_dw2-1.dll

Which, however is not available from the Linux Mingw, by bundling gcc and stdc dependencies at EXE production:

   -static-libstdc++ and -static-libgcc

resolved this problem.

In addition, the Windows Application build from Linux host looks for another file that is itself available in from Linux Mingw

   libwinpthread-1.dll

There are two possible location for this library, so I added an additional two copyFile codes.

TESTS:

I have tested several applications:

1.) BunnyMark
2.) SimpleOpenGLView
3.) AddingAnimation
4.) My application (Literally, build from scratch)

Host Machines were:
    
1.) Ubuntu

    Enable repositories and install Mingw:
    sudo apt-get install mingw-w64

2.) Fedora

     Install mingw
     sudo yum install mingw32 mingw32-gcc-c++ mingw32-headers mingw32-crt mingw-winpthreads mingw32-cpp mingw32-filesystem

Compilation from both Linux hosts were successful and the resulting Windows Applications were fully working in

1.) Wine Abstraction Layer
2.) Windows 7 Machine
3.) WIndows 10 Machine

During the build, the following compilation flags were activated:

1.) This is the flag needed to activate the Linux Mingw cross-compiler

   -Dlinux_host

2.) There is a bug in hxcpp, when it detect that the host is Linux it automatically calls linux-toolchain.xml, so this should be indicated, new issue should be opened for this.

   -Dtoolchain=mingw

3.) The default search for Mingw was in "C:\Mingw", in Linux machine though, it is different, as Hugh suggested, we can add it to the search path through the following

   -DMINGW_ROOT=/usr/i686-w64-mingw32 (This location is the same for both Fedora and Ubuntu)