### PR TITLE
Support Unicode properties in regexp

### DIFF
--- a/project/libs/regexp/Build.xml
+++ b/project/libs/regexp/Build.xml
@@ -14,6 +14,7 @@
 
   <compilerflag value="-DPCRE_STATIC"/>
   <compilerflag value="-DSUPPORT_UTF8"/>
+  <compilerflag value="-DSUPPORT_UCP"/>
   <compilerflag value="-I${PCRE_DIR}"/>
 
   <file name="RegExp.cpp"/>

--- a/src/hx/libs/regexp/Build.xml
+++ b/src/hx/libs/regexp/Build.xml
@@ -11,6 +11,7 @@
 
   <compilerflag value="-DPCRE_STATIC"/>
   <compilerflag value="-DSUPPORT_UTF8"/>
+  <compilerflag value="-DSUPPORT_UCP"/>
   <compilerflag value="-I${PCRE_DIR}"/>
 
   <file name="${this_dir}/RegExp.cpp"/>


### PR DESCRIPTION
Currently, support for Unicode properties in PCRE is not enabled and `\p` patterns cannot be used (See #367).

Since it can be enabled with a flag (`-DSUPPORT_UCP`), why not do so?