### PR TITLE
Do not include xlocale.h on systems, where __GLIBC__ is defined.

### DIFF
--- a/project/libs/std/Sys.cpp
+++ b/project/libs/std/Sys.cpp
@@ -29,7 +29,7 @@ int __sys_prims() { return 0; }
 #	include <limits.h>
 #ifndef ANDROID
 #	include <locale.h>
-#if !defined(BLACKBERRY) && !defined(EPPC) && !defined(GCW0)
+#if !defined(BLACKBERRY) && !defined(EPPC) && !defined(GCW0) && !defined(__GLIBC__)
 #	include <xlocale.h>
 #endif
 #endif

--- a/src/hx/libs/std/Sys.cpp
+++ b/src/hx/libs/std/Sys.cpp
@@ -30,7 +30,7 @@
    #include <limits.h>
    #ifndef ANDROID
       #include <locale.h>
-      #if !defined(BLACKBERRY) && !defined(EPPC) && !defined(GCW0)
+      #if !defined(BLACKBERRY) && !defined(EPPC) && !defined(GCW0) && !defined(__GLIBC__)
          #include <xlocale.h>
       #endif
    #endif


### PR DESCRIPTION
Fixes build on glibc 2.26, where xlocale was removed.
https://sourceware.org/git/?p=glibc.git;a=commit;h=f0be25b

Should not be needed in glibc systems:
https://lists.opensuse.org/opensuse-factory/2017-08/msg00580.html
>xlocale.h has been obsolete for nearly 10 years, since POSIX.1-2008.
