### PR TITLE
include string.h instead of memory.h

### DIFF
--- a/include/hx/CFFI.h
+++ b/include/hx/CFFI.h
@@ -15,7 +15,7 @@ typedef struct _buffer  *buffer;
 #include "OS.h"
 #include <stdio.h>
 #include <stdlib.h>
-#include <memory.h>
+#include <string.h>
 #if defined(BLACKBERRY)
 using namespace std;
 #endif


### PR DESCRIPTION
It appears that memory.h is included for the memcpy function, but the C standard
specifies that memcpy is defined in the string.h header.

This fixes a build issue on proprietary toolchain(s).