### PR TITLE
HXCPP tools speedup (WIP)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ test/extern-lib/gen-externs
 test/cffi/project/ndll
 test/snippets/messagebox/cpp
 hxcpp.n
+hxcpp-fallback.n
 .DS_Store
 
 *.swp

--- a/include/Array.h
+++ b/include/Array.h
@@ -348,9 +348,9 @@ public:
 
    mutable int length;
 
-   static inline int baseOffset() { return (int)offsetof(ArrayBase,mBase); }
-   static inline int allocOffset() { return (int)offsetof(ArrayBase,mAlloc); }
-   static inline int lengthOffset() { return (int)offsetof(ArrayBase,length); }
+   #pragma static inline int baseOffset() { return (int)offsetof(ArrayBase,mBase); }
+   #pragma static inline int allocOffset() { return (int)offsetof(ArrayBase,mAlloc); }
+   #pragma static inline int lengthOffset() { return (int)offsetof(ArrayBase,length); }
 
 protected:
    mutable int mAlloc;

--- a/tools/hxcpp/BuildTool.hx
+++ b/tools/hxcpp/BuildTool.hx
@@ -1,3 +1,5 @@
+import haxe.CallStack;
+import com.thomasuster.threadpool.ThreadPool;
 import CopyFile.Overwrite;
 import haxe.io.Path;
 import haxe.xml.Fast;
@@ -390,17 +392,31 @@ class BuildTool
 
          var inList = new Array<Bool>();
          var groupIsOutOfDate = mDirtyList.indexOf(group.mId)>=0 || mDirtyList.indexOf("all")>=0;
-         for(file in group.mFiles)
-         {
-           if (useCache)
-               file.computeDependHash();
-            var obj_name = mCompiler.getCachedObjName(file);
-            groupObjs.push(obj_name);
-            var outOfDate = groupIsOutOfDate || file.isOutOfDate(obj_name);
-            if (outOfDate)
-               to_be_compiled.push(file);
-            inList.push(outOfDate);
+         
+         Log.initMultiThreaded();
+         for (i in 0...group.mFiles.length) {
+             groupObjs.push(null);
+             to_be_compiled.push(null);
+             inList.push(false);
          }
+         var pool:ThreadPool = new ThreadPool(threads);
+         pool.distributeLoop(group.mFiles.length,function(tid:Int, index:Int) {
+             var file:File = group.mFiles[index];
+             if (useCache)
+                 file.computeDependHash();
+             var obj_name = mCompiler.getCachedObjName(file);
+             groupObjs[index] = (obj_name);
+             var outOfDate = groupIsOutOfDate || file.isOutOfDate(obj_name);
+             if (outOfDate)
+                 to_be_compiled[index] = (file);
+             inList[index] = (outOfDate);     
+         });
+         pool.blockRunAll();
+         pool.end();
+         to_be_compiled = to_be_compiled.filter(function(v:File):Bool {
+             return v != null;
+         });
+
          var someCompiled = to_be_compiled.length > 0;
 
          var pchStamp:Null<Float> = null;

--- a/tools/hxcpp/BuildToolLauncher.hx
+++ b/tools/hxcpp/BuildToolLauncher.hx
@@ -1,0 +1,34 @@
+import sys.FileSystem;
+
+class BuildToolLauncher 
+{
+    public static function main():Void {
+        var bin:String = './bin/tools/${calcBinName()}';
+        if(FileSystem.exists(bin) && !isBuildingSelf()) {
+            Sys.exit(Sys.command('./bin/tools/${calcBinName()}', Sys.args()));
+        }
+        else {
+            Sys.exit(Sys.command('neko', ['hxcpp-fallback.n'].concat(Sys.args())));
+        }
+    }
+    
+    static function isBuildingSelf():Bool {
+        var args:Array<String> = Sys.args();
+        var last:String = args[args.length-1]; 
+        if(sys.FileSystem.exists('${last}../../haxelib.json')) {
+            
+            if(sys.io.File.getContent('${last}../../haxelib.json') == haxe.Resource.getString("Signature")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    static function calcBinName():String {
+        #if windows
+        return 'BuildTool-debug.exe';
+        #else
+        return 'BuildTool-debug';
+        #end
+    }
+}

--- a/tools/hxcpp/File.hx
+++ b/tools/hxcpp/File.hx
@@ -60,7 +60,7 @@ class File
 
       var content = sys.io.File.getContent(inName);
       var md5 = haxe.crypto.Md5.encode(content);
-      mFileHashes.set(inName,md5);
+//      mFileHashes.set(inName,md5); //Causes deadlock
       return md5;
    }
 

--- a/tools/hxcpp/compile.hxml
+++ b/tools/hxcpp/compile.hxml
@@ -7,6 +7,7 @@
 
 -neko ../../hxcpp-fallback.n
 -main BuildTool
+-lib haxe-threadpool
 -D neko_v1
 -debug
 
@@ -14,4 +15,5 @@
 
 -debug
 -main BuildTool
+-lib haxe-threadpool
 -cpp ../../bin/tools

--- a/tools/hxcpp/compile.hxml
+++ b/tools/hxcpp/compile.hxml
@@ -1,4 +1,17 @@
+-main BuildToolLauncher
+-resource ../../haxelib.json@Signature
 -neko ../../hxcpp.n
+-debug
+
+--next
+
+-neko ../../hxcpp-fallback.n
 -main BuildTool
 -D neko_v1
 -debug
+
+--next
+
+-debug
+-main BuildTool
+-cpp ../../bin/tools


### PR DESCRIPTION
Hey @hughsando 

This PR does a few things currently. Note this is NOT ready for merging yet. Still a work in progress.

* Multithread mCompiler.getCachedObjName
* Convert HXCPP build tool to CPP (for performance)
* A neko (-fallback) version is used while building the CPP version itself

But it seems to have problems with GC that I need your help on.
It keeps printing out
`CriticalGCError("Bad Allocation while collecting - from finalizer?");`
I've looked through the source files and I can't make sense of some of the locking mechanisms. It's also a 6,500 line file, it's very tough to figure out what's happening. I was able to print a stack trace where that CriticalGCError statement is. It looks to be triggering from LocalAllocator.callAlloc, which happens to be happening in another thread while a collect is occurring. What mutex or lock is suppose to stop this from happening?

```
0   BuildTool-debug                     0x000000010dcf898c _Z7handleri + 28
1   BuildTool-debug                     0x000000010dcfcf38 _ZN14LocalAllocator15PauseForCollectEv + 72
2   BuildTool-debug                     0x000000010dd06d99 _ZN14LocalAllocator9CallAllocEij + 73
3   BuildTool-debug                     0x000000010dcfd927 _ZN2hx11InternalNewEib + 407
4   BuildTool-debug                     0x000000010dd4c556 _ZN2hx9ArrayBaseC2Eiiib + 134
5   BuildTool-debug                     0x000000010dc29eca _ZN9Array_objIiEC2Eii + 90
6   BuildTool-debug                     0x000000010dc29e61 _ZN9Array_objIiEC1Eii + 33
7   BuildTool-debug                     0x000000010dc289cf _ZN9Array_objIiE5__newEii + 79
8   BuildTool-debug                     0x000000010dc2883b _ZN4haxe6crypto7Md5_obj8doEncodeE5ArrayIiE + 42651
9   BuildTool-debug                     0x000000010dc28bc7 _ZN4haxe6crypto7Md5_obj6encodeE6String + 151
```

It's also using this for now, https://github.com/thomasuster/haxe-threadpool, but I can refactor and/or duplicated it into HXCPP once all other problems are sorted. So let's not worry about that for now.