### PR TITLE
overridable system APIs

### DIFF
--- a/include/hx/Memory.h
+++ b/include/hx/Memory.h
@@ -1,0 +1,24 @@
+#ifdef HX_MEMORY_H_OVERRIDE
+// Users can define their own header to use here, but there is no API
+// compatibility gaurantee for future changes.
+#include HX_MEMORY_H_OVERRIDE
+#else
+
+#ifndef HX_MEMORY_H
+#define HX_MEMORY_H
+
+inline void *HxAlloc(size_t size) {
+   return malloc(size);
+}
+
+inline void *HxAllocGCBlock(size_t size) {
+   return HxAlloc(size);
+}
+
+inline void HxFree(void *p) {
+   return free(p);
+}
+
+#endif
+
+#endif

--- a/include/hx/Thread.h
+++ b/include/hx/Thread.h
@@ -117,9 +117,9 @@ inline int HxAtomicDec(volatile int *ioWhere)
 #if defined(HX_WINDOWS)
 
 
-struct MyMutex
+struct HxMutex
 {
-   MyMutex()
+   HxMutex()
    {
       mValid = true;
       #ifdef HX_WINRT
@@ -128,7 +128,7 @@ struct MyMutex
       InitializeCriticalSection(&mCritSec);
       #endif
    }
-   ~MyMutex() { if (mValid) DeleteCriticalSection(&mCritSec); }
+   ~HxMutex() { if (mValid) DeleteCriticalSection(&mCritSec); }
    void Lock() { EnterCriticalSection(&mCritSec); }
    void Unlock() { LeaveCriticalSection(&mCritSec); }
    bool TryLock() { return TryEnterCriticalSection(&mCritSec); }
@@ -175,16 +175,16 @@ inline bool HxCreateDetachedThread(DWORD (WINAPI *func)(void *), void *param)
 
 #else
 
-struct MyMutex
+struct HxMutex
 {
-   MyMutex()
+   HxMutex()
    {
       pthread_mutexattr_t mta;
       pthread_mutexattr_init(&mta);
       pthread_mutexattr_settype(&mta, PTHREAD_MUTEX_RECURSIVE);
       mValid = pthread_mutex_init(&mMutex,&mta) ==0;
    }
-   ~MyMutex() { if (mValid) pthread_mutex_destroy(&mMutex); }
+   ~HxMutex() { if (mValid) pthread_mutex_destroy(&mMutex); }
    void Lock() { pthread_mutex_lock(&mMutex); }
    void Unlock() { pthread_mutex_unlock(&mMutex); }
    bool TryLock() { return !pthread_mutex_trylock(&mMutex); }
@@ -234,14 +234,14 @@ struct TAutoLock
    LOCKABLE &mMutex;
 };
 
-typedef TAutoLock<MyMutex> AutoLock;
+typedef TAutoLock<HxMutex> AutoLock;
 
 
 #if defined(HX_WINDOWS)
 
-struct MySemaphore
+struct HxSemaphore
 {
-   MySemaphore()
+   HxSemaphore()
    {
       #ifdef HX_WINRT
       mSemaphore = CreateEventEx(nullptr,nullptr,0,EVENT_ALL_ACCESS);
@@ -249,7 +249,7 @@ struct MySemaphore
       mSemaphore = CreateEvent(0,0,0,0);
       #endif
    }
-   ~MySemaphore() { if (mSemaphore) CloseHandle(mSemaphore); }
+   ~HxSemaphore() { if (mSemaphore) CloseHandle(mSemaphore); }
    void Set() { SetEvent(mSemaphore); }
    void Wait()
    {
@@ -279,15 +279,15 @@ struct MySemaphore
 
 #define HX_THREAD_SEMAPHORE_LOCKABLE
 
-struct MySemaphore
+struct HxSemaphore
 {
-   MySemaphore()
+   HxSemaphore()
    {
       mSet = false;
       mValid = true;
       pthread_cond_init(&mCondition,0);
    }
-   ~MySemaphore()
+   ~HxSemaphore()
    {
       if (mValid)
       {
@@ -295,7 +295,7 @@ struct MySemaphore
       }
    }
    // For autolock
-   inline operator MyMutex &() { return mMutex; }
+   inline operator HxMutex &() { return mMutex; }
    void Set()
    {
       AutoLock lock(mMutex);
@@ -384,7 +384,7 @@ struct MySemaphore
    }
 
 
-   MyMutex         mMutex;
+   HxMutex         mMutex;
    pthread_cond_t  mCondition;
    bool            mSet;
    bool            mValid;

--- a/include/hx/Tls.h
+++ b/include/hx/Tls.h
@@ -1,3 +1,9 @@
+#ifdef HX_TLS_H_OVERRIDE
+// Users can define their own header to use here, but there is no API
+// compatibility gaurantee for future changes.
+#include HX_TLS_H_OVERRIDE
+#else
+
 #ifndef HX_TLS_INCLUDED
 #define HX_TLS_INCLUDED
 
@@ -149,5 +155,7 @@ struct TLSData
 
 
 
+
+#endif
 
 #endif

--- a/src/hx/CFFI.cpp
+++ b/src/hx/CFFI.cpp
@@ -1,6 +1,6 @@
 #include <hxcpp.h>
 #include <stdio.h>
-// Get headers etc.
+#include <hx/Memory.h>
 #include <hx/OS.h>
 
 #define IGNORE_CFFI_API_H
@@ -35,7 +35,7 @@ public:
       if (inSize)
       {
          mMarkSize = inSize;
-         mHandle = malloc(inSize);
+         mHandle = HxAlloc(inSize);
          memset(mHandle,0,mMarkSize);
       }
 
@@ -90,7 +90,7 @@ public:
       SetFinalizer(0);
       mType = 0;
       if (mMarkSize && mHandle)
-         free(mHandle);
+         HxFree(mHandle);
       mHandle = 0;
    }
 

--- a/src/hx/Debug.cpp
+++ b/src/hx/Debug.cpp
@@ -306,11 +306,11 @@ struct ProfileEntry
     int mT0;
     std::map<const char *, ProfileEntry> mProfileStats;
 
-    static MyMutex gThreadMutex;
+    static HxMutex gThreadMutex;
     static int gThreadRefCount;
     static int gProfileClock;
 };
-/* static */ MyMutex Profiler::gThreadMutex;
+/* static */ HxMutex Profiler::gThreadMutex;
 /* static */ int Profiler::gThreadRefCount;
 /* static */ int Profiler::gProfileClock;
 
@@ -632,19 +632,19 @@ private:
 
     std::vector<int> *allocation_data;
 
-    static  MyMutex gStashMutex;
-    static MyMutex gThreadMutex;
+    static  HxMutex gStashMutex;
+    static HxMutex gThreadMutex;
     static int gThreadRefCount;
     static int gProfileClock;
 
-    static MyMutex alloc_mutex;
+    static HxMutex alloc_mutex;
     static std::map<void*, Telemetry*> alloc_map;
 };
-/* static */ MyMutex Telemetry::gStashMutex;
-/* static */ MyMutex Telemetry::gThreadMutex;
+/* static */ HxMutex Telemetry::gStashMutex;
+/* static */ HxMutex Telemetry::gThreadMutex;
 /* static */ int Telemetry::gThreadRefCount;
 /* static */ int Telemetry::gProfileClock;
-/* static */ MyMutex Telemetry::alloc_mutex;
+/* static */ HxMutex Telemetry::alloc_mutex;
 /* static */ std::map<void*, Telemetry*> Telemetry::alloc_map;
 
 #endif // HXCPP_TELEMETRY
@@ -1075,7 +1075,7 @@ public:
         // waiting.  If there were good portable time APIs easily available
         // within hxcpp I'd use them ...
         int timeSlicesLeft = 20;
-        MySemaphore timeoutSem;
+        HxSemaphore timeoutSem;
         int i = 0;
         while (i < size) {
             gMutex.Lock();
@@ -1444,9 +1444,9 @@ private:
     hx::QuickVec<StackFrame> mExceptionStack;
 
     int mStepLevel;
-    MyMutex mWaitMutex;
+    HxMutex mWaitMutex;
     bool mWaiting;
-    MySemaphore mWaitSemaphore;
+    HxSemaphore mWaitSemaphore;
     int mContinueCount;
 
     // Profiling support
@@ -1458,11 +1458,11 @@ private:
 #endif
 
     // gMutex protects gMap and gList
-    static MyMutex gMutex;
+    static HxMutex gMutex;
     static std::map<int, CallStack *> gMap;
     static std::list<CallStack *> gList;
 };
-/* static */ MyMutex CallStack::gMutex;
+/* static */ HxMutex CallStack::gMutex;
 /* static */ std::map<int, CallStack *> CallStack::gMap;
 /* static */ std::list<CallStack *> CallStack::gList;
 
@@ -1986,7 +1986,7 @@ private:
 #endif
     Breakpoint *mBreakpoints;
 
-    static MyMutex gMutex;
+    static HxMutex gMutex;
     static int gNextBreakpointNumber;
     static Breakpoints * volatile gBreakpoints;
     static StepType gStepType;
@@ -1997,7 +1997,7 @@ private:
 
 
 
-/* static */ MyMutex Breakpoints::gMutex;
+/* static */ HxMutex Breakpoints::gMutex;
 /* static */ int Breakpoints::gNextBreakpointNumber;
 /* static */ Breakpoints * volatile Breakpoints::gBreakpoints = 
     new Breakpoints();

--- a/src/hx/Debug.cpp
+++ b/src/hx/Debug.cpp
@@ -148,13 +148,8 @@ public:
         gThreadRefCount += 1;
    
         if (gThreadRefCount == 1) {
-#if defined(HX_WINDOWS)
-            _beginthreadex(0, 0, ProfileMainLoop, 0, 0, 0);
-#else
-            pthread_t result;
-            pthread_create(&result, 0, ProfileMainLoop, 0);
-#endif
-}
+            HxCreateDetachedThread(ProfileMainLoop, 0);
+        }
 
         gThreadMutex.Unlock();
     }
