### PR TITLE
Missing function declaration with HXCPP_DEBUGGER

### DIFF
--- a/src/hx/cppia/CppiaModule.cpp
+++ b/src/hx/cppia/CppiaModule.cpp
@@ -97,6 +97,9 @@ void CppiaModule::compile()
 }
 #endif
 
+void addScriptableClass(String inName);
+void addScriptableFile(String inName);
+
 void CppiaModule::registerDebugger()
 {
    #ifdef HXCPP_DEBUGGER


### PR DESCRIPTION
Needs function declaration due to code splitting in 4b1abcc.