### PR TITLE
Automatically default to the most compatible compiler in Windows (MSVC)

### DIFF
--- a/tools/hxcpp/BuildTool.hx
+++ b/tools/hxcpp/BuildTool.hx
@@ -1357,7 +1357,7 @@ class BuildTool
             defines.set("BINDIR",m64 ? "Windows64":"Windows");
 
             // Choose between MSVC and MINGW
-            var useMsvc = false;
+            var useMsvc = true;
 
             if (defines.exists("mingw") || defines.exists("HXCPP_MINGW") || defines.exists("minimingw"))
                useMsvc = false;


### PR DESCRIPTION
If users are knowledgeable on using Mingw and are aware of some compatibility issue that may arise, they typically attempt to do Mingw compilation through `-Dmingw`, `HXCPP_MINGW` or `minimingw`.

Else, for all other users will default to the most compatible compiler for windows through MSVC.