### PR TITLE
Improved error reporting

### DIFF
--- a/tools/hxcpp/Setup.hx
+++ b/tools/hxcpp/Setup.hx
@@ -125,7 +125,16 @@ class Setup
             }
          }
 
-         Log.error('Could not guess MINGW_ROOT (tried $guesses) - please set explicitly');
+         if (ioDefines.exists("mingw"))
+         {
+            //when mingw is explicitly indicated but not properly configured, this log will be shown
+            Log.error('Could not guess MINGW_ROOT (tried $guesses) - please set explicitly');          
+         }
+         else
+         {
+            //when both mingw and MSVC is not properly configured, this log will be shown
+            Log.error('Could not setup any C++ compiler, please install or reinstall a valid C++ compiler');
+         }
       }
    }
 


### PR DESCRIPTION
Internally hxcpp does a search first on MSVC then followed by Mingw. 

In cases when we dont have either MSVC or Mingw compilers in Windows environment, then tried to do

    hxcpp Build.xml

We get an error related to Mingw. Instead of an error that compilers could not be setup.

This pull will cause error reporting to default to

    Could not setup any C++ compiler, please install or reinstall a valid C++ compiler

Then if -Dmingw is indicated explicitly

    Could not guess MINGW_ROOT (tried $guesses) - please set explicitly