### PR TITLE
Minor path changes for VS 2013 SDK references

### DIFF
--- a/toolchain/msvc-setup.bat
+++ b/toolchain/msvc-setup.bat
@@ -16,9 +16,16 @@ setlocal enabledelayedexpansion
 ) else if exist "%VS120COMNTOOLS%\vsvars32.bat" (
 	@call "%VS120COMNTOOLS%\vsvars32.bat"
 	@if defined HXCPP_WINXP_COMPAT (
-		@set "INCLUDE=%ProgramFiles(x86)%\Microsoft SDKs\Windows\7.1A\Include;!INCLUDE!"
-		@set "PATH=%ProgramFiles(x86)%\Microsoft SDKs\Windows\7.1A\Bin;!PATH!"
-		@set "LIB=%ProgramFiles(x86)%\Microsoft SDKs\Windows\7.1A\Lib;!LIB!"
+		@if exist "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v7.1A\" (
+			@set "INCLUDE=%ProgramFiles(x86)%\Microsoft SDKs\Windows\v7.1A\Include;!INCLUDE!"
+			@set "PATH=%ProgramFiles(x86)%\Microsoft SDKs\Windows\v7.1A\Bin;!PATH!"
+			@set "LIB=%ProgramFiles(x86)%\Microsoft SDKs\Windows\v7.1A\Lib;!LIB!"		
+		) else if exist "%ProgramFiles(x86)%\Microsoft SDKs\Windows\7.1A\" (
+			@set "INCLUDE=%ProgramFiles(x86)%\Microsoft SDKs\Windows\7.1A\Include;!INCLUDE!"
+			@set "PATH=%ProgramFiles(x86)%\Microsoft SDKs\Windows\7.1A\Bin;!PATH!"
+			@set "LIB=%ProgramFiles(x86)%\Microsoft SDKs\Windows\7.1A\Lib;!LIB!"
+		)
+
 		@set HXCPP_XP_DEFINE=_USING_V120_SDK71_
 	)
 	@echo HXCPP_VARS


### PR DESCRIPTION
Update 5 (MSVS 2013 Ultimate in my case) probably changed the Microsoft SDKs folder for 7.1A to v7.1A, as last year hxcpp did not have issues with Update 4. I have not checked however if MSVS 2012 and 2015 are affected by this as well.