### PR TITLE
improve portability of runtime with game consoles

### DIFF
--- a/include/hx/Operators.h
+++ b/include/hx/Operators.h
@@ -117,7 +117,7 @@ inline L& UShrEq(L &inLHS, R inRHS) { inLHS = hx::UShr(inLHS,inRHS); return inLH
 template<typename L, typename R>
 inline L& ModEq(L &inLHS, R inRHS) { inLHS = DoubleMod(inLHS,inRHS); return inLHS; }
 
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__SNC__)
 template<typename R>
 inline hx::FieldRef AddEq(hx::FieldRef inLHS, R inRHS) { inLHS = inLHS + inRHS; return inLHS; }
 template<typename R>
@@ -166,7 +166,7 @@ template<typename R>
 inline hx::IndexRef ModEq(hx::IndexRef inLHS, R inRHS) { inLHS = DoubleMod(inLHS,inRHS); return inLHS; }
 
 
-#endif // __GNUC__
+#endif // __GNUC__ || __SNC__
 
 
 template<typename T> inline T TCastObject(hx::Object *inObj) { return hx::BadCast(); }

--- a/src/hx/Date.cpp
+++ b/src/hx/Date.cpp
@@ -4,7 +4,6 @@
 
 #ifdef HX_WINDOWS
    #include <windows.h>
-   #include <shlobj.h>
 #else
    #ifdef EPPC
       #include <time.h>

--- a/src/hx/Date.cpp
+++ b/src/hx/Date.cpp
@@ -5,15 +5,23 @@
 #ifdef HX_WINDOWS
    #include <windows.h>
 #else
-   #ifdef EPPC
-      #include <time.h>
-   #else
-      #include <sys/time.h>
-   #endif
    #include <stdint.h>
-   #ifdef HX_LINUX
+   #if defined __unix__ || __APPLE__
       #include <unistd.h>
       #include <stdio.h>
+      #if _POSIX_VERSION >= 1
+         #define USE_TIME_R
+      #endif
+      #if _POSIX_VERSION >= 199309L
+         #include <sys/time.h>
+         #define USE_CLOCK_GETTIME
+         #define USE_GETTIMEOFDAY
+      #endif
+   #endif
+   #if defined __ORBIS__
+      // fill in for a missing localtime_r with localtime_s
+      #define localtime_r localtime_s
+      #define gmtime_r gmtime_s
    #endif
 #endif
 
@@ -66,19 +74,17 @@ double __hxcpp_time_stamp()
 #else
    #if defined(IPHONE) || defined(APPLETV)
       double t = CACurrentMediaTime();
-   #elif defined(GPH) || defined(HX_LINUX) || defined(EMSCRIPTEN)
+   #elif defined(USE_GETTIMEOFDAY)
       struct timeval tv;
       if( gettimeofday(&tv,NULL) )
          return 0;
       double t =  ( tv.tv_sec + ((double)tv.tv_usec) / 1000000.0 );
-   #elif defined(EPPC)
-      time_t tod;
-      time(&tod);
-      double t = (double)tod;
-   #else
+   #elif defined(USE_CLOCK_GETTIME)
       struct timespec ts;
       clock_gettime(CLOCK_MONOTONIC, &ts);
       double t =  ( ts.tv_sec + ((double)ts.tv_nsec)*1e-9  );
+   #else
+      double t = (double)clock() * (1.0 / CLOCKS_PER_SEC);
    #endif
    if (t0==0) t0 = t;
    return t-t0;
@@ -91,14 +97,14 @@ double __hxcpp_time_stamp()
 void __internal_localtime(double inSeconds, struct tm* time)
 {
    time_t t = (time_t) inSeconds;
-   #ifdef HX_WINDOWS
+   #ifdef USE_TIME_R
+   localtime_r(&t, time);
+   #else
    struct tm *result = localtime(&t);
    if (result)
       *time = *result;
    else
       memset(time, 0, sizeof(*time) );
-   #else
-   localtime_r(&t, time);
    #endif
 }
 
