### PR TITLE
Cache fixes

### DIFF
--- a/tools/hxcpp/CompileCache.hx
+++ b/tools/hxcpp/CompileCache.hx
@@ -110,15 +110,21 @@ class CompileCache
               continue;
            var projectHasDirs = false;
            var projDir = compileCache + "/" + project;
+           if(!FileSystem.isDirectory(projDir))
+               continue;
            var dirs = FileSystem.readDirectory(projDir);
            for(dir in dirs)
            {
+              var path = projDir + "/" + dir;
+              if(!FileSystem.isDirectory(path)) {
+                  FileSystem.deleteFile(path);
+                  continue;
+              }
               if (dir.length!=2 && dir!="lib" && dir.substr(0,3)!="pch" )
               {
                  Log.warn('bad cache name "$dir" found - try manually clearing');
                  continue;
               }
-              var path = projDir + "/" + dir;
               var dirFiles = FileSystem.readDirectory(path);
               var allDeleted = true;
               for(file in dirFiles)

--- a/tools/hxcpp/CompileCache.hx
+++ b/tools/hxcpp/CompileCache.hx
@@ -256,10 +256,14 @@ class CompileCache
            var projSize = size;
            var projCount = count;
            var projDir = compileCache + "/" + project;
+           if(!FileSystem.isDirectory(projDir))
+               continue;
            var dirs = FileSystem.readDirectory(projDir);
            for(dir in dirs)
            {
               var path = projDir + "/" + dir;
+              if(!FileSystem.isDirectory(path))
+                  continue;
               var dirFiles = FileSystem.readDirectory(path);
               for(file in dirFiles)
               {


### PR DESCRIPTION
Some minor fixes for the .DS_Store files on OSX preventing cache clears and cache list to work properly. There's one major fix in here for large cache sizes, if you set your HXCPP_CACHE_MB to 2048 and greater before this change it would delete your entire cache and recompile every file every build. Something that was giving me quite a headache today. The problem was with 32 bit precision when taking inMB * 1024 * 1024. I should the calculations to be in KB instead of K, and that increase the allowed size a decent amount.