### PR TITLE
xlocale.h was removed in glibc 2.26

### DIFF
--- a/project/libs/std/Sys.cpp
+++ b/project/libs/std/Sys.cpp
@@ -30,7 +30,11 @@ int __sys_prims() { return 0; }
 #ifndef ANDROID
 #	include <locale.h>
 #if !defined(BLACKBERRY) && !defined(EPPC) && !defined(GCW0)
-#	include <locale.h>
+#	if defined(HX_LINUX)
+#		include <locale.h>
+#	else
+#		include <xlocale.h>
+#	endif
 #endif
 #endif
 #endif

--- a/project/libs/std/Sys.cpp
+++ b/project/libs/std/Sys.cpp
@@ -30,7 +30,7 @@ int __sys_prims() { return 0; }
 #ifndef ANDROID
 #	include <locale.h>
 #if !defined(BLACKBERRY) && !defined(EPPC) && !defined(GCW0)
-#	include <xlocale.h>
+#	include <locale.h>
 #endif
 #endif
 #endif

--- a/src/hx/libs/std/Sys.cpp
+++ b/src/hx/libs/std/Sys.cpp
@@ -31,7 +31,7 @@
    #ifndef ANDROID
       #include <locale.h>
       #if !defined(BLACKBERRY) && !defined(EPPC) && !defined(GCW0)
-         #include <xlocale.h>
+         #include <locale.h>
       #endif
    #endif
 #endif

--- a/src/hx/libs/std/Sys.cpp
+++ b/src/hx/libs/std/Sys.cpp
@@ -31,7 +31,11 @@
    #ifndef ANDROID
       #include <locale.h>
       #if !defined(BLACKBERRY) && !defined(EPPC) && !defined(GCW0)
-         #include <locale.h>
+        #if defined(HX_LINUX)
+            #include <locale.h>
+        #else
+            #include <xlocale.h>
+        #endif
       #endif
    #endif
 #endif


### PR DESCRIPTION
My linux distribution upgraded to it (openSUSE tumbleweed) and now I can't build if I use `Sys`.

See 4.1 in https://sourceware.org/glibc/wiki/Release/2.26#Removal_of_.27xlocale.h.27

They mention that `xlocale.h` is a subset of `locale.h` so it should be fine, most tests passes locally (what doesn't doesn't seem related) for me but not sure what's the effect on earlier glibc.

Side note:
I get a lot of warning about `warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]` `note: in expansion of macro ‘THROWS’`.
And the error was `Error: ./src/Ops.cpp: In static member function ‘static void Ops_obj::main()’:
./src/Ops.cpp:1601:85: warning: ISO C++ says that these are ambiguous, even though the worst conversion for the first is better than the worst conversion for the second:
 HXLINE(3355)  uint8 = (uint8 + anon2->__Field(HX_("xyz",59,78,5b,00),hx::paccDynamic));`
I have gcc/g++ 7.1.1