### PR TITLE
Deduce Android NDK version from source.properties file

### DIFF
--- a/tools/hxcpp/Setup.hx
+++ b/tools/hxcpp/Setup.hx
@@ -64,6 +64,38 @@ class Setup
             return result;
       }
 
+      var src = toPath(inDirName+"/source.properties");
+      if(sys.FileSystem.exists(src))
+      {
+         var fin = sys.io.File.read(src, false);
+         try
+         {
+            while(true)
+            {
+               var str = fin.readLine();
+               var split = str.split ("=");
+               var name = StringTools.trim(split[0]);
+               if( name == "Pkg.Revision" )
+               {
+                  var revision = StringTools.trim(split[1]);
+                  var split2 = revision.split( "." );
+                  var result = Std.parseInt(split2[0]);
+                  if(result!=null && result>=8)
+                  {
+                     Log.v('Deduced NDK version '+result+' from "$inDirName"/source.properties'); 
+                     fin.close();
+                     return result;
+                  }
+               }
+            }
+         }
+         catch(e:haxe.io.Eof)
+         {
+            Log.v('Could not deduce NDK version from "$inDirName"/source.properties');
+         }
+         fin.close();
+      }
+
       Log.v('Could not deduce NDK version from "$inDirName" - assuming 8');
       return 8;
    }


### PR DESCRIPTION
This fixes ndk linking when the ndk directory name has not the ndk version on it, for example if you want to use the one from SDK Manager which it is installed on [andoidsdk]/ndk-bundle
Releated issue https://github.com/HaxeFoundation/hxcpp/issues/529