@@ -298,15 +293,7 @@ struct ProfileEntry
         int millis = 1;
 
         while (gThreadRefCount > 0) { 
-#ifdef HX_WINDOWS
-            Sleep(millis);
-#else
-            struct timespec t;
-            struct timespec tmp;
-            t.tv_sec = 0;
-            t.tv_nsec = millis * 1000000;
-            nanosleep(&t, &tmp);
-#endif
+            HxSleep(millis);
 
             int count = gProfileClock + 1;
             gProfileClock = (count < 0) ? 0 : count;

--- a/src/hx/Scriptable.cpp
+++ b/src/hx/Scriptable.cpp
@@ -1,6 +1,7 @@
 #include <hxcpp.h>
 #include <hx/Scriptable.h>
 #include <hx/GC.h>
+#include <hx/Memory.h>
 #include <stdio.h>
 #include <vector>
 #include <string>
@@ -1859,7 +1860,7 @@ public:
       if (len==0)
          return String("",0).dup();
 
-      char *buffer = (char *)malloc(len);
+      char *buffer = (char *)HxAlloc(len);
       if (mBytes)
       {
          if (mBytes+len>mBytesEnd)
@@ -1869,11 +1870,11 @@ public:
       }
       else if (fread(buffer,len,1,mFile)!=1)
       {
-         free(buffer);
+         HxFree(buffer);
          Error("Could not read string16");
       }
       Dynamic result = String(buffer,len).dup();
-      free(buffer);
+      HxFree(buffer);
       return result;
    }
 

