### PR TITLE
Fix type parameter shadowing

### DIFF
--- a/include/hx/Native.h
+++ b/include/hx/Native.h
@@ -141,11 +141,11 @@ namespace hx
       template<typename O>
       inline Ref &operator=(const Ref<O> &inRef) { ptr=inRef.ptr; return *this; }
 
-      template<typename T>
-      inline bool operator==(const Ref<T> &inOther) const
+      template<typename O>
+      inline bool operator==(const Ref<O> &inOther) const
             { return ptr == inOther.ptr; }
-      template<typename T>
-      inline bool operator!=(const Ref<T> &inOther) const
+      template<typename O>
+      inline bool operator!=(const Ref<O> &inOther) const
             { return ptr != inOther.ptr; }
    };
 


### PR DESCRIPTION
Fixes:
```
Error: In file included from /home/ibilon/Code/Haxelibs/hxcpp/include/hxcpp.h:327:0,
                 from ./src/wx/widgets/_FontWeight/FontWeight_Impl_.cpp:1:
/home/ibilon/Code/Haxelibs/hxcpp/include/hx/Native.h:144:16: error: declaration of ‘class T’
       template<typename T>
                ^
/home/ibilon/Code/Haxelibs/hxcpp/include/hx/Native.h:113:13: error:  shadows template parm ‘class T’
    template<typename T>
             ^
/home/ibilon/Code/Haxelibs/hxcpp/include/hx/Native.h:147:16: error: declaration of ‘class T’
       template<typename T>
                ^
/home/ibilon/Code/Haxelibs/hxcpp/include/hx/Native.h:113:13: error:  shadows template parm ‘class T’
    template<typename T>
```