### PR TITLE
Ignore library loading code when STATIC_LINK is defined

### DIFF
--- a/src/hx/Lib.cpp
+++ b/src/hx/Lib.cpp
@@ -207,7 +207,7 @@ typedef void (*SetLoaderProcFunc)(void *(*)(const char *));
 typedef void *(*GetNekoEntryFunc)();
 typedef void (*NekoEntryFunc)();
 
-String GetFileContents(String inFile)
+static String GetFileContents(String inFile)
 {
 #ifndef _WIN32
    FILE *file = fopen(inFile.__CStr(),"rb");
@@ -230,14 +230,14 @@ String GetFileContents(String inFile)
 }
 
 #ifndef HX_WINRT
-String GetEnv(const char *inPath)
+static String GetEnv(const char *inPath)
 {
    const char *env  = getenv(inPath);
    String result(env,env?strlen(env):0);
    return result;
 }
 
-String FindHaxelib(String inLib)
+static String FindHaxelib(String inLib)
 {
    bool loadDebug = getenv("HXCPP_LOAD_DEBUG");
 

--- a/src/hx/Lib.cpp
+++ b/src/hx/Lib.cpp
@@ -12,7 +12,7 @@
 #endif
 
 
-#if !defined(HX_WINRT) && !defined(EPPC)
+#if !defined(HX_WINRT) && !defined(STATIC_LINK)
 #include <sys/types.h>
 #include <sys/stat.h>
 #endif
@@ -229,7 +229,7 @@ static String GetFileContents(String inFile)
    return String(buf,strlen(buf)).dup();
 }
 
-#ifndef HX_WINRT
+#if !defined(HX_WINRT) && !defined(STATIC_LINK)
 static String GetEnv(const char *inPath)
 {
    const char *env  = getenv(inPath);
@@ -245,13 +245,11 @@ static String FindHaxelib(String inLib)
 
    String haxepath;
 
-   #if !defined(HX_WINRT) && !defined(EPPC)
-      struct stat s;
-      if ( (stat(".haxelib",&s)==0 && (s.st_mode & S_IFDIR) ) )
-         haxepath = HX_CSTRING(".haxelib");
-      if (loadDebug)
-          printf( haxepath.length ? "Found local .haxelib\n" : "No local .haxelib\n");
-   #endif
+   struct stat s;
+   if ( (stat(".haxelib",&s)==0 && (s.st_mode & S_IFDIR) ) )
+      haxepath = HX_CSTRING(".haxelib");
+   if (loadDebug)
+      printf( haxepath.length ? "Found local .haxelib\n" : "No local .haxelib\n");
 
    if (haxepath.length==0)
    {


### PR DESCRIPTION
Avoids the need to specialize library loading code for new platforms that only support static linking.