### PR TITLE
Attempt at fixing #587

### DIFF
--- a/src/hx/cppia/Cppia.cpp
+++ b/src/hx/cppia/Cppia.cpp
@@ -2046,7 +2046,7 @@ struct CallMemberVTable : public CppiaExpr
    #define CALL_VTABLE_SETUP \
       hx::Object *thisVal = thisExpr ? thisExpr->runObject(ctx) : ctx->getThis(); \
       CPPIA_CHECK(thisVal); \
-      ScriptCallable **vtable = *(ScriptCallable ***)((char *)thisVal +scriptVTableOffset); \
+      ScriptCallable **vtable = (!isInterfaceCall ? (*(ScriptCallable ***)((char *)thisVal +scriptVTableOffset)) : (ScriptCallable **) thisVal->__GetScriptVTable()); \
       unsigned char *pointer = ctx->pointer; \
       vtable[slot]->pushArgs(ctx, thisVal, args); \
       /* TODO */; \

--- a/test/cppia/Client.hx
+++ b/test/cppia/Client.hx
@@ -28,6 +28,12 @@ class Client
          return;
       }
 
+      var c2:ClientExtendsInterface.ClientInterface = new ClientExtendsInterface();
+      if (!c2.isOk()) {
+         Common.status = "Bad client interface implementation";
+         return;
+      }
+
       Common.clientImplementation = new ClientOne();
       Common.status = "ok";
    }

--- a/test/cppia/ClientExtendsInterface.hx
+++ b/test/cppia/ClientExtendsInterface.hx
@@ -1,0 +1,10 @@
+class ClientExtendsInterface extends ClientExtends implements ClientInterface {
+  public function isOk():Bool {
+    return this.ok();
+  }
+}
+
+interface ClientInterface {
+  public function isOk():Bool;
+}
+


### PR DESCRIPTION
Call `__GetScriptVTable()` if this is an interface call

Closes #587

This actually fixes it, but I think there must be a prettier (read: more correct :P ) fix