### PR TITLE
Telemetry updates (GC_MOVING, finalizers -> mark/sweep, gcoverhead)

### DIFF
--- a/include/hx/Object.h
+++ b/include/hx/Object.h
@@ -6,7 +6,7 @@
 #endif
 
 #ifdef HXCPP_TELEMETRY
-extern void __hxt_gc_new(void* obj, int inSize);
+extern void __hxt_gc_new(void* obj, int inSize, const char *inName);
 #endif
 
 
@@ -113,7 +113,7 @@ public:
                                gMarkID;
 
                #ifdef HXCPP_TELEMETRY
-                  __hxt_gc_new(buffer, inSize);
+               __hxt_gc_new(buffer, inSize, inName);
                #endif
                return buffer;
             }
@@ -130,7 +130,7 @@ public:
 
 
       #ifdef HXCPP_TELEMETRY
-         __hxt_gc_new(result, inSize);
+         __hxt_gc_new(result, inSize, inName);
       #endif
       return result;
    }

--- a/include/hx/Telemetry.h
+++ b/include/hx/Telemetry.h
@@ -1,6 +1,8 @@
 #ifndef HX_TELEMETRY_H
 #define HX_TELEMETRY_H
 
+#define HX_TELEMETRY_VERSION 1
+
 #include <hxcpp.h>
 #include <vector>
 
@@ -8,6 +10,7 @@ struct TelemetryFrame
 {
   // microseconds, always valid
   int gctime;
+  int gcoverhead;
 
   // Valid only if profiler is enabled
   std::vector<int> *samples;
@@ -24,7 +27,6 @@ int __hxcpp_hxt_start_telemetry(bool profiler, bool allocations);
 void __hxcpp_hxt_stash_telemetry();
 TelemetryFrame* __hxcpp_hxt_dump_telemetry(int thread_num);
 void __hxcpp_hxt_ignore_allocs(int delta);
-int __hxcpp_hxt_dump_gctime();
 
 // expose these from GCInternal
 int __hxcpp_gc_reserved_bytes();

--- a/src/hx/Debug.cpp
+++ b/src/hx/Debug.cpp
@@ -2723,10 +2723,10 @@ void __hxt_new_hash(void* obj, int inSize)
   hx::CallStack::HXTAllocation(obj, inSize, (const char*)"Hash");
   #endif
 }
-void __hxt_gc_new(void* obj, int inSize)
+void __hxt_gc_new(void* obj, int inSize, const char* name)
 {
   #ifdef HXCPP_STACK_TRACE
-  hx::CallStack::HXTAllocation(obj, inSize, (const char*)0);
+  hx::CallStack::HXTAllocation(obj, inSize, name);
   #endif
 }
 void __hxt_gc_realloc(void* old_obj, void* new_obj, int new_size)

--- a/src/hx/gc/Immix.cpp
+++ b/src/hx/gc/Immix.cpp
@@ -112,7 +112,6 @@ static int sgAllocsSinceLastSpam = 0;
 
 // TODO: Telemetry.h ?
 #ifdef HXCPP_TELEMETRY
-extern void __hxt_gc_new(void* obj, int inSize);
 extern void __hxt_gc_realloc(void* old_obj, void* new_obj, int new_size);
 extern void __hxt_gc_start();
 extern void __hxt_gc_end();

--- a/src/hx/gc/Immix.cpp
+++ b/src/hx/gc/Immix.cpp
@@ -116,6 +116,7 @@ extern void __hxt_gc_new(void* obj, int inSize);
 extern void __hxt_gc_realloc(void* old_obj, void* new_obj, int new_size);
 extern void __hxt_gc_start();
 extern void __hxt_gc_end();
+extern void __hxt_gc_after_mark(int gByteMarkID, int ENDIAN_MARK_ID_BYTE);
 #endif
 
 static int sgTimeToNextTableUpdate = 1;
@@ -1495,9 +1496,6 @@ FILE_SCOPE FinalizerList *sgFinalizers = 0;
 
 typedef hx::UnorderedMap<hx::Object *,hx::finalizer> FinalizerMap;
 FILE_SCOPE FinalizerMap sFinalizerMap;
-#ifdef HXCPP_TELEMETRY
-FILE_SCOPE FinalizerMap hxtFinalizerMap;
-#endif
 
 typedef void (*HaxeFinalizer)(Dynamic);
 typedef hx::UnorderedMap<hx::Object *,HaxeFinalizer> HaxeFinalizerMap;
@@ -1646,24 +1644,6 @@ void RunFinalizers()
       i = next;
    }
 
