### PR TITLE
Fix DEFINE_PRIME5v and DEFINE_PRIME7v preprocessor typos

### DIFF
--- a/include/hx/CFFIPrime.h
+++ b/include/hx/CFFIPrime.h
@@ -308,9 +308,9 @@ struct AutoValue
 #define DEFINE_PRIME2v(func) EMSCRIPTEN_BINDINGS(func) { function(#func, &func); }
 #define DEFINE_PRIME3v(func) EMSCRIPTEN_BINDINGS(func) { function(#func, &func); }
 #define DEFINE_PRIME4v(func) EMSCRIPTEN_BINDINGS(func) { function(#func, &func); }
-#define DEFINE_PRIME5(func) EMSCRIPTEN_BINDINGS(func) { function(#func, &func); }
+#define DEFINE_PRIME5v(func) EMSCRIPTEN_BINDINGS(func) { function(#func, &func); }
 #define DEFINE_PRIME6v(func) EMSCRIPTEN_BINDINGS(func) { function(#func, &func); }
-#define DEFINE_PRIME7vv(func) EMSCRIPTEN_BINDINGS(func) { function(#func, &func); }
+#define DEFINE_PRIME7v(func) EMSCRIPTEN_BINDINGS(func) { function(#func, &func); }
 #define DEFINE_PRIME8v(func) EMSCRIPTEN_BINDINGS(func) { function(#func, &func); }
 #define DEFINE_PRIME9v(func) EMSCRIPTEN_BINDINGS(func) { function(#func, &func); }
 #define DEFINE_PRIME10v(func) EMSCRIPTEN_BINDINGS(func) { function(#func, &func); }


### PR DESCRIPTION
Those preprocessor macros look like they have typos.

Attempts to send some arrays of strings from Haxe to C++ using CFFI PRIME took me here. Is there any documentation or example that could help with that? Thanks :-)