### PR TITLE
Only use fast path if slot is less than 64

### DIFF
--- a/include/hx/Tls.h
+++ b/include/hx/Tls.h
@@ -57,7 +57,10 @@
          DATA **extra = (DATA **)(__readfsdword(kTibExtraTlsOffset));
          return extra[mFastOffset];
          #elif (_MSC_VER >= 1400) & !defined(HXCPP_DEBUG)// 64 bit version...
-         return (DATA *)__readgsqword(mFastOffset);
+         if (mSlot < 64)
+           return (DATA *)__readgsqword(mFastOffset);
+         else
+           return (DATA *)TlsGetValue(mSlot);
          #else
          return (DATA *)TlsGetValue(mSlot);
          #endif


### PR DESCRIPTION
The trick mentioned there only works for < 64 slots. I'm working on integrating with a big application that actually uses those 64 slots before hxcpp gets initialized, and got some very hard to track errors.

It might be possible to make the code work on slots bigger than 64 using http://cbloomrants.blogspot.com/2013/09/09-18-13-fast-tls-on-windows.html. I really didn't want to make a PR of code that I don't understand

I'm curious however if this mode is faster than `__declspec(thread)`. I thought this was the faster way to support TLS.