### PR TITLE
iOS/Mac toolchain: HXCPP_OPTIMIZE_LINK[_INCREMENTAL], HXCPP_CPP11 for Mac

### DIFF
--- a/toolchain/finish-setup.xml
+++ b/toolchain/finish-setup.xml
@@ -28,6 +28,7 @@
 
 <set name="OBJDBG" value="-debug" if="debug" />
 <set name="OBJOPT" value="-opt" if="HXCPP_OPTIMIZE_LINK" unless="debug" />
+<set name="OBJOPT" value="-optinc" if="HXCPP_OPTIMIZE_LINK_INCREMENTAL || HXCPP_LTO_THIN" unless="debug" />
 <set name="OBJEXT" value="${M64}${F32}${STAT}${OBJDBG}${OBJOPT}${NOCONSOLE}${RPI}${APIFP}${PRIME}" />
 
 <set name="STD_MODULE_LINK" value="static_link" if="static_link"/>

--- a/toolchain/iphoneos-toolchain.xml
+++ b/toolchain/iphoneos-toolchain.xml
@@ -17,6 +17,8 @@
 <set name="OBJGCC" value="-gcc" if="HXCPP_GCC" />
 <set name="OBJDBG" value="-dbg" if="debug" />
 
+<set name="HXCPP_LTO_THIN" value="1" if="HXCPP_OPTIMIZE_LINK_INCREMENTAL"/>
+
 
 <compiler id="iPhoneOS" exe="g++" if="iphoneos">
   <exe name="xcrun --sdk iphoneos${IPHONE_VER} g++" if="HXCPP_GCC" />
@@ -56,6 +58,8 @@
   <flag value="-DIPHONE=IPHONE"/>
   <flag value="-DIPHONEOS=IPHONEOS"/>
   <include name="toolchain/common-defines.xml" />
+  <flag value="-flto" if="HXCPP_OPTIMIZE_LINK" unless="debug || HXCPP_LTO_THIN"/>
+  <flag value="-flto=thin" if="HXCPP_LTO_THIN" unless="debug"/>
   <flag value="-DHXCPP_BIG_ENDIAN" if="HXCPP_BIG_ENDIAN"/>
   <flag value="-I${HXCPP}/include"/>
   <!-- Removed for iOS 8 (no need) -->
@@ -74,6 +78,7 @@
 <linker id="dll" exe="g++" >
   <exe name="xcrun --sdk iphoneos${IPHONE_VER} g++" if="HXCPP_GCC" />
   <exe name="xcrun --sdk iphoneos${IPHONE_VER} clang++" />
+  <flag value="-Wl,-cache_path_lto,/tmp" if="HXCPP_OPTIMIZE_LINK_INCREMENTAL" unless="debug"/>
   <flag value="-stdlib=libstdc++" if="FORCE_LIBGCC" />
   <flag value="-stdlib=libc++" if="HXCPP_CPP11" />
   <flag value="-dynamiclib"/>

--- a/toolchain/mac-toolchain.xml
+++ b/toolchain/mac-toolchain.xml
@@ -3,16 +3,20 @@
 
 <set name="HXCPP_USE_LIBTOOL" value="1" />
 <include name="toolchain/gcc-toolchain.xml"/>
-<setenv name="MACOSX_DEPLOYMENT_TARGET" value="10.7" if="OBJC_ARC" unless="MACOSX_DEPLOYMENT_TARGET" />
-<setenv name="MACOSX_DEPLOYMENT_TARGET" value="10.6" unless="MACOSX_DEPLOYMENT_TARGET" />
+<setenv name="MACOSX_DEPLOYMENT_TARGET" value="10.9" if="HXCPP_CPP11" />
+<setenv name="MACOSX_DEPLOYMENT_TARGET" value="10.7" if="OBJC_ARC" unless="MACOSX_DEPLOYMENT_TARGET || HXCPP_CPP11" />
+<setenv name="MACOSX_DEPLOYMENT_TARGET" value="10.6" unless="MACOSX_DEPLOYMENT_TARGET || HXCPP_CPP11" />
 <path name="${DEVELOPER_DIR}/usr/bin" />
+<set name="HXCPP_LTO_THIN" value="1" if="HXCPP_OPTIMIZE_LINK_INCREMENTAL"/>
 
 
 <compiler id="darwin" exe="g++" if="macos">
   <exe name="xcrun --sdk macosx${MACOSX_VER} clang++" if="HXCPP_CLANG" />
   <flag value="-c"/>
   <flag value="-fvisibility=hidden"/>
-  <flag value="-stdlib=libstdc++" unless="HXCPP_GCC" />
+  <cppflag value="-std=c++11" if="HXCPP_CPP11" unless="HXCPP_GCC"/>
+  <flag value="-stdlib=libc++" if="HXCPP_CPP11" unless="HXCPP_GCC" />
+  <flag value="-stdlib=libstdc++" unless="HXCPP_GCC || HXCPP_CPP11" />
   <cppflag value="-frtti"/>
   <pchflag value="-x" />
   <pchflag value="c++-header" />
