### PR TITLE
Blackberry compile fix

### DIFF
--- a/src/hx/gc/GcRegCapture.cpp
+++ b/src/hx/gc/GcRegCapture.cpp
@@ -77,8 +77,6 @@ void CaptureX64(RegisterCaptureBuffer &outBuffer)
 
 #else // }  {
 
-#include <string.h>
-
 // Put this function here so we can be reasonablly sure that "this" register and
 // the 4 registers that may be used to pass args are on the stack.
 int RegisterCapture::Capture(int *inTopOfStack,int **inBuf,int &outSize,int inMaxSize, int *inBottom)

--- a/src/hx/gc/GcRegCapture.h
+++ b/src/hx/gc/GcRegCapture.h
@@ -1,6 +1,8 @@
 #ifndef HX_GC_HELPERS_INCLUDED
 #define HX_GC_HELPERS_INCLUDED
 
+#include <string.h>
+
 namespace hx
 {
 


### PR DESCRIPTION
Move "#include <string.h>" from GcRegCapture.cpp to GcRegCapture.h. This is needed in order to be able to compile on Blackberry. Other targets will keep working ok.