### PR TITLE
Defaults Mingw toolchain to g++.exe when not cross-compiling

### DIFF
--- a/toolchain/mingw-toolchain.xml
+++ b/toolchain/mingw-toolchain.xml
@@ -11,6 +11,8 @@
    </section>
 </section>
 
+<set name="CXX" value="g++.exe" unless="xcompile"/>
+
 <setup name="mingw" />
 
 <path name="${MINGW_ROOT}/bin"/>


### PR DESCRIPTION
Windows users can now compile Win32 app using

    hxcpp Build.xml

While Linux users can do the same using

    hxcpp Build.xml -Dwindows

NOTE:

Windows users who intends to use Mingw as their compiler could install it from this site:

    http://sourceforge.net/projects/mingw-w64/

Linux users on the other hand could do:

    sudo apt-get install mingw-w64

or

    sudo yum install mingw32 mingw32-gcc-c++ mingw32-headers mingw32-crt mingw-winpthreads mingw32-cpp mingw32-filesystem


For a detailed discussion, please refer to 

HaxeFoundation/hxcpp#294