@@ -108,10 +114,10 @@ void __internal_localtime(double inSeconds, struct tm* time)
 void __internal_gmtime(double inSeconds, struct tm* time)
 {
    time_t t = (time_t) inSeconds;
-   #ifdef HX_WINDOWS
-   *time = *gmtime(&t);
-   #else
+   #ifdef USE_TIME_R
    gmtime_r(&t, time);
+   #else
+   *time = *gmtime(&t);
    #endif
 }
 
@@ -320,10 +326,17 @@ double __hxcpp_date_now()
 
    return (double)( (long) ((ularge.QuadPart - EPOCH) / 10000000L) ) +
           system_time.wMilliseconds*0.001;
-   #else
+   #elif defined(USE_GETTIMEOFDAY)
    struct timeval tv;
    gettimeofday(&tv, 0);
    return (tv.tv_sec + (((double) tv.tv_usec) / (1000 * 1000)));
+   #else
+   // per-second time resolution. not ideal, but OK given the docs for Date.now
+   time_t t;
+   struct tm ti;
+   time(&t);
+   __internal_localtime((double)t, &ti);
+   return mktime(&ti);
    #endif
 }
 
@@ -347,7 +360,7 @@ double __hxcpp_timezone_offset(double inSeconds)
    struct tm localTime;
    __internal_localtime( inSeconds, &localTime);
 
-   #ifdef HX_WINDOWS
+   #if defined HX_WINDOWS || defined __SNC__ || defined __ORBIS__
    struct tm gmTime;
    __internal_gmtime(inSeconds, &gmTime );
 

--- a/src/hx/Debug.cpp
+++ b/src/hx/Debug.cpp
@@ -2656,7 +2656,7 @@ static void CriticalErrorHandler(String inErr, bool allowFixup)
 
     DBGLOG("Critical Error: %s\n", inErr.__s);
 
-#if defined(HX_WINDOWS) && !defined(HX_WINRT)
+#if defined(HX_WINDOWS) && (WINAPI_FAMILY == WINAPI_FAMILY_DESKTOP_APP || !defined(WINAPI_FAMILY))
     MessageBoxA(0, inErr.__s, "Critial Error - program must terminate",
         MB_ICONEXCLAMATION|MB_OK);
 #endif

--- a/src/hx/Object.cpp
+++ b/src/hx/Object.cpp
@@ -10,7 +10,6 @@
 #ifdef _WIN32
 
 #include <windows.h>
-#include <time.h>
 // Stoopid windows ...
 #ifdef RegisterClass
 #undef RegisterClass
@@ -21,7 +20,6 @@
 
 #else
 
-#include <sys/time.h>
 #include <wchar.h>
 #ifndef EMSCRIPTEN
 typedef  int64_t  __int64;

--- a/src/hx/StdLibs.cpp
+++ b/src/hx/StdLibs.cpp
@@ -3,11 +3,9 @@
 
 #ifdef HX_WINDOWS
 #include <windows.h>
-#include <stdio.h>
 #include <io.h>
-#else
+#elif defined __unix__ || defined __APPLE__
 #include <sys/time.h>
-#include <stdio.h>
 #ifndef EMSCRIPTEN
 typedef int64_t __int64;
 #endif
