### PR TITLE
Higher entropy seed for Math.random()

### DIFF
--- a/src/Math.cpp
+++ b/src/Math.cpp
@@ -152,20 +152,23 @@ void Math_obj::__boot()
 
 	unsigned int t;
 #ifdef HX_WINDOWS
+    unsigned int t;
 	t = clock();
    #ifdef HX_WINRT
 	int pid = Windows::Security::Cryptography::CryptographicBuffer::GenerateRandomNumber();
    #else
 	int pid = _getpid();
    #endif
+   srand(t ^ (pid | (pid << 16)));
 #else
-	int pid = getpid();
-	struct timeval tv;
-	gettimeofday(&tv,0);
-	t = tv.tv_sec * 1000000 + tv.tv_usec;
-#endif	
+   long s, seed, pid;
 
-  srand(t ^ (pid | (pid << 16)));
+   pid = getpid();
+   s = time(0);
+
+   seed = std::abs(((s*181)*((pid-83)*359))%104729);
+   srand(seed);
+#endif
   rand();
 }
 


### PR DESCRIPTION
I'm getting duplicate uuid from https://github.com/andyli/casahx, @andyli suggested looking into seed. Current implementation was putting a lot of emphasis on pid which is OS specific, and I'm betting may be less random than we think on android / iOS / mac. The implementation I found hear seems to be a lot more random. http://stackoverflow.com/questions/8920411/possible-sources-for-random-number-seeds

Testing:
* Pakka Pets runs fine
* Test suite passes
* Tried printing 10 random numbers spawning multiple processes and skimmed the output to ensure no duplicates

What do you think?