### PR TITLE
warning: binding dereferenced null pointer?

### DIFF
--- a/include/null.h
+++ b/include/null.h
@@ -128,8 +128,11 @@ class null
 
      inline Dynamic &operator()(const AnyArg &a0=0, const AnyArg &a1=0, const AnyArg &a2=0,
             const AnyArg &a4=0, const AnyArg &a5=0, const AnyArg &a6=0,
-            const AnyArg &a7=0, const AnyArg &a8=0, const AnyArg &a9=0 )
-        { hx::NullReference("Function Call", false); return *(Dynamic *)0; }
+            const AnyArg &a7=0, const AnyArg &a8=0, const AnyArg &a9=0 ) {
+                hx::NullReference("Function Call", false);
+                Dynamic* nullDynamic = 0;
+                return *nullDynamic;
+            }
 
 	  HX_NULL_COMPARE_OPS(bool)
 	  HX_NULL_COMPARE_OPS(double)


### PR DESCRIPTION
Hey Hugh

Anything that inlines the function I modified will spit out the following warning, might be mac only. It's just some that I've ignored for a long time, but this minor change seems to fix it. Does it look kosher to you? Not sure what the difference really is, but compiler seems to like it better.

Fix for hxcpp/include/null.h:132:61: warning: binding dereferenced null pointer to reference has undefined behavior [-Wnull-dereference]