### PR TITLE
Fix CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ test/telemetry/cpp
 test/extern-lib/gen-externs
 test/cffi/project/ndll
 test/snippets/messagebox/cpp
+test/haxe/gc/big.txt
 hxcpp.n
 .DS_Store
 

--- a/test/haxe/compile.hxml
+++ b/test/haxe/compile.hxml
@@ -1,4 +1,4 @@
 -cpp bin
 -main TestMain
 -resource TestMain.hx
--D HXCPP_GC_MOVING
+#-D HXCPP_GC_MOVING


### PR DESCRIPTION
```
haxe compile.hxml; bin/TestMain 100
```

Seems to produce runtime errors like the following...

<img width="1256" alt="newest" src="https://user-images.githubusercontent.com/220965/30576638-15f14678-9cbe-11e7-898e-15c6f9f5cd79.png">

Disabling HXCPP_GC_MOVING fixes it. Ran it 100 times on my labtop.

Waiting for travis OSX CI but if it passes please merge.
