### PR TITLE
Propose HXCPP_OPTIMIZE_LINK for link time optimization (windows target for now). small winrt fix

### DIFF
--- a/toolchain/finish-setup.xml
+++ b/toolchain/finish-setup.xml
@@ -27,7 +27,8 @@
 
 
 <set name="OBJDBG" value="-debug" if="debug" />
-<set name="OBJEXT" value="${M64}${F32}${STAT}${OBJDBG}${NOCONSOLE}${RPI}${APIFP}${PRIME}" />
+<set name="OBJOPT" value="-opt" if="HXCPP_OPTIMIZE_LINK" />
+<set name="OBJEXT" value="${M64}${F32}${STAT}${OBJDBG}${OBJOPT}${NOCONSOLE}${RPI}${APIFP}${PRIME}" />
 
 <set name="STD_MODULE_LINK" value="static_link" if="static_link"/>
 <set name="STD_MODULE_LINK" value="exe" if="HXCPP_JS_PRIME"/>

--- a/toolchain/finish-setup.xml
+++ b/toolchain/finish-setup.xml
@@ -27,7 +27,7 @@
 
 
 <set name="OBJDBG" value="-debug" if="debug" />
-<set name="OBJOPT" value="-opt" if="HXCPP_OPTIMIZE_LINK" />
+<set name="OBJOPT" value="-opt" if="HXCPP_OPTIMIZE_LINK" unless="debug" />
 <set name="OBJEXT" value="${M64}${F32}${STAT}${OBJDBG}${OBJOPT}${NOCONSOLE}${RPI}${APIFP}${PRIME}" />
 
 <set name="STD_MODULE_LINK" value="static_link" if="static_link"/>

--- a/toolchain/msvc-toolchain.xml
+++ b/toolchain/msvc-toolchain.xml
@@ -9,7 +9,7 @@
 
 <section if="winrt">
    <set name="C_ABI" value="-MD" />
-   <set name="ABI" value="-ZW" unless="ABI"/>
+   <set name="ABI" value="-ZW" unless="ABI || static_link"/>
    <!-- Note: Default winrt static_link uses native libs. -->
    <!--       Use -DABI=-ZW for "main", or to force UWP libs (e.g. targeting XBOXONE UWP) -->
    <set name="ABI" value="-MD" if="static_link" unless="ABI"/>
@@ -80,6 +80,7 @@
   <flag value="-Od" tag="debug" />
   <flag value="-O2" tag="release" />
   <flag value="-Os" tag="optim-size" />
+  <flag value="-GL" if="HXCPP_OPTIMIZE_LINK" unless="debug"/>
 
   <flag value="-FS" if="HXCPP_FORCE_PDB_SERVER" />
   <flag value="-Oy-"/>
@@ -107,6 +108,7 @@
   <flag value="-machine:${MACHINE}"/>
   <flag value="-dll"/>
   <flag value="-debug" if="HXCPP_DEBUG_LINK"/>
+  <flag value="-LTCG" if="HXCPP_OPTIMIZE_LINK" unless="debug"/>
   <lib name="${dll_import_link}" if="dll_import_link" />
   <ext value=".dll"/>
   <libdir name="obj/lib"/>
@@ -121,6 +123,7 @@
   <flag value="-nologo"/>
   <flag value="-machine:${MACHINE}"/>
   <flag value="-debug" if="HXCPP_DEBUG_LINK"/>
+  <flag value="-LTCG" if="HXCPP_OPTIMIZE_LINK" unless="debug"/>
   <flag value="-subsystem:windows${SUBSYSTEM_VER}" if="SUBSYSTEMWINDOWS" />
   <flag value="-subsystem:console${SUBSYSTEM_VER}" if="SUBSYSTEMCONSOLE" />
   <libpathflag value="-libpath:"/>
@@ -136,6 +139,7 @@
   <flag value="-nologo"/>
   <flag value="-machine:${MACHINE}"/>
   <flag value="-debug" if="HXCPP_DEBUG_LINK"/>
+  <flag value="-LTCG" if="HXCPP_OPTIMIZE_LINK" unless="debug"/>
   <flag value="-subsystem:windows" />
   <flag value="-MANIFEST:NO" />
   <flag value="-WINMD" />
@@ -151,6 +155,7 @@
 </linker>
 
 <linker id="static_link" exe="lib.exe" if="windows">
+  <flag value="-LTCG" if="HXCPP_OPTIMIZE_LINK" unless="debug"/>
   <fromfile value="@"/>
   <flag value="-nologo"/>
   <ext value="${LIBEXT}"/>


### PR DESCRIPTION
link time optimization for windows target using -GL compile flag (TODO: gcc targets should use -flto instead). winrt: fix default behaivor to native libs for static_link

Reference: https://blogs.msdn.microsoft.com/vcblog/2009/02/24/quick-tips-on-using-whole-program-optimization/

I have been testing it, and at least it does not have seem to crash the applications. it is noticeable faster in x86 architecture (tried Mandelbrot), but getting mixed results in M64 (slower with anon, not much difference without anon). The size of exe is also smaller for larger projects. This flag can be combined with HXCPP_DEBUG_LINK to maintain symbol information. 

You can mix -GL objs with non -GL objs but since it would not be the intended behavior, added an extra flag to the OBJEXT (to save objs in a different directory).

It could work without the -LTCG flag, but it avoids the linker to restart when finding a -GL obj.

The user might need to test it to choose if use it or not on their final builds. Please give it a try.