### PR TITLE
Fix when compiling in DEBUG without HX_CPP_DEBUG

### DIFF
--- a/src/hx/gc/Immix.cpp
+++ b/src/hx/gc/Immix.cpp
@@ -4569,7 +4569,7 @@ public:
       sgIsCollecting = true;
 
       StopThreadJobs(true);
-      #ifdef DEBUG
+      #ifdef HXCPP_DEBUG
       sgAllocsSinceLastSpam = 0;
       #endif
 


### PR DESCRIPTION
Fix a mismatch in preprocessor define used for sgAllocsSinceLastSpam. The code would not compile if HX_CPP_DEBUG is undefined while compiling in debug