### PR TITLE
 Fix: Initialized xcompile toolchain when cross-compiling

### DIFF
--- a/toolchain/mingw-toolchain.xml
+++ b/toolchain/mingw-toolchain.xml
@@ -5,6 +5,7 @@
 <section if="xcompile" >
    <section if="linux_host">
       <set name="CXX" value="i686-w64-mingw32-g++"/>
+      <set name="MINGW_ROOT" value="/usr/i686-w64-mingw32"/>
    </section>
    <section if="windows_host">
       <set name="CXX" value="g++.exe" />

--- a/tools/hxcpp/BuildTool.hx
+++ b/tools/hxcpp/BuildTool.hx
@@ -1397,9 +1397,19 @@ class BuildTool
       else if ( (new EReg("linux","i")).match(os) )
       {
          set64(defines,m64);
-         defines.set("toolchain","linux");
-         defines.set("linux","linux");
-         defines.set("BINDIR", m64 ? "Linux64":"Linux");
+         // Cross-compile?
+         if(defines.exists("windows"))
+         {
+            defines.set("toolchain","mingw");
+            defines.set("xcompile","1");
+            defines.set("BINDIR", m64 ? "Windows64":"Windows");
+         }
+         else
+         {
+            defines.set("toolchain","linux");
+            defines.set("linux","linux");
+            defines.set("BINDIR", m64 ? "Linux64":"Linux");
+         }
       }
       else if ( (new EReg("mac","i")).match(os) )
       {

--- a/tools/hxcpp/Setup.hx
+++ b/tools/hxcpp/Setup.hx
@@ -114,7 +114,7 @@ class Setup
             return;
          }
 
-         var guesses = ["c:/MinGW","/usr/i686-w64-mingw32"];
+         var guesses = ["c:/MinGW"];
          for(guess in guesses )
          {
             if (FileSystem.exists(guess))

--- a/tools/hxcpp/Setup.hx
+++ b/tools/hxcpp/Setup.hx
@@ -114,7 +114,7 @@ class Setup
             return;
          }
 
-         var guesses = ["c:/MinGW"];
+         var guesses = ["c:/MinGW","/usr/i686-w64-mingw32"];
          for(guess in guesses )
          {
             if (FileSystem.exists(guess))


### PR DESCRIPTION
ABOUT THE PULL:

When in Linux, the old code will default you to compiling Linux binaries, what ever -Dwindows we do.

This is because the old code is not configured to enable cross-compilation yet.

This pull was offered to ensure that cross compiling from Linux will call on the xcompile toolchain.

Here, only the Linux part of the Condition statement was updated, Windows and Mac users will get the expected action of hxcpp.

To discuss further, the code will ensure to run the xcompile when we attempt to build a windows application in a Linux host by submitting the

    -Dwindows

to the compilation. Else, if we did not include it, the code will resume to compile a Linux binary, thus, we recover the same behavior as the old code.

FULLY WORKING ON:

1.) Fedora
2.) Ubuntu

This goes in complement to the following

HaxeFoundation/hxcpp#294
HaxeFoundation/hxcpp#304

NOTE: xcompile, within the mingw-toolchain.xml. is activated only when attempting to cross-compile (One Platform to  Another Platform).