### PR TITLE
Threaded get cached obj name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ test/cffi/project/ndll
 test/snippets/messagebox/cpp
 test/haxe/gc/big.txt
 hxcpp.n
+hxcpp-fallback.n
 .DS_Store
 
 *.swp

--- a/tools/haxe/build_osx.sh
+++ b/tools/haxe/build_osx.sh
@@ -3,6 +3,7 @@
 
   git clone --recursive https://github.com/HaxeFoundation/haxe.git ~/haxe --depth 1
 
+  brew update
   brew tap Homebrew/bundle
   brew bundle --file=~/haxe/tests/Brewfile
 

--- a/tools/hxcpp/BuildToolLauncher.hx
+++ b/tools/hxcpp/BuildToolLauncher.hx
@@ -1,0 +1,36 @@
+import sys.FileSystem;
+
+class BuildToolLauncher 
+{
+    public static function main():Void {
+        var bin:String = './bin/tools/${calcBinName()}';
+        if(FileSystem.exists(bin) && !isBuildingSelf()) {
+            Sys.exit(Sys.command('./bin/tools/${calcBinName()}', Sys.args()));
+        }
+        else {
+            Sys.exit(Sys.command('neko', ['hxcpp-fallback.n'].concat(Sys.args())));
+        }
+    }
+    
+    static function isBuildingSelf():Bool {
+        var args:Array<String> = Sys.args();
+        var last:String = args[args.length-1]; 
+        if(sys.FileSystem.exists('${last}../../haxelib.json')) {
+            
+            if(sys.io.File.getContent('${last}../../haxelib.json') == haxe.Resource.getString("Signature")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    static function calcBinName():String {
+        var binName:String = 'BuildTool';
+        #if debug
+        binName+='-debug';
+        #end
+        if(Sys.systemName() == 'Windows')
+            binName+='.exe';
+        return binName;
+    }
+}

--- a/tools/hxcpp/File.hx
+++ b/tools/hxcpp/File.hx
@@ -2,7 +2,6 @@ import sys.FileSystem;
 
 class File
 {
-   static var mFileHashes = new Map<String,String>();
    public var mName:String;
    public var mDir:String;
    public var mDependHash:String;
@@ -55,12 +54,8 @@ class File
 
    public static function getFileHash(inName:String)
    {
-      if (mFileHashes.exists(inName))
-         return mFileHashes.get(inName);
-
       var content = sys.io.File.getContent(inName);
       var md5 = haxe.crypto.Md5.encode(content);
-      mFileHashes.set(inName,md5);
       return md5;
    }
 

--- a/tools/hxcpp/Setup.hx
+++ b/tools/hxcpp/Setup.hx
@@ -230,9 +230,9 @@ class Setup
       {
          // Run it in hxcpp directory so it does not lock the build directory after build finishes
          Sys.setCwd(BuildTool.HXCPP);
-         var proc = new Process("mspdbsrv.exe",["-start"]);
+         new Process("mspdbsrv.exe",["-start"]);
          Tools.addOnExitHook(function(_) {
-           proc.kill();
+           Sys.command('taskkill', '/F /IM mspdbsrv.exe /T'.split(' '));
          });
       }
       catch(e:Dynamic)

--- a/tools/hxcpp/com/thomasuster/threadpool/ThreadModel.hx
+++ b/tools/hxcpp/com/thomasuster/threadpool/ThreadModel.hx
@@ -1,0 +1,18 @@
+package com.thomasuster.threadpool;
+#if cpp
+import cpp.vm.Mutex;
+#else
+import neko.vm.Mutex;
+#end
+class ThreadModel {
+  public var id:Int;
+  public var start:Int;
+  public var end:Int;
+  public var mutex:Mutex;
+  public var pending:Bool;
+  public var done:Bool;
+
+  public function new():Void {
+    mutex = new Mutex();
+  }
+}

--- a/tools/hxcpp/com/thomasuster/threadpool/ThreadPool.hx
+++ b/tools/hxcpp/com/thomasuster/threadpool/ThreadPool.hx
@@ -1,0 +1,113 @@
+package com.thomasuster.threadpool;
+
+#if cpp
+import cpp.vm.Thread;
+#else
+import neko.vm.Thread;
+#end
+
+private typedef LoopIndex = Int;
+private typedef ThreadID = Int;
+private typedef Task = ThreadID->Void;
+private typedef Loop = ThreadID->LoopIndex->Void;
+
+class ThreadPool {
+
+  var num:Int;
+  var theEnd:Bool;
+  var models:Array<ThreadModel>;
+  var queue:Array<Task>;
+
+  public function new(num:Int):Void {
+    this.num = num;
+    models = [];
+    queue = [];
+
+    for (i in 0...num) {
+      var model = new ThreadModel();
+      model.id = i;
+      model.mutex.acquire();
+      models.push(model);
+    }
+
+    for (i in 0...num) {
+      Thread.create(function() {
+        threadLoop(models[i]);
+      });
+    }
+  }
+
+  function threadLoop(model:ThreadModel):Void {
+    var id:ThreadID = model.id;
+    while(true) {
+      model.mutex.acquire();
+      model.pending = false;
+      if(theEnd) {
+        model.mutex.release();
+        break;
+      }
+      if(!model.done) {
+        for (i in model.start...model.end)
+          queue[i](id);
+        model.done = true;
+      }
+      model.mutex.release();
+    }
+  }
+
+  public function addConcurrent(task:Task):Void {
+    queue.push(task);
+  }
+
+  public function blockRunAll():Void {
+    var numPerThread:Int = Math.floor(queue.length / num);
+    var remainder:Int = queue.length - num * numPerThread;
+    for (i in 0...num) {
+      models[i].start = i*numPerThread;
+      models[i].end = models[i].start + numPerThread;
+      if(i == num-1) {
+        models[i].end += remainder;
+      }
+      models[i].pending = true;
+      models[i].mutex.release();
+    }
+
+    var i:Int = 0;
+    while(i < num) {
+      models[i].mutex.acquire();
+      if(models[i].pending) {
+        models[i].mutex.release();
+      }
+      else {
+        models[i].done = false;
+        i++;
+      }
+    }
+    queue = [];
+  }
+
+  public function distributeLoop(length:Int, loop:Loop):Void {
+    var numPerThread:Int = Math.floor(length / num);
+    var remainder:Int = length - numPerThread * num;
+    for (i in 0...num) {
+      var start:Int = i * numPerThread;
+      var end:Int = start + numPerThread;
+      if(i == num-1) {
+        end+=remainder;
+      }
+      for (j in start...end) {
+        addConcurrent(function(i) {
+          loop(i,j);
+        });
+      }
+    }
+  }
+
+  public function end():Void {
+    theEnd = true;
+    for (i in 0...num) {
+      models[i].mutex.release();
+    }
+  }
+
+}

--- a/tools/hxcpp/compile.hxml
+++ b/tools/hxcpp/compile.hxml
@@ -1,4 +1,17 @@
+-main BuildToolLauncher
+-resource ../../haxelib.json@Signature
 -neko ../../hxcpp.n
+#-debug
+
+--next
+
+-neko ../../hxcpp-fallback.n
 -main BuildTool
 -D neko_v1
 -debug
+
+--next
+
+-main BuildTool
+-cpp ../../bin/tools
+#-debug


### PR DESCRIPTION
* Increases performances of caches builds by switching build tool to CPP and multi-threading key calculations
* Haxe trunk removed haxe/unit, so I added it to each test src for now

Benchmark Check
This is the results of a build after already building the project.

Current HXCPP: 24.2s
<img width="1178" alt="old-cached" src="https://user-images.githubusercontent.com/220965/30732056-8bc7a892-9f25-11e7-9b94-7014e95bb93d.png">

Multithreaded CPP HXCPP: 16.2s
<img width="1178" alt="new-cached" src="https://user-images.githubusercontent.com/220965/30732071-a09ce16a-9f25-11e7-99d6-1982b47b12d9.png">

33% faster! Not bad.
