### PR TITLE
Android toolchain: Added HXCPP_OPTIMIZE_LINK and other flags

### DIFF
--- a/toolchain/android-toolchain.xml
+++ b/toolchain/android-toolchain.xml
@@ -19,30 +19,30 @@
 
 <!-- Set architecture -->
 <section if="HXCPP_X86">
-   <set name="ARCH" value="-x86" />
-   <set name="ABI" value="x86"  />
-   <set name="PLATFORM_ARCH" value="arch-x86" />
-   <set name="TOOLCHAIN" value="x86-${TOOLCHAIN_VERSION}" />
-   <set name="EXEPREFIX" value="i686-linux-android" />
-   <set name="PLATFORM" value="android-14" unless="PLATFORM" />
+  <set name="ARCH" value="-x86" />
+  <set name="ABI" value="x86"  />
+  <set name="PLATFORM_ARCH" value="arch-x86" />
+  <set name="TOOLCHAIN" value="x86-${TOOLCHAIN_VERSION}" />
+  <set name="EXEPREFIX" value="i686-linux-android" />
+  <set name="PLATFORM" value="android-14" unless="PLATFORM" />
 </section>
 
 <section unless="HXCPP_X86">
-   <set name="ARCH" value="-v7" if="HXCPP_ARMV7" />
-   <set name="ABI" value="armeabi" />
-   <set name="PLATFORM_ARCH" value="arch-arm" />
-   <set name="TOOLCHAIN" value="arm-linux-androideabi-${TOOLCHAIN_VERSION}" />
-   <set name="EXEPREFIX" value="arm-linux-androideabi" />
-   <set name="PLATFORM" value="android-5" unless="PLATFORM" />
+  <set name="ARCH" value="-v7" if="HXCPP_ARMV7" />
+  <set name="ABI" value="armeabi" />
+  <set name="PLATFORM_ARCH" value="arch-arm" />
+  <set name="TOOLCHAIN" value="arm-linux-androideabi-${TOOLCHAIN_VERSION}" />
+  <set name="EXEPREFIX" value="arm-linux-androideabi" />
+  <set name="PLATFORM" value="android-5" unless="PLATFORM" />
 </section>
 
 <section if="HXCPP_ARM64">
-   <set name="ARCH" value="-64"/>
-   <set name="ABI" value="arm64-v8a" />
-   <set name="PLATFORM_ARCH" value="arch-arm64" />
-   <set name="TOOLCHAIN" value="aarch64-linux-android-${TOOLCHAIN_VERSION}" />
-   <set name="EXEPREFIX" value="aarch64-linux-android" />
-   <set name="PLATFORM" value="android-19" unless="PLATFORM" />
+  <set name="ARCH" value="-64"/>
+  <set name="ABI" value="arm64-v8a" />
+  <set name="PLATFORM_ARCH" value="arch-arm64" />
+  <set name="TOOLCHAIN" value="aarch64-linux-android-${TOOLCHAIN_VERSION}" />
+  <set name="EXEPREFIX" value="aarch64-linux-android" />
+  <set name="PLATFORM" value="android-19" unless="PLATFORM" />
 </section>
 
 <set name="prebuiltBase" value="${ANDROID_NDK_ROOT}/toolchains/${TOOLCHAIN}/prebuilt/${ANDROID_HOST}" />
@@ -55,36 +55,37 @@
 
 <compiler id="android-gcc" exe="g++">
 
- <exe name="${EXEPREFIX}-g++" />
+  <exe name="${EXEPREFIX}-g++" />
 
