### PR TITLE
Avoid null pointer exception for a

### DIFF
--- a/src/hx/libs/std/Socket.cpp
+++ b/src/hx/libs/std/Socket.cpp
@@ -465,6 +465,8 @@ static Array<Dynamic> make_array_result( Array<Dynamic> a, fd_set *tmp )
 {
    if (!tmp)
       return null();
+   if (a==0)
+      return null();
 
    int len = a->length;
    Array<Dynamic> r = Array_obj<Dynamic>::__new();


### PR DESCRIPTION
I ran into an issue where a is null and that kills the application. So I figured it might be a good idea to avoid that. Fun fact: if (0==a) doesn't work. Any ideas why that is?