--- a/src/hx/StdLibs.cpp
+++ b/src/hx/StdLibs.cpp
@@ -1,5 +1,6 @@
 #include <hxcpp.h>
 #include <hxMath.h>
+#include <hx/Memory.h>
 
 #ifdef HX_WINDOWS
 #include <windows.h>
@@ -681,7 +682,7 @@ int  __hxcpp_field_to_id( const char *inFieldName )
    if (!sgFieldToStringAlloc)
    {
       sgFieldToStringAlloc = 100;
-      sgFieldToString = (String *)malloc(sgFieldToStringAlloc * sizeof(String));
+      sgFieldToString = (String *)HxAlloc(sgFieldToStringAlloc * sizeof(String));
 
       sgStringToField = new StringToField;
    }

--- a/src/hx/Thread.cpp
+++ b/src/hx/Thread.cpp
@@ -51,7 +51,7 @@ struct Deque : public Array_obj<Dynamic>
    #endif
 
 
-	#ifdef HX_WINDOWS
+	#ifndef HX_THREAD_SEMAPHORE_LOCKABLE
 	MyMutex     mMutex;
 	void PushBack(Dynamic inValue)
 	{
@@ -276,22 +276,11 @@ Dynamic __hxcpp_thread_create(Dynamic inStart)
 	hx::GCPrepareMultiThreaded();
 	hx::EnterGCFreeZone();
 
-   #ifdef HX_WINDOWS
-      bool ok = _beginthreadex(0,0,hxThreadFunc,info,0,0) != 0;
-   #else
-      pthread_t result = 0;
-      int created = pthread_create(&result,0,hxThreadFunc,info);
-      bool ok = created==0;
-   #endif
-
-
-     if (ok)
-     {
-        #ifndef HX_WINDOWS
-        pthread_detach(result);
-        #endif
-        info->mSemaphore->Wait();
-     }
+    bool ok = HxCreateDetachedThread(hxThreadFunc, info);
+    if (ok)
+    {
+       info->mSemaphore->Wait();
+    }
 
     hx::ExitGCFreeZone();
     info->CleanSemaphore();

--- a/src/hx/Thread.cpp
+++ b/src/hx/Thread.cpp
@@ -6,7 +6,7 @@
 DECLARE_TLS_DATA(class hxThreadInfo, tlsCurrentThread);
 
 // g_threadInfoMutex allows atomic access to g_nextThreadNumber
-static MyMutex g_threadInfoMutex;
+static HxMutex g_threadInfoMutex;
 // Thread number 0 is reserved for the main thread
 static int g_nextThreadNumber = 1;
 
@@ -52,7 +52,7 @@ struct Deque : public Array_obj<Dynamic>
 
 
 	#ifndef HX_THREAD_SEMAPHORE_LOCKABLE
-	MyMutex     mMutex;
+	HxMutex     mMutex;
 	void PushBack(Dynamic inValue)
 	{
 		hx::EnterGCFreeZone();
@@ -126,7 +126,7 @@ struct Deque : public Array_obj<Dynamic>
 	#endif
 
 	hx::InternalFinalizer *mFinalizer;
-	MySemaphore mSemaphore;
+	HxSemaphore mSemaphore;
 };
 
 Dynamic __hxcpp_deque_create()
@@ -168,7 +168,7 @@ public:
 	hxThreadInfo(Dynamic inFunction, int inThreadNumber)
         : mFunction(inFunction), mThreadNumber(inThreadNumber), mTLS(0,0)
 	{
-		mSemaphore = new MySemaphore;
+		mSemaphore = new HxSemaphore;
 		mDeque = Deque::Create();
 	}
 	hxThreadInfo()
@@ -219,7 +219,7 @@ public:
 
 
 	Array<Dynamic> mTLS;
-	MySemaphore *mSemaphore;
+	HxSemaphore *mSemaphore;
 	Dynamic mFunction;
     int mThreadNumber;
 	Deque   *mDeque;
@@ -387,7 +387,7 @@ public:
 	}
 
 
