### PR TITLE
WinRT fixes: threads, 64bit, static compile, optional MD abi

### DIFF
--- a/include/Dynamic.h
+++ b/include/Dynamic.h
@@ -330,7 +330,7 @@ inline bool operator <= (bool inLHS,const Dynamic &inRHS) { return false; }
 inline bool operator >= (bool inLHS,const Dynamic &inRHS) { return false; }
 inline bool operator > (bool inLHS,const Dynamic &inRHS) { return false; }
 
-#ifdef HX_WINRT
+#if defined(HX_WINRT) && defined(__cplusplus_winrt)
 // Try to avoid the compiler using injected Box::operator int and Dynamic(null) when doing ==
 template<typename T>
 bool operator==(Platform::Box<T> ^inPtr, nullptr_t)

--- a/include/hx/HxcppMain.h
+++ b/include/hx/HxcppMain.h
@@ -35,7 +35,7 @@
       hxcpp_main();
    }
 
-#elif defined(HX_WINRT)
+#elif defined(HX_WINRT) && defined(__cplusplus_winrt)
 
    #include <Roapi.h>
    [ Platform::MTAThread ]

--- a/include/hx/Thread.h
+++ b/include/hx/Thread.h
@@ -48,7 +48,7 @@ inline int HxAtomicInc(volatile int *ioWhere)
 inline int HxAtomicDec(volatile int *ioWhere)
    { return __atomic_dec(ioWhere); }
 
-#elif defined(HX_WINDOWS) && !defined(HX_WINRT) //winrt test
+#elif defined(HX_WINDOWS)
 
 inline bool HxAtomicExchangeIf(int inTest, int inNewVal,volatile int *ioWhere)
    { return InterlockedCompareExchange((volatile LONG *)ioWhere, inNewVal, inTest)==inTest; }

--- a/include/hxString.h
+++ b/include/hxString.h
@@ -38,7 +38,7 @@ public:
       *this = String([inString UTF8String]);
    }
    #endif
