### PR TITLE
Fix Int64 to Int/Float casts

### DIFF
--- a/include/hx/Operators.h
+++ b/include/hx/Operators.h
@@ -238,18 +238,18 @@ template<> inline bool TCastObject<bool>(hx::Object *inObj)
 template<> inline int TCastObject<int>(hx::Object *inObj)
 {
    if (!inObj || !(inObj->__GetType()==::vtInt ||
-        (inObj->__GetType()==::vtFloat && inObj->__ToDouble()==inObj->__ToInt()) ) ) return hx::BadCast();
+        ((inObj->__GetType()==::vtFloat || inObj->__GetType()==::vtInt64) && inObj->__ToDouble()==inObj->__ToInt()) ) ) return hx::BadCast();
    return inObj->__ToInt();
 }
 template<> inline double TCastObject<double>(hx::Object *inObj)
 {
-   if (!inObj || (inObj->__GetType()!=::vtFloat && inObj->__GetType()!=::vtInt))
+   if (!inObj || (inObj->__GetType()!=::vtFloat && inObj->__GetType()!=::vtInt64 && inObj->__GetType()!=::vtInt))
       return hx::BadCast();
    return inObj->__ToDouble();
 }
 template<> inline float TCastObject<float>(hx::Object *inObj)
 {
-   if (!inObj || (inObj->__GetType()!=::vtFloat && inObj->__GetType()!=::vtInt))
+   if (!inObj || (inObj->__GetType()!=::vtFloat && inObj->__GetType()!=::vtInt64 && inObj->__GetType()!=::vtInt))
       return hx::BadCast();
    return inObj->__ToDouble();
 }


### PR DESCRIPTION
Ever since https://github.com/HaxeFoundation/hxcpp/commit/5f29028d6063b37ff7915cff1b3b83b6beee103d#diff-24091b03a703274be4a56a48d140ed24R144 was done, any casts of Int64's to either Int or Float started to fail with a bad cast. This PR fixes this.