### PR TITLE
Update WinRT to Windows 10 UWP

### DIFF
--- a/include/hx/Thread.h
+++ b/include/hx/Thread.h
@@ -48,7 +48,7 @@ inline int HxAtomicInc(volatile int *ioWhere)
 inline int HxAtomicDec(volatile int *ioWhere)
    { return __atomic_dec(ioWhere); }
 
-#elif defined(HX_WINDOWS)
+#elif defined(HX_WINDOWS) && !defined(HX_WINRT) //winrt test
 
 inline bool HxAtomicExchangeIf(int inTest, int inNewVal,volatile int *ioWhere)
    { return InterlockedCompareExchange((volatile LONG *)ioWhere, inNewVal, inTest)==inTest; }

--- a/include/hx/Tls.h
+++ b/include/hx/Tls.h
@@ -127,9 +127,9 @@ struct TLSData
 #define DECLARE_FAST_TLS_DATA(TYPE,NAME) \
    __declspec(thread) TYPE * NAME = nullptr;
 #define EXTERN_TLS_DATA(TYPE,NAME) \
-   __declspec(thread) extern TYPE * NAME = nullptr;
+   __declspec(thread) extern TYPE * NAME;
 #define EXTERN_FAST_TLS_DATA(TYPE,NAME) \
-   __declspec(thread) extern TYPE * NAME = nullptr;
+   __declspec(thread) extern TYPE * NAME;
 
 #else
 

--- a/include/hxString.h
+++ b/include/hxString.h
@@ -38,6 +38,16 @@ public:
       *this = String([inString UTF8String]);
    }
    #endif
+   #ifdef HX_WINRT
+   inline String(Platform::String^ inString)
+   {
+      *this = String(inString->Data());
+   }
+   inline String(Platform::StringReference inString)
+   {
+      *this = String(inString.Data());
+   }
+   #endif
    inline String(const ::String &inRHS) : __s(inRHS.__s), length(inRHS.length) { }
    String(const int &inRHS);
    String(const cpp::CppInt32__ &inRHS);

--- a/include/hxcpp.h
+++ b/include/hxcpp.h
@@ -96,7 +96,7 @@ typedef char HX_CHAR;
 #ifdef HX_WINRT
 
 #define WINRT_LOG(fmt, ...) {char buf[1024];sprintf(buf,"****LOG: %s(%d): %s \n    [" fmt "]\n",__FILE__,__LINE__,__FUNCTION__, __VA_ARGS__);OutputDebugString(buf);}
-#define WINRT_PRINTF(fmt, ...) {char buf[2048];sprintf(buf,"fmt\n", __VA_ARGS__);OutputDebugString(buf);}
+#define WINRT_PRINTF(fmt, ...) {char buf[2048];sprintf(buf,"fmt", __VA_ARGS__);OutputDebugString(buf);}
 
 #endif
 
@@ -134,24 +134,17 @@ typedef char HX_CHAR;
 // HX_CSTRING is for constant strings without built-in hashes
 //     HX_GC_CONST_ALLOC_BIT | HX_GC_NO_STRING_HASH
 
-#ifdef HX_WINRT
-#ifdef HXCPP_BIG_ENDIAN
 
-#define HX_HCSTRING(s,h0,h1,h2,h3) ::String( const_cast<char *>((h3 h2 h1 h0 "\x80\x00\x00\x00" s )) + 8 , sizeof(s)/sizeof(HX_CHAR)-1)
-#define HX_STRINGI(s,len) ::String( const_cast<char *>(("\xc0\x00\x00\x00" s)) + 4 ,len)
-
-#else
-#define HX_HCSTRING(s,h0,h1,h2,h3) ::String( const_cast<char *>((h0 h1 h2 h3 "\x00\x00\x00\x80" s )) + 8 , sizeof(s)/sizeof(HX_CHAR)-1)
-
-#define HX_STRINGI(s,len) ::String( const_cast<char *>(("\x00\x00\x0\xc0" s)) + 4 ,len)
-#endif
-#else
 
 #ifdef HXCPP_BIG_ENDIAN
 #define HX_HCSTRING(s,h0,h1,h2,h3) ::String( (const HX_CHAR *)((h3 h2 h1 h0 "\x80\x00\x00\x00" s )) + 8 , sizeof(s)/sizeof(HX_CHAR)-1)
 #define HX_STRINGI(s,len) ::String( (const HX_CHAR *)(("\xc0\x00\x00\x00" s)) + 4 ,len)
 #else
 
