### PR TITLE
[winrt] set -ZW abi as default even for static linking, ignore warning

### DIFF
--- a/toolchain/msvc-toolchain.xml
+++ b/toolchain/msvc-toolchain.xml
@@ -8,11 +8,11 @@
 <set name="USE_PRECOMPILED_HEADERS" value="msvc" unless="NO_PRECOMPILED_HEADERS" />
 
 <section if="winrt">
-   <set name="ABI" value="-ZW" unless="ABI">
+   <set name="ABI" value="-ZW" unless="ABI" />
    <set name="C_ABI" value="-MD" />
 </section>
 <section unless="winrt">
-   <set name="ABI" value="-MT" unless="ABI"/>
+   <set name="ABI" value="-MT" unless="ABI" />
    <set name="C_ABI" value="${ABI}" />
 </section>
 <set name="CPP_ABI" value="${ABI}" />

--- a/toolchain/msvc-toolchain.xml
+++ b/toolchain/msvc-toolchain.xml
@@ -8,13 +8,9 @@
 <set name="USE_PRECOMPILED_HEADERS" value="msvc" unless="NO_PRECOMPILED_HEADERS" />
 
 <section if="winrt">
+   <set name="ABI" value="-ZW" unless="ABI">
    <set name="C_ABI" value="-MD" />
-   <set name="ABI" value="-ZW" unless="ABI || static_link"/>
-   <!-- Note: Default winrt static_link uses native libs. -->
-   <!--       Use -DABI=-ZW for "main", or to force UWP libs (e.g. targeting XBOXONE UWP) -->
-   <set name="ABI" value="-MD" if="static_link" unless="ABI"/>
 </section>
-
 <section unless="winrt">
    <set name="ABI" value="-MT" unless="ABI"/>
    <set name="C_ABI" value="${ABI}" />
@@ -161,6 +157,7 @@
   <flag value="-LTCG" if="HXCPP_OPTIMIZE_LINK" unless="debug"/>
   <fromfile value="@"/>
   <flag value="-nologo"/>
+  <flag value="-IGNORE:4264" if="winrt" />
   <ext value="${LIBEXT}"/>
   <outflag value="-out:"/>
 </linker>


### PR DESCRIPTION
Assume that winrt target will be compiled using msvc 2015 update 3 or later. 
Ignores the following warning.
warning LNK4264: archiving object file compiled with /ZW into a static library; note that when authoring Windows Runtime types it is not recommended to link with a static library that contains Windows Runtime metadata if you are using a linker released before VS 2015 Update 2