### PR TITLE
BuildTool: don't hardcode verbose output to travis

### DIFF
--- a/tools/hxcpp/BuildTool.hx
+++ b/tools/hxcpp/BuildTool.hx
@@ -962,7 +962,7 @@ class BuildTool
 
       if (defines.exists("HXCPP_NO_COLOUR") || defines.exists("HXCPP_NO_COLOR"))
          Log.colorSupported = false;
-      Log.verbose = defines.exists("HXCPP_VERBOSE") || defines.exists("TRAVIS_OS_NAME");
+      Log.verbose = defines.exists("HXCPP_VERBOSE");
       exitOnThreadError = defines.exists("HXCPP_EXIT_ON_ERROR");
 
 


### PR DESCRIPTION
Pretty sure this is the reason why Flixel's cpp dev builds are still verbose even though I explicitly define `HXCPP_QUIET`.

I general it seems like bad practice to hardcode this to a particular CI system?