### PR TITLE
iOS fix getFloat from unaligned data on Release

### DIFF
--- a/include/hx/StdLibs.h
+++ b/include/hx/StdLibs.h
@@ -301,9 +301,13 @@ inline float __hxcpp_align_get_float32( unsigned char *base, int addr)
    if (addr & 3)
    {
       float buf;
+      #ifdef IPHONE
+      memcpy((void*)&buf,(base+addr),sizeof(float));
+      #else
       unsigned int *dest = (unsigned int *)&buf;
       const unsigned int *src = (const unsigned int *)(base+addr);
       *dest = *src;
+      #endif
       return buf;
    }
    #endif


### PR DESCRIPTION
Prevent EXC_ARM_DA_ALIGN exception on iOS Release when reading a unaligned float. 
https://github.com/HaxeFoundation/hxcpp/issues/557

TODO: check __hxcpp_align_set_float32, __hxcpp_align_set_float64 and __hxcpp_align_get_float64