### PR TITLE
SSL Mac fix (and GCFreeZone)

### DIFF
--- a/src/hx/libs/ssl/Build.xml
+++ b/src/hx/libs/ssl/Build.xml
@@ -88,8 +88,8 @@
 	<lib name="crypt32.lib" if="windows" unless="static_link" />
 	<lib name="ws2_32.lib" if="windows" unless="static_link" />
 	
-	<flag value="-framework" if="mac"/>
-  	<flag value="Security" if="mac"/>
+	<flag value="-framework" if="macos"/>
+  	<flag value="Security" if="macos"/>
 </target>
 
 </xml>

--- a/src/hx/libs/ssl/SSL.cpp
+++ b/src/hx/libs/ssl/SSL.cpp
@@ -219,11 +219,17 @@ void _hx_ssl_handshake( Dynamic hssl ) {
 }
 
 int net_read( void *fd, unsigned char *buf, size_t len ){
-	return recv((SOCKET)(socket_int)fd, (char *)buf, len, 0);
+	hx::EnterGCFreeZone();
+	int r = recv((SOCKET)(socket_int)fd, (char *)buf, len, 0);
+	hx::ExitGCFreeZone();
+	return r;
 }
 
 int net_write( void *fd, const unsigned char *buf, size_t len ){
-	return send((SOCKET)(socket_int)fd, (char *)buf, len, 0);
+	hx::EnterGCFreeZone();
+	int r = send((SOCKET)(socket_int)fd, (char *)buf, len, 0);
+	hx::ExitGCFreeZone();
+	return r;
 }
 
 void _hx_ssl_set_socket( Dynamic hssl, Dynamic hsocket ) {
@@ -442,12 +448,11 @@ Dynamic _hx_ssl_cert_load_defaults(){
 	SecKeychainRef keychain;
 	SecCertificateRef item;
 	CFDataRef dat;
-	value v;
 	sslcert *chain = NULL;
 
 	// Load keychain
 	if( SecKeychainOpen("/System/Library/Keychains/SystemRootCertificates.keychain",&keychain) != errSecSuccess )
-		return val_null;
+		return null();
 
 	// Search for certificates
 	search = CFDictionaryCreateMutable( NULL, 0, NULL, NULL );


### PR DESCRIPTION
I left some old `value` in a Mac specific block during the conversion to native extern.

By the way I add Enter/Exit GCFreeZone around net operations as Hugh suggested in the previous PR.