-   #ifdef HXCPP_TELEMETRY
-   for(FinalizerMap::iterator i=hxtFinalizerMap.begin(); i!=hxtFinalizerMap.end(); )
-   {
-      hx::Object *obj = i->first;
-      FinalizerMap::iterator next = i;
-      ++next;
-
-      unsigned char mark = ((unsigned char *)obj)[ENDIAN_MARK_ID_BYTE];
-      if ( mark!=gByteMarkID )
-      {
-         (*i->second)(obj);
-         hxtFinalizerMap.erase(i);
-      }
-
-      i = next;
-   }
-   #endif
-
    for(ObjectIdMap::iterator i=sObjectIdMap.begin(); i!=sObjectIdMap.end(); )
    {
       ObjectIdMap::iterator next = i;
@@ -1779,28 +1759,6 @@ void  GCSetHaxeFinalizer( hx::Object *obj, HaxeFinalizer f )
    else
       sHaxeFinalizerMap[obj] = f;
 }
-
-#ifdef HXCPP_TELEMETRY
-// Callback finalizer on non-abstract type;
-void  GCSetHXTFinalizer( void*obj, hx::finalizer f )
-{
-   if (!obj)
-      throw Dynamic(HX_CSTRING("set_hxt_finalizer - invalid null object"));
-   //if (((unsigned int *)obj)[-1] & HX_GC_CONST_ALLOC_BIT) return;
-
-   //printf("Setting hxt finalizer on %018x\n", obj);
-
-   AutoLock lock(*gSpecialObjectLock);
-   if (f==0)
-   {
-     FinalizerMap::iterator i = hxtFinalizerMap.find((hx::Object*)obj);
-      if (i!=hxtFinalizerMap.end())
-         hxtFinalizerMap.erase(i);
-   }
-   else
-     hxtFinalizerMap[(hx::Object*)obj] = f;
-}
-#endif
 
 void GCDoNotKill(hx::Object *inObj)
 {
@@ -2304,17 +2262,6 @@ public:
           hx::sHaxeFinalizerMap.erase(h);
           hx::sHaxeFinalizerMap[inTo] = f;
        }
-
-       #ifdef HXCPP_TELEMETRY
-       i = hx::hxtFinalizerMap.find(inFrom);
-       if (i!=hx::hxtFinalizerMap.end())
-       {
-          hx::finalizer f = i->second;
-          hx::hxtFinalizerMap.erase(i);
-          hx::hxtFinalizerMap[inTo] = f;
-          printf("HXT TODO: potential lost collection / ID collision, maintain alloc_map across move?");
-       }
-       #endif
 
        hx::MakeZombieSet::iterator mz = hx::sMakeZombieSet.find(inFrom);
        if (mz!=hx::sMakeZombieSet.end())
@@ -3060,6 +3007,12 @@ public:
       MarkAll();
 
       STAMP(t2)
+
+
+      #ifdef HXCPP_TELEMETRY
+      // Detect deallocations - TODO: add STAMP() ?
+      __hxt_gc_after_mark(gByteMarkID, ENDIAN_MARK_ID_BYTE);
+      #endif
 
       // Sweep large
       int idx = 0;
@@ -4110,13 +4063,6 @@ void __hxcpp_set_finalizer(Dynamic inObj, void *inFunc)
 {
    GCSetHaxeFinalizer( inObj.mPtr, (hx::HaxeFinalizer) inFunc );
 }
-
-#ifdef HXCPP_TELEMETRY
-void __hxcpp_set_hxt_finalizer(void* inObj, void *inFunc)
-{
-   GCSetHXTFinalizer( inObj, (hx::finalizer) inFunc );
-}
-#endif
 
 extern "C"
 {

--- a/src/hx/gc/Immix.cpp
+++ b/src/hx/gc/Immix.cpp
@@ -2243,7 +2243,7 @@ public:
 
    #if  defined(HXCPP_VISIT_ALLOCS) // {
 
-   void MoveSpecial(hx::Object *inTo, hx::Object *inFrom)
+  void MoveSpecial(hx::Object *inTo, hx::Object *inFrom, int size)
    {
        // FinalizerList will get visited...
 
@@ -2279,6 +2279,12 @@ public:
        }
 
        // Maybe do something faster with weakmaps
+
+#ifdef HXCPP_TELEMETRY
+       //printf(" -- moving %018x to %018x, size %d\n", inFrom, inTo, size);
+       __hxt_gc_realloc(inFrom, inTo, size);
+#endif
+
    }
 
 
@@ -2388,7 +2394,7 @@ public:
 
                         unsigned int *src = row + i + 1;
 
-                        MoveSpecial((hx::Object *)buffer,(hx::Object *)src);
+                        MoveSpecial((hx::Object *)buffer,(hx::Object *)src, size);
 
                         // Result has moved - store movement in original position...
                         memcpy(buffer, src, size);


### PR DESCRIPTION
A couple of updates to HXCPP_TELEMETRY:

1. Compatibility with HXCPP_GC_MOVING
2. Changed deallocation tracking from finalizers to post-mark ID-check sweep
3. The above allowed easy measurement of GC telemetry overhead (which I'll later report in hxScout)

@larsiusprime - you mentioned running your code through hxScout soon -- if you want to use this hxcpp branch (jcward/telemetry_update) that might be a nice smoke test. If not, no worries. :)