### PR TITLE
A basic telemetry testcase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ test/std/mybase.db
 test/opMatrix/Ops.hx
 test/opMatrix/cpp
 test/haxe/cpp
+test/telemetry/cpp
 test/extern-lib/gen-externs
 test/cffi/project/ndll
 hxcpp.n

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,7 @@ script:
   - cd ${TRAVIS_BUILD_DIR}/test
   - haxe --run RunTests cffi
   - haxe --run RunTests haxe
+  - haxe --run RunTests telemetry
   - haxe --run RunTests std32
   - haxe --run RunTests std64
   - cd ~/haxe/tests/unit

--- a/test/RunTests.hx
+++ b/test/RunTests.hx
@@ -37,6 +37,20 @@ class RunTests
       command("bin" + sep + "TestMain-debug",[]);
    }
 
+   public static function runTelemetry()
+   {
+      setDir("telemetry");
+
+      // Telemetry should work in debug and non-debug modes
+      // TODO: do we need m64Def?
+      command("haxe", ["compile.hxml", "-debug"].concat(cppAst) );
+      command("bin" + sep + "TestMain-debug",[]);
+
+      command("haxe", ["compile.hxml"].concat(cppAst) );
+      command("bin" + sep + "TestMain",[]);
+
+   }
+
 
    public static function opMatrix()
    {
@@ -159,6 +173,7 @@ class RunTests
       run("cffi", cffi);
       run("opMatrix", opMatrix);
       run("haxe", runHaxe);
+      run("telemetry", runTelemetry);
       run("std32", std32);
       run("std64", std64);
       run("native", native);

--- a/test/telemetry/TestBasic.hx
+++ b/test/telemetry/TestBasic.hx
@@ -1,0 +1,19 @@
+class TestBasic extends haxe.unit.TestCase
+{
+  public function new() super();
+
+  function testStartTelemetry(string:String)
+  {
+    var thread_id:Int = startTelemetry(true, true);
+    assertTrue(thread_id>=0);
+  }
+
+  function startTelemetry(with_profiler:Bool=true,
+                          with_allocations:Bool=true):Int
+  {
+    // Compile will fail without -D HXCPP_TELEMETRY
+    return untyped __global__.__hxcpp_hxt_start_telemetry(with_profiler,
+                                                          with_allocations);
+  }
+
+}

--- a/test/telemetry/TestMain.hx
+++ b/test/telemetry/TestMain.hx
@@ -1,0 +1,13 @@
+package;
+
+class TestMain {
+
+	static function main(){
+		var r = new haxe.unit.TestRunner();
+		r.add(new TestBasic());
+    var t0 = haxe.Timer.stamp();
+		var success = r.run();
+    trace(" Time : " + (haxe.Timer.stamp()-t0)*1000 );
+		Sys.exit(success ? 0 : 1);
+	}
+}

--- a/test/telemetry/TestMain.hx
+++ b/test/telemetry/TestMain.hx
@@ -2,12 +2,12 @@ package;
 
 class TestMain {
 
-	static function main(){
-		var r = new haxe.unit.TestRunner();
-		r.add(new TestBasic());
+  static function main(){
+    var r = new haxe.unit.TestRunner();
+    r.add(new TestBasic());
     var t0 = haxe.Timer.stamp();
-		var success = r.run();
+    var success = r.run();
     trace(" Time : " + (haxe.Timer.stamp()-t0)*1000 );
-		Sys.exit(success ? 0 : 1);
-	}
+    Sys.exit(success ? 0 : 1);
+  }
 }

--- a/test/telemetry/compile.hxml
+++ b/test/telemetry/compile.hxml
@@ -1,0 +1,5 @@
+-cpp bin
+-main TestMain
+-resource TestMain.hx
+-D HXCPP_TELEMETRY
+-D HXCPP_STACK_TRACE

--- a/test/telemetry/test.bat
+++ b/test/telemetry/test.bat
@@ -1,0 +1,2 @@
+haxe compile.hxml
+"bin/TestMain.exe"


### PR DESCRIPTION
Hi @hughsando -

I've been meaning to write a basic telemetry testcase (and @gama11 reminded me yesterday), since it's easy for the code to fall into disrepair since it's all tucked behind an `HXCPP_TELEMETRY` define.

Feel free to review -- I copied from the `haxe` test, and it seemed pretty straightforward, but let me know if I need to make any changes. I did note (RunTest.hx line 47) -- do I need the `m64Def` I see some tests using?

This new telemetry test passes in hxcpp 3.4.56 (the version when we fixed the [thread_id issue](https://github.com/HaxeFoundation/hxcpp/issues/567)), as well as the latest nightly, 3.4.62. It segfaults in the older 3.4.49 (as expected, I think -- telemetry was broken then.)

Does the testing framework catch segfaults and compiler issues (e.g. due to code shuffle)?

Thanks!
-Jeff