+#ifdef HX_WINRT
+#define HX_HCSTRING(s,h0,h1,h2,h3) ::String( const_cast<char *>((h0 h1 h2 h3 "\x00\x00\x00\x80" s )) + 8 , sizeof(s)/sizeof(HX_CHAR)-1)
+#define HX_STRINGI(s,len) ::String( const_cast<char *>(("\x00\x00\x0\xc0" s)) + 4 ,len)
+#else
 #define HX_HCSTRING(s,h0,h1,h2,h3) ::String( (const HX_CHAR *)((h0 h1 h2 h3 "\x00\x00\x00\x80" s )) + 8 , sizeof(s)/sizeof(HX_CHAR)-1)
 
 #define HX_STRINGI(s,len) ::String( (const HX_CHAR *)(("\x00\x00\x0\xc0" s)) + 4 ,len)

--- a/include/hxcpp.h
+++ b/include/hxcpp.h
@@ -93,6 +93,12 @@ typedef char HX_CHAR;
 #define HXCPP_CHECK_POINTER
 #endif
 
+#ifdef HX_WINRT
+
+#define WINRT_LOG(fmt, ...) {char buf[1024];sprintf(buf,"****LOG: %s(%d): %s \n    [" fmt "]\n",__FILE__,__LINE__,__FUNCTION__, __VA_ARGS__);OutputDebugString(buf);}
+#define WINRT_PRINTF(fmt, ...) {char buf[2048];sprintf(buf,"fmt\n", __VA_ARGS__);OutputDebugString(buf);}
+
+#endif
 
 
 #ifdef BIG_ENDIAN
@@ -128,6 +134,19 @@ typedef char HX_CHAR;
 // HX_CSTRING is for constant strings without built-in hashes
 //     HX_GC_CONST_ALLOC_BIT | HX_GC_NO_STRING_HASH
 
+#ifdef HX_WINRT
+#ifdef HXCPP_BIG_ENDIAN
+
+#define HX_HCSTRING(s,h0,h1,h2,h3) ::String( const_cast<char *>((h3 h2 h1 h0 "\x80\x00\x00\x00" s )) + 8 , sizeof(s)/sizeof(HX_CHAR)-1)
+#define HX_STRINGI(s,len) ::String( const_cast<char *>(("\xc0\x00\x00\x00" s)) + 4 ,len)
+
+#else
+#define HX_HCSTRING(s,h0,h1,h2,h3) ::String( const_cast<char *>((h0 h1 h2 h3 "\x00\x00\x00\x80" s )) + 8 , sizeof(s)/sizeof(HX_CHAR)-1)
+
+#define HX_STRINGI(s,len) ::String( const_cast<char *>(("\x00\x00\x0\xc0" s)) + 4 ,len)
+#endif
+#else
+
 #ifdef HXCPP_BIG_ENDIAN
 #define HX_HCSTRING(s,h0,h1,h2,h3) ::String( (const HX_CHAR *)((h3 h2 h1 h0 "\x80\x00\x00\x00" s )) + 8 , sizeof(s)/sizeof(HX_CHAR)-1)
 #define HX_STRINGI(s,len) ::String( (const HX_CHAR *)(("\xc0\x00\x00\x00" s)) + 4 ,len)
@@ -137,7 +156,7 @@ typedef char HX_CHAR;
 
 #define HX_STRINGI(s,len) ::String( (const HX_CHAR *)(("\x00\x00\x0\xc0" s)) + 4 ,len)
 #endif
-
+#endif
 
 
 #define HX_STRI(s) HX_STRINGI(s,sizeof(s)/sizeof(HX_CHAR)-1)

--- a/project/Build.xml
+++ b/project/Build.xml
@@ -68,7 +68,7 @@
    <target id="regexp"/>
    <target id="zlib"/>
    <target id="mysql"/>
-   <target id="sqlite"/>
+   <target id="sqlite" unless="winrt"/><!-- TODO -->
    <section if="static_link">
       <target id="msvccompat" if="windows" unless="mingw||MSVC19" />
       <target id="linuxcompat" if="linux" />

