### PR TITLE
added HXCPP_OPTIMIZE_FOR_SIZE

### DIFF
--- a/toolchain/android-toolchain.xml
+++ b/toolchain/android-toolchain.xml
@@ -123,7 +123,12 @@
  <flag value="${ANDROID_PLATFORM_DEFINE}"/>
  <!-- todo <flag value="-Werror"/> -->
  <flag value="-Wa,--noexecstack"/>
- <flag value="-O2" unless="debug"/>
+ <flag value="-O2" unless="debug || HXCPP_OPTIMIZE_FOR_SIZE"/>
+ <section if="HXCPP_OPTIMIZE_FOR_SIZE" unless="debug">
+	<!-- see https://software.intel.com/en-us/blogs/2013/01/17/x86-gcc-code-size-optimizations -->
+	<flag value="-Os" />
+	<flag value="-fno-asynchronous-unwind-tables" />
+ </section>
  <flag value="-O0" if="debug"/>
  <flag value="-g" if="HXCPP_DEBUG_LINK"/>
  <flag value="-DNDEBUG"/>
@@ -147,6 +152,10 @@
   <flag value="-nostdlib"/>
   <flag value="-std=c++11" if="HXCPP_CPP11"/>
   <flag value="-Wl,-shared,-Bsymbolic"/>
+  <section if="HXCPP_OPTIMIZE_FOR_SIZE" unless="debug">
+	<!-- see https://software.intel.com/en-us/blogs/2013/01/17/x86-gcc-code-size-optimizations -->
+	<flag value="-Wl,--gc-sections" />
+  </section>
   <flag value="-Wl,--no-undefined" unless="dll_import" />
   <flag value="-Wl,--unresolved-symbols=ignore-in-object-files" if="dll_import" />
   <flag value="-Wl,-z,noexecstack"/>


### PR DESCRIPTION
When creating non-gaming apps for mobile devices optimization for APK size may be desirable. Specifying the compiler flags **-Os**, **-fno-asynchronous-unwind-tables** and the linker flag **-Wl,--gc-sections** reduced the size of a test haxeui APK by 25%.

The compiler flag -Os is described in the gcc manual with: *-Os enables all -O2 optimizations that do not typically increase code size.*

With this pull request, the new **HXCPP_OPTIMIZE_FOR_SIZE** switch will be introduced for the Android toolchain, which - if specified - enables the mentioned compiler/linker flags.

openfl projects can now for example use:

    <haxedef name="HXCPP_OPTIMIZE_FOR_SIZE" if="android" />