@@ -35,6 +39,8 @@
   <flag value="-fobjc-arc" if="OBJC_ARC" />
   <flag value="-DOBJC_ARC" if="OBJC_ARC" />
   <include name="toolchain/common-defines.xml" />
+  <flag value="-flto" if="HXCPP_OPTIMIZE_LINK" unless="debug || HXCPP_LTO_THIN"/>
+  <flag value="-flto=thin" if="HXCPP_LTO_THIN" unless="debug"/>
   <objdir value="obj/darwin${OBJEXT}/" />
   <outflag value="-o"/>
   <ext value=".o"/>
@@ -45,7 +51,9 @@
   <exe name="xcrun --sdk macosx${MACOSX_VER} clang++" if="HXCPP_CLANG" />
   <fromfile value="" if="GCC_OLD" />
   <flag value="-Wl,-bundle,-bundle_loader,${dll_import_link}" if="dll_import_link" />
-  <flag value="-stdlib=libstdc++" unless="HXCPP_GCC" />
+  <flag value="-Wl,-cache_path_lto,/tmp" if="HXCPP_LTO_THIN" unless="debug"/>
+  <flag value="-stdlib=libc++" if="HXCPP_CPP11" unless="HXCPP_GCC" />
+  <flag value="-stdlib=libstdc++" unless="HXCPP_GCC || HXCPP_CPP11" />
   <flag value="-fpic"/>
   <flag value="-fPIC"/>
   <flag value="-dynamiclib"/>
@@ -64,8 +72,10 @@
 <linker id="exe" exe="g++" if="macos">
   <exe name="xcrun --sdk macosx${MACOSX_VER} clang++" if="HXCPP_CLANG" />
   <!-- <flag value="-Wl,-stack_size,0x8000"/> -->
+  <flag value="-Wl,-cache_path_lto,/tmp" if="HXCPP_OPTIMIZE_LINK_INCREMENTAL" unless="debug"/>
   <fromfile value="" if="GCC_OLD" />
-  <flag value="-stdlib=libstdc++" unless="HXCPP_GCC" />
+  <flag value="-stdlib=libc++" if="HXCPP_CPP11" unless="HXCPP_GCC" />
+  <flag value="-stdlib=libstdc++" unless="HXCPP_GCC || HXCPP_CPP11" />
   <flag value="-framework"/>
   <flag value="Cocoa"/>
   <flag value="-isysroot" unless="LEGACY_MACOSX_SDK"/>

--- a/toolchain/mac-toolchain.xml
+++ b/toolchain/mac-toolchain.xml
@@ -3,9 +3,9 @@
 
 <set name="HXCPP_USE_LIBTOOL" value="1" />
 <include name="toolchain/gcc-toolchain.xml"/>
-<setenv name="MACOSX_DEPLOYMENT_TARGET" value="10.9" if="HXCPP_CPP11" />
-<setenv name="MACOSX_DEPLOYMENT_TARGET" value="10.7" if="OBJC_ARC" unless="MACOSX_DEPLOYMENT_TARGET || HXCPP_CPP11" />
-<setenv name="MACOSX_DEPLOYMENT_TARGET" value="10.6" unless="MACOSX_DEPLOYMENT_TARGET || HXCPP_CPP11" />
+<setenv name="MACOSX_DEPLOYMENT_TARGET" value="10.9" if="HXCPP_CPP11" unless="MACOSX_DEPLOYMENT_TARGET"/>
+<setenv name="MACOSX_DEPLOYMENT_TARGET" value="10.7" if="OBJC_ARC" unless="MACOSX_DEPLOYMENT_TARGET" />
+<setenv name="MACOSX_DEPLOYMENT_TARGET" value="10.6" unless="MACOSX_DEPLOYMENT_TARGET" />
 <path name="${DEVELOPER_DIR}/usr/bin" />
 <set name="HXCPP_LTO_THIN" value="1" if="HXCPP_OPTIMIZE_LINK_INCREMENTAL"/>
 
@@ -74,7 +74,6 @@
   <!-- <flag value="-Wl,-stack_size,0x8000"/> -->
   <flag value="-Wl,-cache_path_lto,/tmp" if="HXCPP_OPTIMIZE_LINK_INCREMENTAL" unless="debug"/>
   <fromfile value="" if="GCC_OLD" />
-  <flag value="-stdlib=libc++" if="HXCPP_CPP11" unless="HXCPP_GCC" />
   <flag value="-stdlib=libstdc++" unless="HXCPP_GCC || HXCPP_CPP11" />
   <flag value="-framework"/>
   <flag value="Cocoa"/>


### PR DESCRIPTION
HXCPP_OPTIMIZE_LINK compiles and links using lto
HXCPP_OPTIMIZE_LINK_INCREMENTAL compiles and links using "thin lto",
sets a cache on /tmp
HXCPP_CPP11 for macOS 10.9+ target
https://github.com/HaxeFoundation/hxcpp/issues/560
https://github.com/HaxeFoundation/hxcpp/issues/541

Note: Thin LTO requires XCode 8+