- <!-- These must appear in this order! -->
- <flag value="--sysroot=${ANDROID_NDK_ROOT}/platforms/${PLATFORM}/${PLATFORM_ARCH}"/>
- <section if="NDKV8+">
-   <flag value="-I${ANDROID_NDK_ROOT}/sources/cxx-stl/gnu-libstdc++/${TOOLCHAIN_VERSION}/include" />
-   <flag value="-I${ANDROID_NDK_ROOT}/sources/cxx-stl/gnu-libstdc++/${TOOLCHAIN_VERSION}/libs/${ABI}/include" />
- </section>
- <section unless="NDKV8+">
+  <!-- These must appear in this order! -->
+  <flag value="--sysroot=${ANDROID_NDK_ROOT}/platforms/${PLATFORM}/${PLATFORM_ARCH}"/>
+  <section if="NDKV8+">
+    <flag value="-I${ANDROID_NDK_ROOT}/sources/cxx-stl/gnu-libstdc++/${TOOLCHAIN_VERSION}/include" />
+    <flag value="-I${ANDROID_NDK_ROOT}/sources/cxx-stl/gnu-libstdc++/${TOOLCHAIN_VERSION}/libs/${ABI}/include" />
+  </section>
+  <section unless="NDKV8+">
     <flag value="-I${ANDROID_NDK_ROOT}/sources/cxx-stl/gnu-libstdc++/libs/${ABI}/include" />
-   <flag value="-I${ANDROID_NDK_ROOT}/sources/cxx-stl/gnu-libstdc++/include" />
- </section>
+    <flag value="-I${ANDROID_NDK_ROOT}/sources/cxx-stl/gnu-libstdc++/include" />
+  </section>
 
- <include name="toolchain/common-defines.xml" />
- <flag value="-I${HXCPP}/include"/>
- <flag value="-Iinclude"/>
- <flag value="-fpic"/>
- <flag value="-fvisibility=hidden"/>
- <flag value="-ffunction-sections"/>
- <flag value="-funwind-tables"/>
- <flag value="-fstack-protector"/>
- <flag value="-fno-short-enums"/>
- <cppflag value="-Wno-invalid-offsetof" />
- <cppflag value="-frtti"/>
- <flag value="-D_LINUX_STDDEF_H "/> <!-- Avoid compiler including 2 version of file -->
- <flag value="-Wno-psabi" />
- <cppflag value="-std=c++11" if="HXCPP_CPP11"/>
- <flag value="-DHXCPP_CPP11" if="HXCPP_CPP11"/>
+  <include name="toolchain/common-defines.xml" />
+  <flag value="-flto" if="HXCPP_OPTIMIZE_LINK" unless="debug"/>
+  <flag value="-I${HXCPP}/include"/>
+  <flag value="-Iinclude"/>
+  <flag value="-fpic"/>
+  <flag value="-fvisibility=hidden"/>
+  <flag value="-ffunction-sections"/>
+  <flag value="-funwind-tables"/>
+  <flag value="-fstack-protector"/>
+  <flag value="-fno-short-enums"/>
+  <cppflag value="-Wno-invalid-offsetof" />
+  <cppflag value="-frtti"/>
+  <flag value="-D_LINUX_STDDEF_H "/> <!-- Avoid compiler including 2 version of file -->
+  <flag value="-Wno-psabi" />
+  <cppflag value="-std=c++11" if="HXCPP_CPP11"/>
+  <flag value="-DHXCPP_CPP11" if="HXCPP_CPP11"/>
 
- <section unless="HXCPP_X86">
+  <section unless="HXCPP_X86">
 
     <section if="HXCPP_ARMV7">
        <flag value="-march=armv7-a"  />
@@ -100,35 +101,39 @@
        <flag value="-mtune=xscale" />
        <flag value="-msoft-float" />
     </section>