-   MyMutex mMutex;
+   HxMutex mMutex;
 };
 
 
@@ -507,8 +507,8 @@ public:
 	}
 
 
-	MySemaphore mNotEmpty;
-   MyMutex     mAvailableLock;
+	HxSemaphore mNotEmpty;
+   HxMutex     mAvailableLock;
 	int         mAvailable;
 };
 

--- a/src/hx/cppia/CppiaCtx.cpp
+++ b/src/hx/cppia/CppiaCtx.cpp
@@ -10,7 +10,7 @@
 namespace hx
 {
 
-static MyMutex *sCppiaCtxLock = 0;
+static HxMutex *sCppiaCtxLock = 0;
 
 DECLARE_TLS_DATA(CppiaCtx,tlsCppiaCtx)
 
@@ -44,7 +44,7 @@ CppiaCtx *CppiaCtx::getCurrent()
       tlsCppiaCtx = result = new CppiaCtx();
 
       if (!sCppiaCtxLock)
-         sCppiaCtxLock = new MyMutex();
+         sCppiaCtxLock = new HxMutex();
       sCppiaCtxLock->Lock();
       sAllContexts.push_back(result);
       sCppiaCtxLock->Unlock();
@@ -59,7 +59,7 @@ void CppiaCtx::mark(hx::MarkContext *__inCtx)
 
 void scriptMarkStack(hx::MarkContext *__inCtx)
 {
-   MyMutex *m = sCppiaCtxLock;
+   HxMutex *m = sCppiaCtxLock;
    if (m)
        m->Lock();
 

--- a/src/hx/gc/Immix.cpp
+++ b/src/hx/gc/Immix.cpp
@@ -140,8 +140,8 @@ static int sgTimeToNextTableUpdate = 1;
 
 
 
-MyMutex  *gThreadStateChangeLock=0;
-MyMutex  *gSpecialObjectLock=0;
+HxMutex  *gThreadStateChangeLock=0;
+HxMutex  *gSpecialObjectLock=0;
 
 class LocalAllocator;
 enum LocalAllocState { lasNew, lasRunning, lasStopped, lasWaiting, lasTerminal };
@@ -317,7 +317,7 @@ typedef hx::QuickVec<hx::Object *> ObjectStack;
 // Dummy lock
 typedef HxAtomicLock ThreadPoolLock;
 #else
-typedef MyMutex ThreadPoolLock;
+typedef HxMutex ThreadPoolLock;
 #endif
 
 static ThreadPoolLock sThreadPoolLock;
@@ -331,7 +331,7 @@ inline void WaitThreadLocked(ThreadPoolSignal &ioSignal)
    pthread_cond_wait(&ioSignal, &sThreadPoolLock.mMutex);
 }
 #else
-typedef MySemaphore ThreadPoolSignal;
+typedef HxSemaphore ThreadPoolSignal;
 #endif
 
 typedef TAutoLock<ThreadPoolLock> ThreadPoolAutoLock;
@@ -1598,7 +1598,7 @@ void MarkStringArray(String *inPtr, int inLength, hx::MarkContext *__inCtx)
 
 // --- Roots -------------------------------
 
-FILE_SCOPE MyMutex *sGCRootLock = 0;
+FILE_SCOPE HxMutex *sGCRootLock = 0;
 typedef hx::UnorderedSet<hx::Object **> RootSet;
 static RootSet sgRootSet;
 
@@ -1648,7 +1648,7 @@ void GcRemoveOffsetRoot(void *inRoot)
 class WeakRef;
 typedef hx::QuickVec<WeakRef *> WeakRefs;
 
-FILE_SCOPE MyMutex *sFinalizerLock = 0;
+FILE_SCOPE HxMutex *sFinalizerLock = 0;
 FILE_SCOPE WeakRefs sWeakRefs;
 
 class WeakRef : public hx::Object
@@ -2152,8 +2152,8 @@ public:
    {
       if (!gThreadStateChangeLock)
       {
-         gThreadStateChangeLock = new MyMutex();
-         gSpecialObjectLock = new MyMutex();
+         gThreadStateChangeLock = new HxMutex();
+         gSpecialObjectLock = new HxMutex();
       }
       // Until we add ourselves, the colled will not wait
       //  on us - ie, we are assumed ot be in a GC free zone.
@@ -3558,7 +3558,7 @@ public:
    BlockList mFreeBlocks;
    BlockList mZeroList;
    LargeList mLargeList;
-   MyMutex    mLargeListLock;
+   HxMutex    mLargeListLock;
    hx::QuickVec<LocalAllocator *> mLocalAllocs;
    LocalAllocator *mLocalPool[LOCAL_POOL_SIZE];
 };
@@ -3964,8 +3964,8 @@ public:
    bool            mGCFreeZone;
    int             mStackLocks;
    int             mID;
-   MySemaphore     mReadyForCollect;
-   MySemaphore     mCollectDone;
+   HxSemaphore     mReadyForCollect;
+   HxSemaphore     mCollectDone;
 };
 
 
