### PR TITLE
pursue compatibility with Microsoft Visual Studio 2017 

### DIFF
--- a/toolchain/msvc-setup.bat
+++ b/toolchain/msvc-setup.bat
@@ -1,5 +1,9 @@
 setlocal enabledelayedexpansion
-@if exist "%HXCPP_MSVC%\vsvars32.bat" (
+@if exist "%HXCPP_MSVC%\vcvars32.bat" (
+	@call "%HXCPP_MSVC%\vcvars32.bat"
+	@echo HXCPP_VARS
+	@set
+) else if exist "%HXCPP_MSVC%\vsvars32.bat" (
 	@call "%HXCPP_MSVC%\vsvars32.bat"
 	@echo HXCPP_VARS
 	@set


### PR DESCRIPTION
the `vsvars*` files we need are now located at `"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat"`

i combine this patch with:

```
export HXCPP_MSVC="C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\VC\\Auxiliary\\Build\\"
```

before running things like:

```
haxelib run lime rebuild windows
```

someone should also work on the 64 bit equivalent scripts we have in here
and maybe make it so that HXCPP_MSVC env var is not necessary to specify by default


this works for me.