### PR TITLE
Add Android arm64-v8a toolchain using HXCPP_ARM64 and -64 for LIBEXTRA

### DIFF
--- a/hxcpp/Builder.hx
+++ b/hxcpp/Builder.hx
@@ -162,6 +162,7 @@ class Builder
                case "android":
                   validArchs.set("armv5", ["-Dandroid"].concat(staticFlags) );
                   validArchs.set("armv7", ["-Dandroid", "-DHXCPP_ARMV7"].concat(staticFlags) );
+                  validArchs.set("arm64", ["-Dandroid", "-DHXCPP_ARM64"].concat(staticFlags) );
                   validArchs.set("x86", ["-Dandroid", "-DHXCPP_X86"].concat(staticFlags) );
                
                case "blackberry":

--- a/toolchain/android-toolchain.xml
+++ b/toolchain/android-toolchain.xml
@@ -12,6 +12,7 @@
 <set name="NDKV7" value="1" unless="NDKV8" />
 <unset name="NDKV7" if="NDKV6" />
 
+<set name="NDKV10+" value="1" if="NDKV10" />
 <set name="NDKV9+" value="1" if="NDKV9" />
 
 <set name="NDKV8+" value="1" if="NDKV8" />
@@ -28,10 +29,10 @@
 <set name="PLATFORM" value="android-9" if="android-9"/>
 <set name="PLATFORM " value="android-14" if="android-14"/>
 
-
+<set name="TOOLCHAIN_VERSION" value="4.9" unless="TOOLCHAIN_VERSION" if="NDKV10+" />
 <set name="TOOLCHAIN_VERSION" value="4.8" unless="TOOLCHAIN_VERSION" if="NDKV9+" />
 <set name="TOOLCHAIN_VERSION" value="4.4.3" unless="TOOLCHAIN_VERSION" />
-<set name="HXCPP_CPP11" value="1" if="NDKV9+" unless="HXCPP_NO_CPP11" />
+<set name="HXCPP_CPP11" value="1" if="NDKV9+ || NDKV10+" unless="HXCPP_NO_CPP11" />
 
 
 <!-- Set architecture -->
@@ -51,6 +52,15 @@
    <set name="TOOLCHAIN" value="arm-linux-androideabi-${TOOLCHAIN_VERSION}" />
    <set name="EXEPREFIX" value="arm-linux-androideabi" />
    <set name="PLATFORM" value="android-5" unless="PLATFORM" />
+</section>
+
+<section if="HXCPP_ARM64">
+   <set name="ARCH" value="-64"/>
+   <set name="ABI" value="arm64-v8a" />
+   <set name="PLATFORM_ARCH" value="arch-arm64" />
+   <set name="TOOLCHAIN" value="aarch64-linux-android-${TOOLCHAIN_VERSION}" />
+   <set name="EXEPREFIX" value="aarch64-linux-android" />
+   <set name="PLATFORM" value="android-19" unless="PLATFORM" />
 </section>
 
 <set name="prebuiltBase" value="${ANDROID_NDK_ROOT}/toolchains/${TOOLCHAIN}/prebuilt/${ANDROID_HOST}" />
@@ -103,7 +113,7 @@
        <flag value="-mfpu=vfpv3-d16"  />
        <flag value="-mfloat-abi=softfp" />
     </section>
-    <section unless="HXCPP_ARMV7">
+    <section unless="HXCPP_ARMV7 || HXCPP_ARM64">
        <flag value="-march=armv5te" />
        <flag value="-mtune=xscale" />
        <flag value="-msoft-float" />

--- a/toolchain/finish-setup.xml
+++ b/toolchain/finish-setup.xml
@@ -51,6 +51,7 @@
 <set name="LIBEXTRA" value="" if="blackberry" unless="simulator" />
 <set name="LIBEXTRA" value="-x86" if="HXCPP_X86" />
 <set name="LIBEXTRA" value="-v7" if="HXCPP_ARMV7" unless="LIBEXTRA" />
+<set name="LIBEXTRA" value="-64" if="HXCPP_ARM64" unless="LIBEXTRA" />
 <set name="LIBEXTRA" value="-x86" if="tizen"/>
 <set name="LIBEXTRA" value="" if="tizen" unless="simulator" />
 <set name="LIBEXT" value=".a" />

--- a/tools/hxcpp/Setup.hx
+++ b/tools/hxcpp/Setup.hx
@@ -278,6 +278,10 @@ class Setup
          defines.set("NDKV" + version, "1" );
       }
 
+      var arm_type = 'arm-linux-androideabi';
+      var arm_64 = defines.exists('HXCPP_ARM64');
+      if(arm_64) arm_type = 'aarch64-linux-android';
+
       // Find toolchain
       if (!defines.exists("TOOLCHAIN_VERSION"))
       {
@@ -287,6 +291,8 @@ class Setup
 
             // Prefer clang?
             var extract_version = ~/^arm-linux-androideabi-(\d.*)/;
+            if(arm_64) extract_version = ~/^aarch64-linux-android-(\d.*)/;
+
             var bestVer="";
             for(file in files)
             {
@@ -302,7 +308,7 @@ class Setup
             if (bestVer!="")
             {
                defines.set("TOOLCHAIN_VERSION",bestVer);
-               Log.info("", "\x1b[33;1mDetected Android toolchain: arm-linux-androideabi-" + bestVer + "\x1b[0m");
+               Log.info("", "\x1b[33;1mDetected Android toolchain: "+arm_type+"-" + bestVer + "\x1b[0m");
             }
          }
          catch(e:Dynamic) { }
@@ -311,7 +317,7 @@ class Setup
       // See what ANDROID_HOST to use ...
       try
       {
-         var prebuilt =  root+"/toolchains/arm-linux-androideabi-" + defines.get("TOOLCHAIN_VERSION") + "/prebuilt";
+         var prebuilt =  root+"/toolchains/"+arm_type+"-" + defines.get("TOOLCHAIN_VERSION") + "/prebuilt";
          var files = FileSystem.readDirectory(prebuilt);
          for (file in files)
          {  


### PR DESCRIPTION
Based on the [docs here](http://developer.android.com/ndk/guides/standalone_toolchain.html)

- The code in Setup.hx probably requires some future tidying - it was hardcoding the arm compiler name, I made a quick solution using a variable.

- The NDK10+ stuff I'm not 100% sure of, but I tested against r10e.

- I rebuilt all of hxcpp and my codebase (SDL, ogg, openal etc) for this android arch without trouble 
**note** The compiler doesn't need -march or any of that like with previous compiler versions due to the compiler being explicitly arm64 flavour and not sharing arches.

**side note**
Not included in this PR: This line in android-toolchain includes a space in `PLATFORM ` - probably unintentional. `<set name="PLATFORM " value="android-14" if="android-14"/>`