- </section>
- <section if="HXCPP_X86">
-   <flag value="-DANDROID_X86"/>
- </section>
+  </section>
+  <section if="HXCPP_X86">
+    <flag value="-DANDROID_X86"/>
+  </section>
 
 
- <flag value="-fomit-frame-pointer"/>
- <flag value="-fexceptions"/>
- <flag value="-fno-strict-aliasing"/>
- <flag value="-finline-limit=10000"/>
- <flag value="-DANDROID=ANDROID"/>
- <flag value="-DHX_ANDROID"/>
- <flag value="${ANDROID_PLATFORM_DEFINE}"/>
- <!-- todo <flag value="-Werror"/> -->
- <flag value="-Wa,--noexecstack"/>
- <flag value="-O2" unless="debug || HXCPP_OPTIMIZE_FOR_SIZE"/>
- <section if="HXCPP_OPTIMIZE_FOR_SIZE" unless="debug">
-	<!-- see https://software.intel.com/en-us/blogs/2013/01/17/x86-gcc-code-size-optimizations -->
-	<flag value="-Os" />
-	<flag value="-fno-asynchronous-unwind-tables" />
- </section>
- <flag value="-O0" if="debug"/>
- <flag value="-g" if="HXCPP_DEBUG_LINK"/>
- <flag value="-DNDEBUG"/>
- <flag value="-DHXCPP_LOAD_DEBUG" if="HXCPP_LOAD_DEBUG"/>
- <flag value="-c"/>
- <outflag value="-o"/>
- <ext value=".obj"/>
- <objdir value="obj/android${OBJEXT}${ARCH}" />
+  <flag value="-fomit-frame-pointer"/>
+  <flag value="-fexceptions"/>
+  <flag value="-fno-strict-aliasing"/>
+  <flag value="-finline-limit=10000"/>
+  <flag value="-DANDROID=ANDROID"/>
+  <flag value="-DHX_ANDROID"/>
+  <flag value="${ANDROID_PLATFORM_DEFINE}"/>
+  <!-- todo <flag value="-Werror"/> -->
+  <flag value="-Wa,--noexecstack"/>
+  <flag value="-O2" unless="debug || HXCPP_OPTIMIZE_FOR_SIZE || HXCPP_OPTIMIZE_FOR_FAST"/>
+  <flag value="-Ofast"  if="HXCPP_OPTIMIZE_FOR_FAST" unless="debug"/> 
+  <section if="HXCPP_OPTIMIZE_FOR_SIZE" unless="debug || HXCPP_OPTIMIZE_FOR_FAST">
+	  <!-- see https://software.intel.com/en-us/blogs/2013/01/17/x86-gcc-code-size-optimizations -->
+    <flag value="-Os" />
+    <flag value="-fno-asynchronous-unwind-tables" />
+  </section>
+  <section if="HXCPP_OPTIMIZE_FOR_FAST" unless="debug">
+    <flag value="-Ofast" />
+  </section>
+  <flag value="-O0" if="debug"/>
+  <flag value="-g" if="HXCPP_DEBUG_LINK"/>
+  <flag value="-DNDEBUG"/>
+  <flag value="-DHXCPP_LOAD_DEBUG" if="HXCPP_LOAD_DEBUG"/>
+  <flag value="-c"/>
+  <outflag value="-o"/>
+  <ext value=".obj"/>
+  <objdir value="obj/android${OBJEXT}${ARCH}" />
 </compiler>
 
 
@@ -144,9 +149,11 @@
   <flag value="-nostdlib"/>
   <flag value="-std=c++11" if="HXCPP_CPP11"/>
   <flag value="-Wl,-shared,-Bsymbolic"/>
-  <section if="HXCPP_OPTIMIZE_FOR_SIZE" unless="debug">
-	<!-- see https://software.intel.com/en-us/blogs/2013/01/17/x86-gcc-code-size-optimizations -->
-	<flag value="-Wl,--gc-sections" />
+  <section if="HXCPP_OPTIMIZE_FOR_SIZE || HXCPP_GC_SECTIONS" unless="debug">
+    <flag value="-Wl,--gc-sections" />
+  </section>
+  <section if="HXCPP_STRIP_ALL" unless="debug || HXCPP_DEBUG_LINK">
+    <flag value="-Wl,--strip-all" unless="HXCPP_DEBUG_LINK"/>
   </section>
   <flag value="-Wl,--no-undefined" unless="dll_import" />
   <flag value="-Wl,--unresolved-symbols=ignore-in-object-files" if="dll_import" />


### PR DESCRIPTION
Added 
HXCPP_OPTIMIZE_LINK: Uses lto (link time optimization. reduces apk size)
HXCPP_OPTIMIZE_FOR_FAST: Uses "Ofast" instead of "O2"
HXCPP_GC_SECTIONS: strips gc sections without having to use HXCPP_OPTIMIZE_FOR_SIZE which sets "Os"
HXCPP_STRIP_ALL: strips debugging data for a smaller APK but may be difficult to debug.

Fix some file space alignment.

Issues
https://github.com/HaxeFoundation/hxcpp/issues/548
https://github.com/HaxeFoundation/hxcpp/issues/541