### PR TITLE
[cppia] Check if native interface functions is null when implementing vtable

### DIFF
--- a/src/hx/cppia/Cppia.cpp
+++ b/src/hx/cppia/Cppia.cpp
@@ -1698,9 +1698,11 @@ struct CppiaClassInfo
       {
          vtable.push_back( findInterfaceFunction("toString") );
          ScriptNamedFunction *functions = interface->functions;
-         for(ScriptNamedFunction *f = functions; f->name; f++)
-            if (strcmp(f->name,"toString"))
-               vtable.push_back( findInterfaceFunction(f->name) );
+         if (functions != 0) {
+            for(ScriptNamedFunction *f = functions; f->name; f++)
+               if (strcmp(f->name,"toString"))
+                  vtable.push_back( findInterfaceFunction(f->name) );
+         }
             
       }
 


### PR DESCRIPTION
Fixes hard crash when cppia is implementing an empty native interface