--- a/project/libs/std/Sys.cpp
+++ b/project/libs/std/Sys.cpp
@@ -48,6 +48,7 @@ int __sys_prims() { return 0; }
 
 #ifdef HX_WINRT
 #include <hx/Thread.h>
+#include <hx/Tls.h>
 #endif
 
 #ifndef CLK_TCK
@@ -110,8 +111,7 @@ static value put_env( value e, value v ) {
 **/
 
 #ifdef HX_WINRT
-//DECLARE_TLS_DATA(void,tlsSleepEvent)
-__declspec(thread) void * tlsSleepEvent = nullptr;
+DECLARE_TLS_DATA(void,tlsSleepEvent)
 #endif
 
 static value sys_sleep( value f ) {

--- a/project/libs/std/Sys.cpp
+++ b/project/libs/std/Sys.cpp
@@ -110,7 +110,8 @@ static value put_env( value e, value v ) {
 **/
 
 #ifdef HX_WINRT
-DECLARE_TLS_DATA(void,tlsSleepEvent)
+//DECLARE_TLS_DATA(void,tlsSleepEvent)
+__declspec(thread) void * tlsSleepEvent = nullptr;
 #endif
 
 static value sys_sleep( value f ) {

--- a/src/hx/Debug.cpp
+++ b/src/hx/Debug.cpp
@@ -162,7 +162,6 @@ public:
 	   {
 	     auto workItemHandler = ref new WorkItemHandler([=](IAsyncAction^)
 	        {
-	            // Run the user callback.
 	            ProfileMainLoop(0);
 	        }, Platform::CallbackContext::Any);
 
@@ -420,7 +419,6 @@ public:
 		   {
 		     auto workItemHandler = ref new WorkItemHandler([=](IAsyncAction^)
 		        {
-		            // Run the user callback.
 		            ProfileMainLoop(0);
 		        }, Platform::CallbackContext::Any);
 
@@ -626,7 +624,6 @@ private:
 #ifndef HX_WINRT
             Sleep(millis);
 #else
-            // TODO
             Sleep(millis);
 #endif
 #else

--- a/src/hx/Debug.cpp
+++ b/src/hx/Debug.cpp
@@ -2267,8 +2267,14 @@ void __hxcpp_dbg_threadCreatedOrTerminated(int threadNumber, bool created)
 Dynamic __hxcpp_dbg_checkedThrow(Dynamic toThrow)
 {
     if (!hx::CallStack::CanBeCaught(toThrow)) {
+	#ifdef HX_WINRT
+	//todo
+        hx::CriticalErrorHandler(HX_CSTRING("Uncatchable Throw: " ), true);
+	
+	#else
         hx::CriticalErrorHandler(HX_CSTRING("Uncatchable Throw: " +
                                             toThrow->toString()), true);
+	#endif
       }
 
     return hx::Throw(toThrow);

--- a/src/hx/Lib.cpp
+++ b/src/hx/Lib.cpp
@@ -585,7 +585,7 @@ void *__hxcpp_get_proc_address(String inLib, String full_name,bool inNdllProc,bo
          if (gLoadDebug)
          {
             #ifdef HX_WINRT
-            ERROR_LOG(" try %s...\n", testPath.__s);
+            WINRT_LOG(" try %s...\n", testPath.__s);
 
             #elif !defined(ANDROID)
             printf(" try %s...\n", testPath.__s);

--- a/src/hx/Lib.cpp
+++ b/src/hx/Lib.cpp
@@ -599,7 +599,7 @@ void *__hxcpp_get_proc_address(String inLib, String full_name,bool inNdllProc,bo
             if (gLoadDebug)
             {
                #ifdef HX_WINRT
-                WINRT_LOG("Found %s\n", testPath.__s);
+               WINRT_LOG("Found %s\n", testPath.__s);
                #elif !defined(ANDROID)
                printf("Found %s\n", testPath.__s);
                #else

--- a/src/hx/StdLibs.cpp
+++ b/src/hx/StdLibs.cpp
@@ -354,19 +354,27 @@ Array<String> __get_args()
 
 void __hxcpp_print(Dynamic &inV)
 {
+   #ifdef HX_WINRT
+   WINRT_PRINTF("%s",inV->toString().__s);
+   #else
    #ifdef HX_UTF8_STRINGS
    printf("%s",inV->toString().__s);
    #else
    printf("%S",inV->toString().__s);
    #endif
+   #endif
 }
 
 void __hxcpp_println(Dynamic &inV)
 {
+   #ifdef HX_WINRT
+   WINRT_PRINTF("%s\n",inV->toString().__s);
+   #else
    #ifdef HX_UTF8_STRINGS
    printf("%s\n",inV->toString().__s);
    #else
    printf("%S\n",inV->toString().__s);
+   #endif
    #endif
 }
 

--- a/src/hx/gc/Immix.cpp
+++ b/src/hx/gc/Immix.cpp
@@ -854,9 +854,8 @@ namespace hx
 void BadImmixAlloc()
 {
    #ifdef HX_WINRT
-     WINRT_LOG("Bad local allocator - requesting memory from unregistered thread!");
-   #else
-   #ifdef ANDROID
+   WINRT_LOG(
+   #elif defined(ANDROID)
    __android_log_print(ANDROID_LOG_ERROR, "hxcpp",
    #else
    fprintf(stderr,
@@ -868,7 +867,6 @@ void BadImmixAlloc()
    );
    #else
    );
-   #endif
    #endif
 
    #if __has_builtin(__builtin_trap)

--- a/src/hx/gc/Immix.cpp
+++ b/src/hx/gc/Immix.cpp
@@ -853,9 +853,11 @@ namespace hx
 
 void BadImmixAlloc()
 {
+
    #ifdef HX_WINRT
-   WINRT_LOG(
-   #elif defined(ANDROID)
+   WINRT_LOG("Bad local allocator - requesting memory from unregistered thread!");
+   #else
+   #ifdef ANDROID
    __android_log_print(ANDROID_LOG_ERROR, "hxcpp",
    #else
    fprintf(stderr,
@@ -867,6 +869,7 @@ void BadImmixAlloc()
    );
    #else
    );
+   #endif
    #endif
 
    #if __has_builtin(__builtin_trap)

--- a/src/hx/gc/Immix.cpp
+++ b/src/hx/gc/Immix.cpp
@@ -154,6 +154,7 @@ int gMarkIDWithContainer = (0x10 << 24) | IMMIX_ALLOC_IS_CONTAINER;
 
 void ExitGCFreeZoneLocked();
 
+
 DECLARE_FAST_TLS_DATA(ImmixAllocator, tlsImmixAllocator);
 
 #ifdef HXCPP_SCRIPTABLE
@@ -852,10 +853,11 @@ namespace hx
 
 void BadImmixAlloc()
 {
+   #ifdef HX_WINRT
+     WINRT_LOG("Bad local allocator - requesting memory from unregistered thread!");
+   #else
    #ifdef ANDROID
    __android_log_print(ANDROID_LOG_ERROR, "hxcpp",
-   #elif defined( HX_WINRT )
-   WINRT_LOG(
    #else
    fprintf(stderr,
    #endif
@@ -866,6 +868,7 @@ void BadImmixAlloc()
    );
    #else
    );
+   #endif
    #endif
 
    #if __has_builtin(__builtin_trap)
@@ -2868,7 +2871,7 @@ public:
 	      }
 	      catch (...)
 	      {
-	         ERROR_LOG(".");
+	         WINRT_LOG(".");
 	         ok = false;
 	      }
 

--- a/toolchain/finish-setup.xml
+++ b/toolchain/finish-setup.xml
@@ -85,6 +85,7 @@
 
 <section if="isMsvc">
    <section unless="HXCPP_M64">
+      <set name="HXCPP_NO_WINXP_COMPAT" value="1" if="HX_WINRT || winrt" />
       <set name="HXCPP_WINXP_COMPAT" value="1" unless="HXCPP_NO_WINXP_COMPAT" />
    </section>
    <setup name="msvc"/>

--- a/toolchain/msvc-toolchain.xml
+++ b/toolchain/msvc-toolchain.xml
@@ -66,7 +66,6 @@
   <flag value="-Oy-"/>
   <flag value="-c"/>
   <flag value="-EHs" unless="winrt"/>
-
   <flag value="-EHsc" if="winrt"/>
   <flag value="-GS-"/>
   <flag value="-arch:SSE" unless="HXCPP_M64" />

--- a/toolchain/msvc-toolchain.xml
+++ b/toolchain/msvc-toolchain.xml
@@ -49,6 +49,7 @@
   <flag value = "/fp:precise" if="MSVC17+" />
   <flag value = "-DWINAPI_FAMILY=WINAPI_FAMILY_APP" if="winrt" />
   <flag value = "-DHX_WINRT" if="winrt" />
+  <flag value = "-errorReport:prompt" if="winrt" />
 
   <cflag value="${C_ABI}" />
   <cppflag value="${CPP_ABI}" />
@@ -64,7 +65,9 @@
   <flag value="-FS" if="HXCPP_FORCE_PDB_SERVER" />
   <flag value="-Oy-"/>
   <flag value="-c"/>
-  <flag value="-EHs"/>
+  <flag value="-EHs" unless="winrt"/>
+
+  <flag value="-EHsc" if="winrt"/>
   <flag value="-GS-"/>
   <flag value="-arch:SSE" unless="HXCPP_M64" />
   <flag value="-I${HXCPP}/include"/>

--- a/toolchain/msvc-winrt-setup.bat
+++ b/toolchain/msvc-winrt-setup.bat
@@ -1,0 +1,10 @@
+setlocal enabledelayedexpansion
+
+	@call "%VS140COMNTOOLS%\vsvars32.bat"
+		@set "INCLUDE=%ProgramFiles(x86)%\Windows Kits\10\Include;!INCLUDE!"
+		@set "PATH=%ProgramFiles(x86)%\Windows Kits\10\bin\x86;!PATH!"
+		@set "LIB=%ProgramFiles(x86)%\Windows Kits\10\Lib\10.0.10240.0\um\x86;!LIB!"
+		@set "LIBPATH=%ProgramFiles(x86)%\Microsoft Visual Studio 14.0\VC\lib\store\references;!LIBPATH!"
+
+	@echo HXCPP_VARS
+	@set

--- a/toolchain/msvc-winrt-setup.bat
+++ b/toolchain/msvc-winrt-setup.bat
@@ -1,5 +1,5 @@
 setlocal enabledelayedexpansion
-
+@if exist "%VS140COMNTOOLS%\vsvars32.bat" (
 	@call "%VS140COMNTOOLS%\vsvars32.bat"
 		@set "INCLUDE=%ProgramFiles(x86)%\Windows Kits\10\Include;!INCLUDE!"
 		@set "PATH=%ProgramFiles(x86)%\Windows Kits\10\bin\x86;!PATH!"
@@ -8,3 +8,7 @@ setlocal enabledelayedexpansion
 
 	@echo HXCPP_VARS
 	@set
+
+) else (
+	echo Warning: Could not find environment variables for Visual Studio 2015
+)

--- a/tools/hxcpp/Setup.hx
+++ b/tools/hxcpp/Setup.hx
@@ -214,7 +214,7 @@ class Setup
       }
       else if (inWhat=="msvc")
       {
-         setupMSVC(ioDefines, ioDefines.exists("HXCPP_M64"));
+         setupMSVC(ioDefines, ioDefines.exists("HXCPP_M64"), ioDefines.exists("winrt"));
       }
       else if (inWhat=="pdbserver")
       {
@@ -449,7 +449,7 @@ class Setup
       }
    }
 
-   public static function setupMSVC(ioDefines:Hash<String>, in64:Bool)
+   public static function setupMSVC(ioDefines:Hash<String>, in64:Bool, isWinRT:Bool)
    {
       var detectMsvc = !ioDefines.exists("NO_AUTO_MSVC") &&
                        !ioDefines.exists("HXCPP_MSVC_CUSTOM");
@@ -495,6 +495,7 @@ class Setup
       if (detectMsvc)
       {
          var extra = in64 ? "64" : "";
+         extra += isWinRT? "-winrt" : "";
          var xpCompat = false;
          if (ioDefines.exists("HXCPP_WINXP_COMPAT"))
          {


### PR DESCRIPTION
Hi. 

Here is our ***awesome*** contribution to make HXCPP work with Windows Universal Platform (aka WinRT for Windows 10), which includes XBOX ONE. 

-I am considering Windows 8 WinRT deprecated, but we can add flags if needed. 
-SQLLite still not compiling.
-There seems to be an issue with threading, thus "HAS_ATOMIC" is disabled.
-Had to add a separate msvc-winrt-setup.bat file to set environment variables.
-Fix DLL loading

Please give it a try ;)
