### PR TITLE
tools: add <linker> needsQuotes attribute

### DIFF
--- a/tools/hxcpp/BuildTool.hx
+++ b/tools/hxcpp/BuildTool.hx
@@ -636,7 +636,11 @@ class BuildTool
                case "ranlib" : l.mRanLib = (substitute(el.att.name));
                case "recreate" : l.mRecreate = (substitute(el.att.value)) != "";
                case "expandAr" : l.mExpandArchives = substitute(el.att.value) != "";
-               case "fromfile" : l.mFromFile = (substitute(el.att.value));
+               case "fromfile" :
+                  if (el.has.value)
+                     l.mFromFile = substitute(el.att.value);
+                  if (el.has.needsQuotes)
+                     l.mFromFileNeedsQuotes = parseBool(substitute(el.att.needsQuotes));
                case "exe" : l.mExe = (substitute(el.att.name));
                case "section" : createLinker(el,l);
             }

--- a/tools/hxcpp/Linker.hx
+++ b/tools/hxcpp/Linker.hx
@@ -13,6 +13,7 @@ class Linker
    public var mLibDir:String;
    public var mRanLib:String;
    public var mFromFile:String;
+   public var mFromFileNeedsQuotes:Bool;
    public var mLibs:Array<String>;
    public var mExpandArchives:Bool;
    public var mRecreate:Bool;
@@ -29,6 +30,7 @@ class Linker
       mExpandArchives = false;
       // Default to on...
       mFromFile = "@";
+      mFromFileNeedsQuotes = true;
       mLibs = [];
       mRecreate = false;
    }
@@ -209,8 +211,16 @@ class Linker
             PathManager.mkdir(inCompiler.mObjDir);
             var fname = inCompiler.mObjDir + "/all_objs";
             var fout = sys.io.File.write(fname,false);
-            for(obj in objs)
-               fout.writeString('"' + obj + '"\n');
+            if (mFromFileNeedsQuotes)
+            {
+               for(obj in objs)
+                  fout.writeString('"' + obj + '"\n');
+            }
+            else
+            {
+               for(obj in objs)
+                  fout.writeString(obj + '\n');
+            }
             fout.close();
             args.push("@" + fname );
          }


### PR DESCRIPTION
Certain toolchains do not support quotes in the all_objs file.