### PR TITLE
Don't call system() on iOS and Apple Watch

### DIFF
--- a/project/libs/std/Sys.cpp
+++ b/project/libs/std/Sys.cpp
@@ -278,7 +278,7 @@ static value sys_is64() {
 	<doc>Run the shell command and return exit code</doc>
 **/
 static value sys_command( value cmd ) {
-   #if defined(HX_WINRT) || defined(EMSCRIPTEN) || defined(EPPC) || defined(APPLETV)
+   #if defined(HX_WINRT) || defined(EMSCRIPTEN) || defined(EPPC) || defined(IPHONE) || defined(APPLETV) || defined(HX_APPLEWATCH)
 	return alloc_int( -1 );
    #else
 	val_check(cmd,string);


### PR DESCRIPTION
system() function isn't available on these platforms. Calling it causes a build break:

`Error: /usr/local/Cellar/haxe/lib/hxcpp/git/project/libs/std/Sys.cpp:293:16: error: call to unavailable function 'system': not available on iOS
        int result =  system(val_string(cmd));`

`/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS11.0.sdk/usr/include/stdlib.h:195:6: note: candidate function has been explicitly made unavailable
int      system(const char *) __DARWIN_ALIAS_C(system);
`