@@ -28,6 +26,7 @@ extern "C" EXPORT_EXTRA void AppLogInternal(const char* pFunction, int lineNumbe
 #include <string>
 #include <vector>
 #include <map>
+#include <stdio.h>
 #include <time.h>
 
 

--- a/src/hx/StdLibs.cpp
+++ b/src/hx/StdLibs.cpp
@@ -171,7 +171,7 @@ int __hxcpp_irand(int inMax)
 
 void __hxcpp_stdlibs_boot()
 {
-   #if defined(HX_WINDOWS) && !defined(HX_WINRT)
+   #if defined(HX_WINDOWS) && (WINAPI_FAMILY == WINAPI_FAMILY_DESKTOP_APP || !defined(WINAPI_FAMILY))
    HMODULE kernel32 = LoadLibraryA("kernel32");
    if (kernel32)
    {

--- a/src/hx/StdLibs.cpp
+++ b/src/hx/StdLibs.cpp
@@ -232,7 +232,6 @@ void __hxcpp_exit(int inExitCode)
    exit(inExitCode);
 }
 
-static double t0 = 0;
 double  __time_stamp()
 {
 #ifdef HX_WINDOWS
@@ -253,15 +252,17 @@ double  __time_stamp()
       if (period!=0)
          return (now-t0)*period;
    }
-
    return (double)clock() / ( (double)CLOCKS_PER_SEC);
-#else
+#elif defined __unix__ || defined __APPLE__
+   static double t0 = 0;
    struct timeval tv;
    if( gettimeofday(&tv,0) )
       throw Dynamic("Could not get time");
    double t =  ( tv.tv_sec + ((double)tv.tv_usec) / 1000000.0 );
    if (t0==0) t0 = t;
    return t-t0;
+#else
+   return (double)clock() / ( (double)CLOCKS_PER_SEC);
 #endif
 }
 
@@ -447,8 +448,7 @@ Array<String> __get_args()
    #else
    #ifdef ANDROID
    // TODO: Get from java
-   #else // linux
-
+   #elif defined(__linux__)
    char buf[80];
    sprintf(buf, "/proc/%d/cmdline", getpid());
    FILE *cmd = fopen(buf,"rb");

--- a/src/hx/Thread.cpp
+++ b/src/hx/Thread.cpp
@@ -477,12 +477,12 @@ public:
 
 	hx::InternalFinalizer *mFinalizer;
 
-	#ifdef HX_WINDOWS
+	#if defined HX_WINDOWS || defined __SNC__
 	double Now()
 	{
 		return (double)clock()/CLOCKS_PER_SEC;
 	}
-	#else
+	#elif defined __unix__ || defined __APPLE__
 	double Now()
 	{
 		struct timeval tv;

--- a/src/hx/gc/GcCommon.cpp
+++ b/src/hx/gc/GcCommon.cpp
@@ -44,7 +44,8 @@ int sgTargetFreeSpacePercentage  = 100;
 // Called internally before and GC operations
 void CommonInitAlloc()
 {
-   #ifndef HX_WINRT
+   #if !defined(HX_WINRT) && !defined(__SNC__) && !defined(__ORBIS__) && \
+       !(defined(WINAPI_FAMILY) && (WINAPI_FAMILY != WINAPI_FAMILY_DESKTOP_APP))
    const char *minimumWorking = getenv("HXCPP_MINIMUM_WORKING_MEMORY");
    if (minimumWorking)
    {

--- a/src/hx/gc/Immix.cpp
+++ b/src/hx/gc/Immix.cpp
@@ -328,7 +328,8 @@ typedef MyMutex ThreadPoolLock;
 
 static ThreadPoolLock sThreadPoolLock;
 
-#if !defined(HX_WINDOWS) && !defined(EMSCRIPTEN) && !defined(HX_WINRT)
+#if !defined(HX_WINDOWS) && !defined(EMSCRIPTEN) && !defined(HX_WINRT) && \
+	!defined(__SNC__) && !defined(__ORBIS__)
 #define HX_GC_PTHREADS
 typedef pthread_cond_t ThreadPoolSignal;
 inline void WaitThreadLocked(ThreadPoolSignal &ioSignal)


### PR DESCRIPTION
These changes address some problems with various proprietary SDKs used for game consoles. Originally, I wanted to have a number of smaller PRs each addressing separate platforms, but there is a lot of overlap in many cases. 

Most of these changes involve being more specific when encountering non-POSIX systems, quirks in POSIX support when it comes to date/time APIs, and specializing certain uses of Windows APIs as desktop-only.

This is not a holistic set of changes. Anything involving actual use of platform SDKs, even to create a thread or allocate memory, has been excluded due to NDAs. How this is currently approached in OpenFL's Lime framework is by moving relevant system calls in hxcpp's runtime into a common API. This API is implemented only in header files, that can then be replaced by a user-provided set of header files when certain macros are defined. Not super keen on this approach, but not sure of a better alternative. Will be submitting a PR soon that can take specific feedback.

[TODO: link to the above mentioned PR]