-   #ifdef HX_WINRT
+   #if defined(HX_WINRT) && defined(__cplusplus_winrt)
    inline String(Platform::String^ inString)
    {
       *this = String(inString->Data());

--- a/project/libs/std/Random.cpp
+++ b/project/libs/std/Random.cpp
@@ -61,8 +61,10 @@ static void rnd_set_seed( rnd *r, int s ) {
 
 static rnd *rnd_init( void *data ) {
 	rnd *r = (rnd*)data;
-   #ifdef HX_WINRT
+   #if defined(HX_WINRT) && defined(__cplusplus_winrt)
 	int pid = Windows::Security::Cryptography::CryptographicBuffer::GenerateRandomNumber();
+   #elif defined(NEKO_WINDOWS)
+	int pid = GetCurrentProcessId();
    #elif defined(EPPC)
 	int pid = 1;
    #else

--- a/project/libs/std/Sys.cpp
+++ b/project/libs/std/Sys.cpp
@@ -49,6 +49,7 @@ int __sys_prims() { return 0; }
 #ifdef HX_WINRT
 #include <hx/Thread.h>
 #include <hx/Tls.h>
+#define WINRT_LOG(fmt, ...) {char buf[1024];sprintf(buf,"****LOG: %s(%d): %s \n    [" fmt "]\n",__FILE__,__LINE__,__FUNCTION__, __VA_ARGS__);OutputDebugString(buf);}
 #endif
 
 #ifndef CLK_TCK
@@ -110,14 +111,14 @@ static value put_env( value e, value v ) {
 	<doc>Sleep a given number of seconds</doc>
 **/
 
-#ifdef HX_WINRT
+#if defined(HX_WINRT) && (_WIN32_WINNT == _WIN32_WINNT_WIN8)
 DECLARE_TLS_DATA(void,tlsSleepEvent)
 #endif
 
 static value sys_sleep( value f ) {
 	val_check(f,number);
 	gc_enter_blocking();
-#ifdef HX_WINRT
+#if defined(HX_WINRT) && (_WIN32_WINNT == _WIN32_WINNT_WIN8)
    if (!tlsSleepEvent)
       tlsSleepEvent = CreateEventEx(nullptr, nullptr, CREATE_EVENT_MANUAL_RESET, EVENT_ALL_ACCESS);
    WaitForSingleObjectEx(tlsSleepEvent, (int)(val_number(f)*1000), false);
@@ -559,7 +560,7 @@ static value sys_read_dir( value p) {
 	val_check(p,string);
 
         value result = alloc_array(0);
-#ifdef HX_WINRT
+#if defined(HX_WINRT) && defined(__cplusplus_winrt)
    auto folder = (Windows::Storage::StorageFolder::GetFolderFromPathAsync( ref new Platform::String(val_wstring(p)) ))->GetResults();
    auto results = folder->GetFilesAsync(Windows::Storage::Search::CommonFileQuery::DefaultQuery)->GetResults();
    for(int i=0;i<results->Size;i++)
@@ -574,8 +575,13 @@ static value sys_read_dir( value p) {
 	WIN32_FIND_DATAW d;
 	HANDLE handle;
 	buffer b;
+	#ifdef HX_WINRT
+	std::wstring tempWStr(path);
+	std::string searchPath(tempWStr.begin(), tempWStr.end());
+	#else
    wchar_t searchPath[ MAX_PATH + 4 ];
    memcpy(searchPath,path, len*sizeof(wchar_t));
+	#endif
 
 
 	if( len && path[len-1] != '/' && path[len-1] != '\\' )
@@ -586,7 +592,11 @@ static value sys_read_dir( value p) {
    searchPath[len] = '\0';
 
 	gc_enter_blocking();
+	#ifdef HX_WINRT
+	handle = FindFirstFileEx(searchPath.c_str(), FindExInfoStandard, &d, FindExSearchNameMatch, NULL, 0);
+	#else
 	handle = FindFirstFileW(searchPath,&d);
+	#endif
 	if( handle == INVALID_HANDLE_VALUE )
 	{
 		gc_exit_blocking();
@@ -636,11 +646,16 @@ static value sys_read_dir( value p) {
 	<doc>Return an absolute path from a relative one. The file or directory must exists</doc>
 **/
 static value file_full_path( value path ) {
-#ifdef HX_WINRT
+#if defined(HX_WINRT)
+	#ifndef __cplusplus_winrt
+		printf("Sys.cpp file_full_path not implemented, compile with ABI=-ZW");
+		return path;
+	#else
    Windows::ApplicationModel::Package^ package = Windows::ApplicationModel::Package::Current;
    Windows::Storage::StorageFolder^ installedLocation = package->InstalledLocation;
    Platform::String^ output = "Installed Location: " + installedLocation->Path;
    return path;
+   #endif
 #elif defined(NEKO_WINDOWS)
 	char buf[MAX_PATH+1];
 	val_check(path,string);
@@ -663,7 +678,7 @@ static value file_full_path( value path ) {
 	<doc>Return the path of the executable</doc>
 **/
 static value sys_exe_path() {
-#ifdef HX_WINRT
+#if defined(HX_WINRT) && defined(__cplusplus_winrt)
    Windows::ApplicationModel::Package^ package = Windows::ApplicationModel::Package::Current;
    Windows::Storage::StorageFolder^ installedLocation = package->InstalledLocation;
    return(alloc_wstring(installedLocation->Path->Data()));

--- a/project/libs/std/Sys.cpp
+++ b/project/libs/std/Sys.cpp
@@ -647,15 +647,15 @@ static value sys_read_dir( value p) {
 **/
 static value file_full_path( value path ) {
 #if defined(HX_WINRT)
-	#ifndef __cplusplus_winrt
-		printf("Sys.cpp file_full_path not implemented, compile with ABI=-ZW");
-		return path;
-	#else
-   Windows::ApplicationModel::Package^ package = Windows::ApplicationModel::Package::Current;
-   Windows::Storage::StorageFolder^ installedLocation = package->InstalledLocation;
-   Platform::String^ output = "Installed Location: " + installedLocation->Path;
-   return path;
-   #endif
+	#ifdef __cplusplus_winrt
+	Windows::ApplicationModel::Package^ package = Windows::ApplicationModel::Package::Current;
+	Windows::Storage::StorageFolder^ installedLocation = package->InstalledLocation;
+	Platform::String^ output = "Installed Location: " + installedLocation->Path;
+	std::wstring tempWStr(output->Begin());
+	std::string tempStr(tempWStr.begin(), tempWStr.end());
+	WINRT_LOG("%s",tempStr.c_str());
+	#endif
+	return path;
 #elif defined(NEKO_WINDOWS)
 	char buf[MAX_PATH+1];
 	val_check(path,string);

--- a/src/Math.cpp
+++ b/src/Math.cpp
@@ -9,7 +9,7 @@
 #include <unistd.h>
 #include <sys/time.h>
 #else
-#ifdef HX_WINRT && !defined(__cplusplus_winrt)
+#if defined(HX_WINRT) && !defined(__cplusplus_winrt)
 #include <windows.h>
 #endif
 #include <process.h>

--- a/src/Math.cpp
+++ b/src/Math.cpp
@@ -9,6 +9,9 @@
 #include <unistd.h>
 #include <sys/time.h>
 #else
+#ifdef HX_WINRT && !defined(__cplusplus_winrt)
+#include <windows.h>
+#endif
 #include <process.h>
 #endif
 

--- a/src/Math.cpp
+++ b/src/Math.cpp
@@ -140,8 +140,10 @@ void Math_obj::__boot()
 	unsigned int t;
 #ifdef HX_WINDOWS
 	t = clock();
-   #ifdef HX_WINRT
-	int pid = Windows::Security::Cryptography::CryptographicBuffer::GenerateRandomNumber();
+   #if defined(HX_WINRT) && defined(__cplusplus_winrt)
+    int pid = Windows::Security::Cryptography::CryptographicBuffer::GenerateRandomNumber();
+   #elif defined(HX_WINRT) 
+    int pid = GetCurrentProcessId();
    #else
 	int pid = _getpid();
    #endif

--- a/src/hx/Debug.cpp
+++ b/src/hx/Debug.cpp
@@ -19,7 +19,7 @@
 #define DBGLOG printf
 #endif
 
-#if defined(WINRT) && (_WIN32_WINNT == _WIN32_WINNT_WIN8)
+#if defined(HX_WINRT) && (_WIN32_WINNT == _WIN32_WINNT_WIN8)
 using namespace Windows::Foundation;
 using namespace Windows::System::Threading;
 #endif
@@ -154,7 +154,7 @@ public:
    
         if (gThreadRefCount == 1) {
 #if defined(HX_WINDOWS)
-#if !(defined(WINRT) && (_WIN32_WINNT == _WIN32_WINNT_WIN8))
+#if !(defined(HX_WINRT) && (_WIN32_WINNT == _WIN32_WINNT_WIN8))
             _beginthreadex(0, 0, ProfileMainLoop, 0, 0, 0);
 #else
 	   bool ok = true;
@@ -407,7 +407,7 @@ public:
         gThreadRefCount += 1;
         if (gThreadRefCount == 1) {
 #if defined(HX_WINDOWS)
-#if !(defined(WINRT) && (_WIN32_WINNT == _WIN32_WINNT_WIN8))
+#if !(defined(HX_WINRT) && (_WIN32_WINNT == _WIN32_WINNT_WIN8))
             _beginthreadex(0, 0, ProfileMainLoop, 0, 0, 0);
 #else
 		   bool ok = true;

--- a/src/hx/Debug.cpp
+++ b/src/hx/Debug.cpp
@@ -19,7 +19,7 @@
 #define DBGLOG printf
 #endif
 
-#ifdef HX_WINRT
+#if defined(WINRT) && (_WIN32_WINNT == _WIN32_WINNT_WIN8)
 using namespace Windows::Foundation;
 using namespace Windows::System::Threading;
 #endif
@@ -154,7 +154,7 @@ public:
    
         if (gThreadRefCount == 1) {
 #if defined(HX_WINDOWS)
-#ifndef HX_WINRT
+#if !(defined(WINRT) && (_WIN32_WINNT == _WIN32_WINNT_WIN8))
             _beginthreadex(0, 0, ProfileMainLoop, 0, 0, 0);
 #else
 	   bool ok = true;
@@ -323,12 +323,7 @@ struct ProfileEntry
 
         while (gThreadRefCount > 0) { 
 #ifdef HX_WINDOWS
-#ifndef HX_WINRT
             Sleep(millis);
-#else
-            // TODO
-            Sleep(millis);
-#endif
 #else
             struct timespec t;
             struct timespec tmp;
@@ -412,7 +407,7 @@ public:
         gThreadRefCount += 1;
         if (gThreadRefCount == 1) {
 #if defined(HX_WINDOWS)
-#ifndef HX_WINRT
+#if !(defined(WINRT) && (_WIN32_WINNT == _WIN32_WINNT_WIN8))
             _beginthreadex(0, 0, ProfileMainLoop, 0, 0, 0);
 #else
 		   bool ok = true;
@@ -649,11 +644,7 @@ private:
 
         while (gThreadRefCount > 0) { 
 #ifdef HX_WINDOWS
-#ifndef HX_WINRT
             Sleep(millis);
-#else
-            Sleep(millis);
-#endif
 #else
             struct timespec t;
             struct timespec tmp;
@@ -2292,17 +2283,9 @@ void __hxcpp_dbg_threadCreatedOrTerminated(int threadNumber, bool created)
 
 Dynamic __hxcpp_dbg_checkedThrow(Dynamic toThrow)
 {
-    if (!hx::CallStack::CanBeCaught(toThrow)) {
-	#ifdef HX_WINRT
-	//todo
-        hx::CriticalErrorHandler(HX_CSTRING("Uncatchable Throw: " ), true);
-	
-	#else
-        hx::CriticalErrorHandler(HX_CSTRING("Uncatchable Throw: " +
-                                            toThrow->toString()), true);
-	#endif
-      }
-
+    if (!hx::CallStack::CanBeCaught(toThrow))
+        hx::CriticalErrorHandler(HX_CSTRING("Uncatchable Throw: ") +
+                                            toThrow->toString(), true);
     return hx::Throw(toThrow);
 }
 

--- a/src/hx/Lib.cpp
+++ b/src/hx/Lib.cpp
@@ -501,8 +501,8 @@ void *__hxcpp_get_proc_address(String inLib, String full_name,bool inNdllProc,bo
    String module_name = inLib;
    #endif
 
-   #if defined(HX_WINRT) && defined(HXCPP_DEBUG_LINK)
-   gLoadDebug = true;   
+   #if defined(HX_WINRT) && defined(HXCPP_DEBUG)
+   gLoadDebug = true;
    #elif defined(IPHONE) || defined(APPLETV)
    gLoadDebug = true;
    setenv("DYLD_PRINT_APIS","1",true);

--- a/src/hx/Lib.cpp
+++ b/src/hx/Lib.cpp
@@ -586,7 +586,6 @@ void *__hxcpp_get_proc_address(String inLib, String full_name,bool inNdllProc,bo
          {
             #ifdef HX_WINRT
             WINRT_LOG(" try %s...\n", testPath.__s);
-
             #elif !defined(ANDROID)
             printf(" try %s...\n", testPath.__s);
             #else

--- a/src/hx/StdLibs.cpp
+++ b/src/hx/StdLibs.cpp
@@ -266,7 +266,7 @@ double  __time_stamp()
 #endif
 }
 
-#if defined(HX_WINDOWS)
+#if defined(HX_WINDOWS) && !defined(HX_WINRT)
 
 /*
 ISWHITE and ParseCommandLine are based on the implementation of the 

--- a/src/hx/Thread.cpp
+++ b/src/hx/Thread.cpp
@@ -3,7 +3,7 @@
 #include <hx/Thread.h>
 #include <time.h>
 
-#if defined(WINRT) && (_WIN32_WINNT == _WIN32_WINNT_WIN8)
+#if defined(HX_WINRT) && (_WIN32_WINNT == _WIN32_WINNT_WIN8)
 using namespace Windows::Foundation;
 using namespace Windows::System::Threading;
 #endif
@@ -281,7 +281,7 @@ Dynamic __hxcpp_thread_create(Dynamic inStart)
 	hx::GCPrepareMultiThreaded();
 	hx::EnterGCFreeZone();
 
-   #if defined(WINRT) && (_WIN32_WINNT == _WIN32_WINNT_WIN8)
+   #if defined(HX_WINRT) && (_WIN32_WINNT == _WIN32_WINNT_WIN8)
 
    bool ok = true;
    try

--- a/src/hx/Thread.cpp
+++ b/src/hx/Thread.cpp
@@ -3,7 +3,7 @@
 #include <hx/Thread.h>
 #include <time.h>
 
-#ifdef HX_WINRT
+#if defined(WINRT) && (_WIN32_WINNT == _WIN32_WINNT_WIN8)
 using namespace Windows::Foundation;
 using namespace Windows::System::Threading;
 #endif
@@ -281,7 +281,7 @@ Dynamic __hxcpp_thread_create(Dynamic inStart)
 	hx::GCPrepareMultiThreaded();
 	hx::EnterGCFreeZone();
 
-   #if defined(HX_WINRT)
+   #if defined(WINRT) && (_WIN32_WINNT == _WIN32_WINNT_WIN8)
 
    bool ok = true;
    try

--- a/src/hx/gc/GcRegCapture.h
+++ b/src/hx/gc/GcRegCapture.h
@@ -10,7 +10,7 @@ namespace hx
 #define HXCPP_CAPTURE_x86
 #endif
 
-#if (defined(HX_MACOS) || defined(HX_WINDOWS)) && defined(HXCPP_M64)
+#if (defined(HX_MACOS) || defined(HX_WINDOWS)) && defined(HXCPP_M64) && !defined(HX_WINRT)
 #define HXCPP_CAPTURE_x64
 #endif
 

--- a/src/hx/gc/Immix.cpp
+++ b/src/hx/gc/Immix.cpp
@@ -120,8 +120,7 @@ static int sgAllocsSinceLastSpam = 0;
 #define GCLOG printf
 #endif
 
-
-#ifdef HX_WINRT
+#if defined(WINRT) && (_WIN32_WINNT == _WIN32_WINNT_WIN8)
 using namespace Windows::Foundation;
 using namespace Windows::System::Threading;
 #endif
@@ -294,8 +293,9 @@ MID = ENDIAN_MARK_ID_BYTE = is measured from the object pointer
 void CriticalGCError(const char *inMessage)
 {
    // Can't perfrom normal handling because it needs the GC system
-
-   #ifdef ANDROID
+   #ifdef HX_WINRT
+      WINRT_LOG("HXCPP Critical Error: %s\n", inMessage);
+   #elif ANDROID
    __android_log_print(ANDROID_LOG_ERROR, "HXCPP", "Critical Error: %s", inMessage);
    #else
    printf("Critical Error: %s\n", inMessage);
@@ -328,7 +328,7 @@ typedef MyMutex ThreadPoolLock;
 
 static ThreadPoolLock sThreadPoolLock;
 
-#if !defined(HX_WINDOWS) && !defined(EMSCRIPTEN) && !defined(HX_WINRT)
+#if !defined(HX_WINDOWS) && !defined(EMSCRIPTEN)
 #define HX_GC_PTHREADS
 typedef pthread_cond_t ThreadPoolSignal;
 inline void WaitThreadLocked(ThreadPoolSignal &ioSignal)
@@ -2906,7 +2906,7 @@ public:
          int created = pthread_create(&result,0,SThreadLoop,info);
          bool ok = created==0;
       #else
-         #ifdef HX_WINRT
+         #if defined(WINRT) && (_WIN32_WINNT == _WIN32_WINNT_WIN8)
 	      bool ok = true;
 	      try
 	      {

--- a/src/hx/gc/Immix.cpp
+++ b/src/hx/gc/Immix.cpp
@@ -120,7 +120,7 @@ static int sgAllocsSinceLastSpam = 0;
 #define GCLOG printf
 #endif
 
-#if defined(WINRT) && (_WIN32_WINNT == _WIN32_WINNT_WIN8)
+#if defined(HX_WINRT) && (_WIN32_WINNT == _WIN32_WINNT_WIN8)
 using namespace Windows::Foundation;
 using namespace Windows::System::Threading;
 #endif
@@ -2906,7 +2906,7 @@ public:
          int created = pthread_create(&result,0,SThreadLoop,info);
          bool ok = created==0;
       #else
-         #if defined(WINRT) && (_WIN32_WINNT == _WIN32_WINNT_WIN8)
+         #if defined(HX_WINRT) && (_WIN32_WINNT == _WIN32_WINNT_WIN8)
 	      bool ok = true;
 	      try
 	      {

--- a/toolchain/msvc-toolchain.xml
+++ b/toolchain/msvc-toolchain.xml
@@ -7,14 +7,12 @@
 
 <set name="USE_PRECOMPILED_HEADERS" value="msvc" unless="NO_PRECOMPILED_HEADERS" />
 
-
 <set name="ABI" value="-MD" if="winrt static_link HXCPP_WINRT_NATIVE_LIBS" unless="ABI"/>
-<set name="C_ABI" value="${ABI}" if="ABI"/>
-<section unless="ABI">
-   <set name="ABI" value="-MT"/>
-   <set name="C_ABI" value="${ABI}" />
-   <set name="ABI" value="-ZW" if="winrt" />
-</section>
+<set name="ABI" value="-MT" unless="ABI"/>
+<set name="C_ABI" value="${ABI}" />
+
+<set name="ABI" value="-ZW" if="winrt" unless="ABI"/>
+
 <set name="CPP_ABI" value="${ABI}" />
 
 <set name="XPOBJ" value="xp" if="HXCPP_WINXP_COMPAT" />
@@ -123,7 +121,7 @@
   <flag value="-MANIFEST:NO" />
   <flag value="-WINMD" />
   <flag value="-APPCONTAINER" />
-  <flag value="-WINMDFILE:obj/msvc${MSVC_VER}-rt${OBJEXT}/app.winmd"  unless="HXCPP_WINRT_NATIVE_LIBS"/>
+  <flag value="-WINMDFILE:obj/msvc${MSVC_VER}-rt${OBJEXT}/app.winmd" />
   <flag value="-DYNAMICBASE" />
   <flag value="-NXCOMPAT" />
   <flag value="-libpath:lib"/>

--- a/toolchain/msvc-toolchain.xml
+++ b/toolchain/msvc-toolchain.xml
@@ -8,7 +8,7 @@
 <set name="USE_PRECOMPILED_HEADERS" value="msvc" unless="NO_PRECOMPILED_HEADERS" />
 
 
-<!--<set name="ABI" value="-MD" if="winrt static_link" unless="ABI"/>-->
+<set name="ABI" value="-MD" if="winrt static_link HXCPP_WINRT_MD" unless="ABI"/>
 <set name="C_ABI" value="${ABI}" if="ABI"/>
 <section unless="ABI">
    <set name="ABI" value="-MT"/>
@@ -123,7 +123,7 @@
   <flag value="-MANIFEST:NO" />
   <flag value="-WINMD" />
   <flag value="-APPCONTAINER" />
-  <flag value="-WINMDFILE:obj/msvc${MSVC_VER}-rt${OBJEXT}/app.winmd"  unless="static_link"/>
+  <flag value="-WINMDFILE:obj/msvc${MSVC_VER}-rt${OBJEXT}/app.winmd"  unless="HXCPP_WINRT_MD"/>
   <flag value="-DYNAMICBASE" />
   <flag value="-NXCOMPAT" />
   <flag value="-libpath:lib"/>
@@ -135,7 +135,7 @@
 <linker id="static_link" exe="lib.exe" if="windows">
   <fromfile value="@"/>
   <flag value="-nologo"/>
-  <!--<flag value="-IGNORE: 4264" if="winrt static_link"/>-->
+  <flag value="-IGNORE: 4264" if="winrt static_link" unless="HXCPP_WINRT_MD"/>
   <ext value="${LIBEXT}"/>
   <outflag value="-out:"/>
 </linker>

--- a/toolchain/msvc-toolchain.xml
+++ b/toolchain/msvc-toolchain.xml
@@ -7,12 +7,11 @@
 
 <set name="USE_PRECOMPILED_HEADERS" value="msvc" unless="NO_PRECOMPILED_HEADERS" />
 
-<set name="ABI" value="-MD" if="winrt static_link HXCPP_WINRT_NATIVE_LIBS" unless="ABI"/>
+<set name="ABI" value="-MD" if="winrt static_link" unless="ABI"/>
 <set name="ABI" value="-MT" unless="ABI"/>
 <set name="C_ABI" value="${ABI}" />
 
 <set name="ABI" value="-ZW" if="winrt" unless="ABI"/>
-
 <set name="CPP_ABI" value="${ABI}" />
 
 <set name="XPOBJ" value="xp" if="HXCPP_WINXP_COMPAT" />
@@ -133,7 +132,6 @@
 <linker id="static_link" exe="lib.exe" if="windows">
   <fromfile value="@"/>
   <flag value="-nologo"/>
-  <flag value="-IGNORE: 4264" if="winrt static_link" unless="HXCPP_WINRT_NATIVE_LIBS"/>
   <ext value="${LIBEXT}"/>
   <outflag value="-out:"/>
 </linker>

--- a/toolchain/msvc-toolchain.xml
+++ b/toolchain/msvc-toolchain.xml
@@ -8,7 +8,7 @@
 <set name="USE_PRECOMPILED_HEADERS" value="msvc" unless="NO_PRECOMPILED_HEADERS" />
 
 
-<set name="ABI" value="-MD" if="winrt static_link HXCPP_WINRT_MD" unless="ABI"/>
+<set name="ABI" value="-MD" if="winrt static_link HXCPP_WINRT_NATIVE_LIBS" unless="ABI"/>
 <set name="C_ABI" value="${ABI}" if="ABI"/>
 <section unless="ABI">
    <set name="ABI" value="-MT"/>
@@ -123,7 +123,7 @@
   <flag value="-MANIFEST:NO" />
   <flag value="-WINMD" />
   <flag value="-APPCONTAINER" />
-  <flag value="-WINMDFILE:obj/msvc${MSVC_VER}-rt${OBJEXT}/app.winmd"  unless="HXCPP_WINRT_MD"/>
+  <flag value="-WINMDFILE:obj/msvc${MSVC_VER}-rt${OBJEXT}/app.winmd"  unless="HXCPP_WINRT_NATIVE_LIBS"/>
   <flag value="-DYNAMICBASE" />
   <flag value="-NXCOMPAT" />
   <flag value="-libpath:lib"/>
@@ -135,7 +135,7 @@
 <linker id="static_link" exe="lib.exe" if="windows">
   <fromfile value="@"/>
   <flag value="-nologo"/>
-  <flag value="-IGNORE: 4264" if="winrt static_link" unless="HXCPP_WINRT_MD"/>
+  <flag value="-IGNORE: 4264" if="winrt static_link" unless="HXCPP_WINRT_NATIVE_LIBS"/>
   <ext value="${LIBEXT}"/>
   <outflag value="-out:"/>
 </linker>

--- a/toolchain/msvc-toolchain.xml
+++ b/toolchain/msvc-toolchain.xml
@@ -7,10 +7,14 @@
 
 <set name="USE_PRECOMPILED_HEADERS" value="msvc" unless="NO_PRECOMPILED_HEADERS" />
 
-<set name="ABI" value="-MT" unless="ABI"/>
-<set name="C_ABI" value="${ABI}" />
 
-<set name="ABI" value="-ZW" if="winrt" />
+<!--<set name="ABI" value="-MD" if="winrt static_link" unless="ABI"/>-->
+<set name="C_ABI" value="${ABI}" if="ABI"/>
+<section unless="ABI">
+   <set name="ABI" value="-MT"/>
+   <set name="C_ABI" value="${ABI}" />
+   <set name="ABI" value="-ZW" if="winrt" />
+</section>
 <set name="CPP_ABI" value="${ABI}" />
 
 <set name="XPOBJ" value="xp" if="HXCPP_WINXP_COMPAT" />
@@ -113,13 +117,13 @@
 <linker id="exe" exe="link.exe" if="winrt">
   <fromfile value="@"/>
   <flag value="-nologo"/>
-  <flag value="-machine:x86"/>
+  <flag value="-machine:${MACHINE}"/>
   <flag value="-debug" if="HXCPP_DEBUG_LINK"/>
   <flag value="-subsystem:windows" />
   <flag value="-MANIFEST:NO" />
   <flag value="-WINMD" />
   <flag value="-APPCONTAINER" />
-  <flag value="-WINMDFILE:obj/msvc${MSVC_VER}-rt${OBJEXT}/app.winmd" />
+  <flag value="-WINMDFILE:obj/msvc${MSVC_VER}-rt${OBJEXT}/app.winmd"  unless="static_link"/>
   <flag value="-DYNAMICBASE" />
   <flag value="-NXCOMPAT" />
   <flag value="-libpath:lib"/>
@@ -131,6 +135,7 @@
 <linker id="static_link" exe="lib.exe" if="windows">
   <fromfile value="@"/>
   <flag value="-nologo"/>
+  <!--<flag value="-IGNORE: 4264" if="winrt static_link"/>-->
   <ext value="${LIBEXT}"/>
   <outflag value="-out:"/>
 </linker>

--- a/toolchain/msvc-winrt-setup.bat
+++ b/toolchain/msvc-winrt-setup.bat
@@ -1,23 +1,12 @@
 setlocal enabledelayedexpansion
 @if exist "%VS140COMNTOOLS%\vsvars32.bat" (
-        FOR /F "usebackq skip=4 tokens=1-3" %%A IN (`REG QUERY "HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\Windows Kits\Installed Roots" /v KitsRoot10 2^>nul`) DO (
-            set KitsRoot10Path=%%C
-        )
-        if defined KitsRoot10Path (
-            @call "%VS140COMNTOOLS%\vsvars32.bat"
-            @set "INCLUDE=%KitsRoot10Path%Include;!INCLUDE!"
-            @set "PATH=%KitsRoot10Path%bin\x86;!PATH!"
-            @if exist "%KitsRoot10Path%Lib\10.0.10586.0" (
-                @set "LIB=%KitsRoot10Path%Lib\10.0.10586.0\um\x86;!LIB!"
-            ) else ( 
-                @set "LIB=%KitsRoot10Path%Lib\10.0.10240.0\um\x86;!LIB!"
-            )
-            @set "LIBPATH=%ProgramFiles(x86)%\Microsoft Visual Studio 14.0\VC\lib\store\references;!LIBPATH!"
-            @echo HXCPP_VARS
-            @set
-        ) else (
-            echo Warning: Could not find Windows 10 Kits Path
-        )
+        @call "%VS140COMNTOOLS%\vsvars32.bat"
+        @set "INCLUDE=%ProgramFiles(x86)%\Windows Kits\10\Include;!INCLUDE!"
+        @set "PATH=%ProgramFiles(x86)%\Windows Kits\10\bin\x86;!PATH!"
+        @set "LIB=%ProgramFiles(x86)%\Windows Kits\10\Lib\10.0.10586.0\um\x86;!LIB!"
+        @set "LIBPATH=%ProgramFiles(x86)%\Microsoft Visual Studio 14.0\VC\lib\store\references;!LIBPATH!"
+        @echo HXCPP_VARS
+        @set
 ) else (   
     echo Warning: Could not find environment variables for Visual Studio 2015
 )

--- a/toolchain/msvc-winrt-setup.bat
+++ b/toolchain/msvc-winrt-setup.bat
@@ -1,12 +1,12 @@
 setlocal enabledelayedexpansion
 @if exist "%VS140COMNTOOLS%\vsvars32.bat" (
-        @call "%VS140COMNTOOLS%\vsvars32.bat"
-        @set "INCLUDE=%ProgramFiles(x86)%\Windows Kits\10\Include;!INCLUDE!"
-        @set "PATH=%ProgramFiles(x86)%\Windows Kits\10\bin\x86;!PATH!"
-        @set "LIB=%ProgramFiles(x86)%\Windows Kits\10\Lib\10.0.10586.0\um\x86;!LIB!"
-        @set "LIBPATH=%ProgramFiles(x86)%\Microsoft Visual Studio 14.0\VC\lib\store\references;!LIBPATH!"
-        @echo HXCPP_VARS
-        @set
+    @call "%VS140COMNTOOLS%\vsvars32.bat"
+        @set "INCLUDE=%WindowsSdkDir%Include;!INCLUDE!"
+        @set "PATH=%WindowsSdkDir%bin\x86;!PATH!"
+        @set "LIB=%WindowsSdkDir%Lib\%WindowsSDKLibVersion%um\x86;!LIB!"
+        @set "LIBPATH=%VS140COMNTOOLS%\..\..\VC\lib\store\references;!LIBPATH!"
+    @echo HXCPP_VARS
+    @set
 ) else (   
     echo Warning: Could not find environment variables for Visual Studio 2015
 )

--- a/toolchain/msvc-winrt-setup.bat
+++ b/toolchain/msvc-winrt-setup.bat
@@ -1,14 +1,19 @@
 setlocal enabledelayedexpansion
 @if exist "%VS140COMNTOOLS%\vsvars32.bat" (
-	@call "%VS140COMNTOOLS%\vsvars32.bat"
-		@set "INCLUDE=%ProgramFiles(x86)%\Windows Kits\10\Include;!INCLUDE!"
-		@set "PATH=%ProgramFiles(x86)%\Windows Kits\10\bin\x86;!PATH!"
-		@set "LIB=%ProgramFiles(x86)%\Windows Kits\10\Lib\10.0.10240.0\um\x86;!LIB!"
-		@set "LIBPATH=%ProgramFiles(x86)%\Microsoft Visual Studio 14.0\VC\lib\store\references;!LIBPATH!"
-
-	@echo HXCPP_VARS
-	@set
-
+        FOR /F "usebackq skip=2 tokens=1-3" %%A IN (`REG QUERY "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows" /v CurrentVersion 2^>nul`) DO (
+            set CurrentSDKVersion=%%C
+        )
+        if defined CurrentSDKVersion (
+            @call "%VS140COMNTOOLS%\vsvars32.bat"
+            @set "INCLUDE=%ProgramFiles(x86)%\Windows Kits\10\Include;!INCLUDE!"
+            @set "PATH=%ProgramFiles(x86)%\Windows Kits\10\bin\x86;!PATH!"
+            @set "LIB=%ProgramFiles(x86)%\Windows Kits\10\Lib\%CurrentSDKVersion%\um\x86;!LIB!"
+            @set "LIBPATH=%ProgramFiles(x86)%\Microsoft Visual Studio 14.0\VC\lib\store\references;!LIBPATH!"
+            @echo HXCPP_VARS
+            @set
+        ) else (
+            echo Warning: Could not find Windows SDK
+        )
 ) else (
 	echo Warning: Could not find environment variables for Visual Studio 2015
 )

--- a/toolchain/msvc-winrt-setup.bat
+++ b/toolchain/msvc-winrt-setup.bat
@@ -1,19 +1,23 @@
 setlocal enabledelayedexpansion
 @if exist "%VS140COMNTOOLS%\vsvars32.bat" (
-        FOR /F "usebackq skip=2 tokens=1-3" %%A IN (`REG QUERY "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows" /v CurrentVersion 2^>nul`) DO (
-            set CurrentSDKVersion=%%C
+        FOR /F "usebackq skip=4 tokens=1-3" %%A IN (`REG QUERY "HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\Windows Kits\Installed Roots" /v KitsRoot10 2^>nul`) DO (
+            set KitsRoot10Path=%%C
         )
-        if defined CurrentSDKVersion (
+        if defined KitsRoot10Path (
             @call "%VS140COMNTOOLS%\vsvars32.bat"
-            @set "INCLUDE=%ProgramFiles(x86)%\Windows Kits\10\Include;!INCLUDE!"
-            @set "PATH=%ProgramFiles(x86)%\Windows Kits\10\bin\x86;!PATH!"
-            @set "LIB=%ProgramFiles(x86)%\Windows Kits\10\Lib\%CurrentSDKVersion%\um\x86;!LIB!"
+            @set "INCLUDE=%KitsRoot10Path%Include;!INCLUDE!"
+            @set "PATH=%KitsRoot10Path%bin\x86;!PATH!"
+            @if exist "%KitsRoot10Path%Lib\10.0.10586.0" (
+                @set "LIB=%KitsRoot10Path%Lib\10.0.10586.0\um\x86;!LIB!"
+            ) else ( 
+                @set "LIB=%KitsRoot10Path%Lib\10.0.10240.0\um\x86;!LIB!"
+            )
             @set "LIBPATH=%ProgramFiles(x86)%\Microsoft Visual Studio 14.0\VC\lib\store\references;!LIBPATH!"
             @echo HXCPP_VARS
             @set
         ) else (
-            echo Warning: Could not find Windows SDK
+            echo Warning: Could not find Windows 10 Kits Path
         )
-) else (
-	echo Warning: Could not find environment variables for Visual Studio 2015
+) else (   
+    echo Warning: Could not find environment variables for Visual Studio 2015
 )

--- a/toolchain/msvc-winrt64-setup.bat
+++ b/toolchain/msvc-winrt64-setup.bat
@@ -1,0 +1,14 @@
+setlocal enabledelayedexpansion
+@if exist "%VS140COMNTOOLS%\..\..\VC\bin\x86_amd64\vcvarsx86_amd64.bat" (
+    @call "%VS140COMNTOOLS%\..\..\VC\bin\x86_amd64\vcvarsx86_amd64.bat"
+		@set "INCLUDE=%ProgramFiles(x86)%\Windows Kits\10\Include;!INCLUDE!"
+		@set "PATH=%ProgramFiles(x86)%\Windows Kits\10\bin\x64;!PATH!"
+		@set "LIB=%ProgramFiles(x86)%\Windows Kits\10\Lib\10.0.10240.0\um\x64;!LIB!"
+		@set "LIBPATH=%ProgramFiles(x86)%\Microsoft Visual Studio 14.0\VC\lib\store\references;!LIBPATH!"
+
+	@echo HXCPP_VARS
+	@set
+
+) else (
+	echo Warning: Could not find x64 environment variables for Visual Studio 2015
+)

--- a/toolchain/msvc-winrt64-setup.bat
+++ b/toolchain/msvc-winrt64-setup.bat
@@ -5,10 +5,9 @@ setlocal enabledelayedexpansion
 		@set "PATH=%ProgramFiles(x86)%\Windows Kits\10\bin\x64;!PATH!"
 		@set "LIB=%ProgramFiles(x86)%\Windows Kits\10\Lib\10.0.10240.0\um\x64;!LIB!"
 		@set "LIBPATH=%ProgramFiles(x86)%\Microsoft Visual Studio 14.0\VC\lib\store\references;!LIBPATH!"
-
-	@echo HXCPP_VARS
-	@set
-
+		@echo HXCPP_VARS
+		@set
+		@echo HXCPP_HACK_PDBSRV=1
 ) else (
 	echo Warning: Could not find x64 environment variables for Visual Studio 2015
 )

--- a/toolchain/msvc-winrt64-setup.bat
+++ b/toolchain/msvc-winrt64-setup.bat
@@ -1,24 +1,13 @@
 setlocal enabledelayedexpansion
 @if exist "%VS140COMNTOOLS%\..\..\VC\bin\x86_amd64\vcvarsx86_amd64.bat" (
-        FOR /F "usebackq skip=4 tokens=1-3" %%A IN (`REG QUERY "HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\Windows Kits\Installed Roots" /v KitsRoot10 2^>nul`) DO (
-            set KitsRoot10Path=%%C
-        )
-        @if defined KitsRoot10Path ( 
-            @call "%VS140COMNTOOLS%\..\..\VC\bin\x86_amd64\vcvarsx86_amd64.bat"
-            @set "INCLUDE=%KitsRoot10Path%Include;!INCLUDE!"
-            @set "PATH=%KitsRoot10Path%bin\x64;!PATH!"
-            @if exist "%KitsRoot10Path%Lib\10.0.10586.0" (
-                @set "LIB=%KitsRoot10Path%Lib\10.0.10586.0\um\x64;!LIB!"
-            ) else ( 
-                @set "LIB=%KitsRoot10Path%Lib\10.0.10240.0\um\x64;!LIB!"
-            )
-            @set "LIBPATH=%ProgramFiles(x86)%\Microsoft Visual Studio 14.0\VC\lib\store\references;!LIBPATH!"
-            @echo HXCPP_VARS
-            @set
-            @echo HXCPP_HACK_PDBSRV=1
-        ) else (
-            echo Warning: Could not find Windows Kits Root path
-        )
+        @call "%VS140COMNTOOLS%\..\..\VC\bin\x86_amd64\vcvarsx86_amd64.bat"
+        @set "INCLUDE=%ProgramFiles(x86)%\Windows Kits\10\Include;!INCLUDE!"
+        @set "PATH=%ProgramFiles(x86)%\Windows Kits\10\bin\x64;!PATH!"
+        @set "LIB=%ProgramFiles(x86)%\Windows Kits\10\Lib\10.0.10586.0\um\x64;!LIB!"
+        @set "LIBPATH=%ProgramFiles(x86)%\Microsoft Visual Studio 14.0\VC\lib\store\references;!LIBPATH!"
+        @echo HXCPP_VARS
+        @set
+        @echo HXCPP_HACK_PDBSRV=1
 ) else (
 	echo Warning: Could not find x64 environment variables for Visual Studio 2015
 )

--- a/toolchain/msvc-winrt64-setup.bat
+++ b/toolchain/msvc-winrt64-setup.bat
@@ -1,13 +1,20 @@
 setlocal enabledelayedexpansion
 @if exist "%VS140COMNTOOLS%\..\..\VC\bin\x86_amd64\vcvarsx86_amd64.bat" (
-    @call "%VS140COMNTOOLS%\..\..\VC\bin\x86_amd64\vcvarsx86_amd64.bat"
-		@set "INCLUDE=%ProgramFiles(x86)%\Windows Kits\10\Include;!INCLUDE!"
-		@set "PATH=%ProgramFiles(x86)%\Windows Kits\10\bin\x64;!PATH!"
-		@set "LIB=%ProgramFiles(x86)%\Windows Kits\10\Lib\10.0.10240.0\um\x64;!LIB!"
-		@set "LIBPATH=%ProgramFiles(x86)%\Microsoft Visual Studio 14.0\VC\lib\store\references;!LIBPATH!"
-		@echo HXCPP_VARS
-		@set
-		@echo HXCPP_HACK_PDBSRV=1
+        FOR /F "usebackq skip=2 tokens=1-3" %%A IN (`REG QUERY "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows" /v CurrentVersion 2^>nul`) DO (
+            set CurrentSDKVersion=%%C
+        )
+        if defined CurrentSDKVersion (    
+	    @call "%VS140COMNTOOLS%\..\..\VC\bin\x86_amd64\vcvarsx86_amd64.bat"
+            @set "INCLUDE=%ProgramFiles(x86)%\Windows Kits\10\Include;!INCLUDE!"
+            @set "PATH=%ProgramFiles(x86)%\Windows Kits\10\bin\x64;!PATH!"
+            @set "LIB=%ProgramFiles(x86)%\Windows Kits\10\Lib\%CurrentSDKVersion%\um\x64;!LIB!"
+            @set "LIBPATH=%ProgramFiles(x86)%\Microsoft Visual Studio 14.0\VC\lib\store\references;!LIBPATH!"
+            @echo HXCPP_VARS
+            @set
+            @echo HXCPP_HACK_PDBSRV=1
+        ) else (
+            echo Warning: Could not find Windows SDK
+        )
 ) else (
 	echo Warning: Could not find x64 environment variables for Visual Studio 2015
 )

--- a/toolchain/msvc-winrt64-setup.bat
+++ b/toolchain/msvc-winrt64-setup.bat
@@ -1,19 +1,23 @@
 setlocal enabledelayedexpansion
 @if exist "%VS140COMNTOOLS%\..\..\VC\bin\x86_amd64\vcvarsx86_amd64.bat" (
-        FOR /F "usebackq skip=2 tokens=1-3" %%A IN (`REG QUERY "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows" /v CurrentVersion 2^>nul`) DO (
-            set CurrentSDKVersion=%%C
+        FOR /F "usebackq skip=4 tokens=1-3" %%A IN (`REG QUERY "HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\Windows Kits\Installed Roots" /v KitsRoot10 2^>nul`) DO (
+            set KitsRoot10Path=%%C
         )
-        if defined CurrentSDKVersion (    
-	    @call "%VS140COMNTOOLS%\..\..\VC\bin\x86_amd64\vcvarsx86_amd64.bat"
-            @set "INCLUDE=%ProgramFiles(x86)%\Windows Kits\10\Include;!INCLUDE!"
-            @set "PATH=%ProgramFiles(x86)%\Windows Kits\10\bin\x64;!PATH!"
-            @set "LIB=%ProgramFiles(x86)%\Windows Kits\10\Lib\%CurrentSDKVersion%\um\x64;!LIB!"
+        @if defined KitsRoot10Path ( 
+            @call "%VS140COMNTOOLS%\..\..\VC\bin\x86_amd64\vcvarsx86_amd64.bat"
+            @set "INCLUDE=%KitsRoot10Path%Include;!INCLUDE!"
+            @set "PATH=%KitsRoot10Path%bin\x64;!PATH!"
+            @if exist "%KitsRoot10Path%Lib\10.0.10586.0" (
+                @set "LIB=%KitsRoot10Path%Lib\10.0.10586.0\um\x64;!LIB!"
+            ) else ( 
+                @set "LIB=%KitsRoot10Path%Lib\10.0.10240.0\um\x64;!LIB!"
+            )
             @set "LIBPATH=%ProgramFiles(x86)%\Microsoft Visual Studio 14.0\VC\lib\store\references;!LIBPATH!"
-            @echo HXCPP_VARS
+            '@echo HXCPP_VARS
             @set
             @echo HXCPP_HACK_PDBSRV=1
         ) else (
-            echo Warning: Could not find Windows SDK
+            echo Warning: Could not find Windows Kits Root path
         )
 ) else (
 	echo Warning: Could not find x64 environment variables for Visual Studio 2015

--- a/toolchain/msvc-winrt64-setup.bat
+++ b/toolchain/msvc-winrt64-setup.bat
@@ -1,13 +1,13 @@
 setlocal enabledelayedexpansion
 @if exist "%VS140COMNTOOLS%\..\..\VC\bin\x86_amd64\vcvarsx86_amd64.bat" (
-        @call "%VS140COMNTOOLS%\..\..\VC\bin\x86_amd64\vcvarsx86_amd64.bat"
-        @set "INCLUDE=%ProgramFiles(x86)%\Windows Kits\10\Include;!INCLUDE!"
-        @set "PATH=%ProgramFiles(x86)%\Windows Kits\10\bin\x64;!PATH!"
-        @set "LIB=%ProgramFiles(x86)%\Windows Kits\10\Lib\10.0.10586.0\um\x64;!LIB!"
-        @set "LIBPATH=%ProgramFiles(x86)%\Microsoft Visual Studio 14.0\VC\lib\store\references;!LIBPATH!"
-        @echo HXCPP_VARS
-        @set
-        @echo HXCPP_HACK_PDBSRV=1
+    @call "%VS140COMNTOOLS%\..\..\VC\bin\x86_amd64\vcvarsx86_amd64.bat"
+        @set "INCLUDE=%WindowsSdkDir%Include;!INCLUDE!"
+        @set "PATH=%WindowsSdkDir%bin\x64;!PATH!"
+        @set "LIB=%WindowsSdkDir%Lib\%WindowsSDKLibVersion%um\x86;!LIB!"
+        @set "LIBPATH=%VS140COMNTOOLS%\..\..\VC\lib\store\references;!LIBPATH!"
+    @echo HXCPP_VARS
+    @set
+    @echo HXCPP_HACK_PDBSRV=1
 ) else (
 	echo Warning: Could not find x64 environment variables for Visual Studio 2015
 )

--- a/toolchain/msvc-winrt64-setup.bat
+++ b/toolchain/msvc-winrt64-setup.bat
@@ -13,7 +13,7 @@ setlocal enabledelayedexpansion
                 @set "LIB=%KitsRoot10Path%Lib\10.0.10240.0\um\x64;!LIB!"
             )
             @set "LIBPATH=%ProgramFiles(x86)%\Microsoft Visual Studio 14.0\VC\lib\store\references;!LIBPATH!"
-            '@echo HXCPP_VARS
+            @echo HXCPP_VARS
             @set
             @echo HXCPP_HACK_PDBSRV=1
         ) else (

--- a/tools/hxcpp/BuildTool.hx
+++ b/tools/hxcpp/BuildTool.hx
@@ -1381,7 +1381,7 @@ class BuildTool
             {
                defines.set("toolchain","msvc");
                if ( defines.exists("winrt") )
-                  defines.set("BINDIR",m64 ? "WinRTx64":"WinRTx86");
+                  defines.set("BINDIR",m64 ? "WinRT64":"WinRT");
             }
             else
             {

--- a/tools/hxcpp/Setup.hx
+++ b/tools/hxcpp/Setup.hx
@@ -494,8 +494,11 @@ class Setup
 
       if (detectMsvc)
       {
-         var extra = in64 ? "64" : "";
-         extra += isWinRT? "-winrt" : "";
+        var extra:String = "";
+        if( isWinRT )
+            extra += "-winrt";
+        if( in64 )
+            extra += "64";
          var xpCompat = false;
          if (ioDefines.exists("HXCPP_WINXP_COMPAT"))
          {


### PR DESCRIPTION
Removed some WinRT code since now it is available in Windows 10 UWP and
previusly unavailable in Windows Store 8. Using 

    (_WIN32_WINNT == _WIN32_WINNT_WIN8) 

in case that someone is still interested in compiling for WinRT for Windows 8, but requires to fix toolchain.  

Encapsulated code for store-api with   

    defined(__cplusplus_winrt) 

so it can compile with the  -MD abi (-DABI="-MD" or -DHXCPP_WINRT_NATIVE_LIBS flags)

In this way, you can compile your
static libs for winrt more similar to C++ and only need to use the store-api in a Main.cpp file compiled with the ZW abi. Reference: https://msdn.microsoft.com/en-us/library/mt186162.aspx