### PR TITLE
Do not use boolean and operator when converting to Int64 / UInt64

### DIFF
--- a/include/Dynamic.h
+++ b/include/Dynamic.h
@@ -68,8 +68,8 @@ public:
    inline operator char () const { return mPtr ? mPtr->__ToInt() : 0; }
    inline operator signed char () const { return mPtr ? mPtr->__ToInt() : 0; }
    inline operator bool() const { return mPtr && mPtr->__ToInt(); }
-   inline operator cpp::Int64() const { return mPtr && mPtr->__ToInt64(); }
-   inline operator cpp::UInt64() const { return mPtr && mPtr->__ToInt64(); }
+   inline operator cpp::Int64() const { return mPtr ? mPtr->__ToInt64() : 0; }
+   inline operator cpp::UInt64() const { return mPtr ? mPtr->__ToInt64() : 0; }
 
    // Conversion to generic pointer requires you to tag the class with a typedef
    template<typename T>


### PR DESCRIPTION
Without this, the following behaviour happens:
```haxe
class Main {

  static function main() {
    var i:cpp.Int64 = getDynamic();
    trace(i); // 1 :(
  }

  static function getDynamic():Dynamic {
    var i:cpp.Int64 = 42;
    return i;
  }

  }
```

That was a hard one to catch :P