### PR TITLE
Fix for Telemetry wrt HxCreateDetachedThread

### DIFF
--- a/src/hx/Debug.cpp
+++ b/src/hx/Debug.cpp
@@ -369,13 +369,8 @@ public:
    
         gThreadRefCount += 1;
         if (gThreadRefCount == 1) {
-#if defined(HX_WINDOWS)
-            _beginthreadex(0, 0, ProfileMainLoop, 0, 0, 0);
-#else
-            pthread_t result;
-            pthread_create(&result, 0, ProfileMainLoop, 0);
-#endif
-}
+            HxCreateDetachedThread(ProfileMainLoop, 0);
+        }
 
         gThreadMutex.Unlock();
     }


### PR DESCRIPTION
Same change made in 0fb5599e51d8 in `class Profiler` on [line 151](https://github.com/HaxeFoundation/hxcpp/blob/master/src/hx/Debug.cpp#L150-L152) needs to be reflected in `class Telemetry` for starting the profiler thread.