### PR TITLE
[WinRT] Fix Sys.print and trace

### DIFF
--- a/include/hxcpp.h
+++ b/include/hxcpp.h
@@ -95,8 +95,8 @@ typedef char HX_CHAR;
 
 #ifdef HX_WINRT
 
-#define WINRT_LOG(fmt, ...) {char buf[1024];sprintf(buf,"****LOG: %s(%d): %s \n    [" fmt "]\n",__FILE__,__LINE__,__FUNCTION__, __VA_ARGS__);OutputDebugString(buf);}
-#define WINRT_PRINTF(fmt, ...) {char buf[2048];sprintf(buf,fmt,__VA_ARGS__);OutputDebugString(buf);}
+#define WINRT_LOG(fmt, ...) {char buf[1024];snprintf(buf,1024,"****LOG: %s(%d): %s \n    [" fmt "]\n",__FILE__,__LINE__,__FUNCTION__, __VA_ARGS__);OutputDebugString(buf);}
+#define WINRT_PRINTF(fmt, ...) {char buf[2048];snprintf(buf,2048,fmt,__VA_ARGS__);OutputDebugString(buf);}
 
 #endif
 

--- a/include/hxcpp.h
+++ b/include/hxcpp.h
@@ -96,7 +96,7 @@ typedef char HX_CHAR;
 #ifdef HX_WINRT
 
 #define WINRT_LOG(fmt, ...) {char buf[1024];sprintf(buf,"****LOG: %s(%d): %s \n    [" fmt "]\n",__FILE__,__LINE__,__FUNCTION__, __VA_ARGS__);OutputDebugString(buf);}
-#define WINRT_PRINTF(fmt, ...) {char buf[2048];sprintf(buf,"fmt", __VA_ARGS__);OutputDebugString(buf);}
+#define WINRT_PRINTF(fmt, ...) {char buf[2048];sprintf(buf,fmt,__VA_ARGS__);OutputDebugString(buf);}
 
 #endif
 

--- a/src/hx/StdLibs.cpp
+++ b/src/hx/StdLibs.cpp
@@ -224,7 +224,12 @@ void __hxcpp_stdlibs_boot()
 
 void __trace(Dynamic inObj, Dynamic inData)
 {
-#ifdef TIZEN
+#ifdef HX_WINRT
+   WINRT_PRINTF("%s:%d: %s\n",
+               inData==null() ? "?" : inData->__Field( HX_CSTRING("fileName") , HX_PROP_DYNAMIC) ->toString().__s,
+               inData==null() ? 0 : inData->__Field( HX_CSTRING("lineNumber") , HX_PROP_DYNAMIC)->__ToInt(),
+               inObj.GetPtr() ? inObj->toString().__s : "null" );
+#elif defined(TIZEN)
    AppLogInternal(inData==null() ? "?" : Dynamic(inData->__Field( HX_CSTRING("fileName")), HX_PROP_DYNAMIC)->toString().__s,
       inData==null() ? 0 : (int)(inData->__Field( HX_CSTRING("lineNumber")), HX_PROP_DYNAMIC),
       "%s\n", inObj.GetPtr() ? inObj->toString().__s : "null" );


### PR DESCRIPTION
Needed a fix in the WINRT_PRINTF macro ("fmt" -> fmt) and implemented in __trace function.