@@ -4058,8 +4058,8 @@ void InitAlloc()
    sgAllocInit = true;
    sGlobalAlloc = new GlobalAllocator();
    sgFinalizers = new FinalizerList();
-   sFinalizerLock = new MyMutex();
-   sGCRootLock = new MyMutex();
+   sFinalizerLock = new HxMutex();
+   sGCRootLock = new HxMutex();
    hx::Object tmp;
    void **stack = *(void ***)(&tmp);
    sgObject_root = stack[0];

--- a/src/hx/gc/Immix.cpp
+++ b/src/hx/gc/Immix.cpp
@@ -3006,12 +3006,10 @@ public:
          pthread_t result = 0;
          int created = pthread_create(&result,0,SThreadLoop,info);
          bool ok = created==0;
-      #else
-         #ifdef EMSCRIPTEN
+      #elif defined(EMSCRIPTEN)
          // Only one thread
-         #elif defined(HX_WINDOWS)
-         bool ok = _beginthreadex(0,0,SThreadLoop,info,0,0) != 0;
-         #endif
+      #else
+         bool ok = HxCreateDetachedThread(SThreadLoop, info);
       #endif
    }
 


### PR DESCRIPTION
This is the last major set of changes needed to support building Haxe C++ applications with proprietary, closed SDKs. These changes move most of the system calls that hxcpp's runtime makes into header files that the user can override with their own by defining a macro.

Not sure how I feel about this approach, though it gets the job done. Open to feedback, big and small.