### PR TITLE
Update readme due to no dlls needed since haxe 3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,55 +6,26 @@
 hxcpp is the runtime support for the c++ backend of the [haxe](http://haxe.org/) compiler. This contains the headers, libraries and support code required to generate a fully compiled executable from haxe code.
 
 
-# building
-
-Build the tools.
+# building the tools
 
 ```
-cd tools/hxcpp
+REPO=$(pwd)
+cd ${REPO}/tools/run
 haxe compile.hxml
-cd ../build
+cd ${REPO}/tools/hxcpp
 haxe compile.hxml
+cd $REPO
 ```
-
-Running neko on the build.n script will rebuild the supported architectures on your current platform.
-
-```
-cd project
-neko build.n clean
-neko build.n
-```
-
-
-In the same folder, you can cross build to other platforms using the run.n with the said platform name.
-
-For example : 
-
-```
-neko build.n android
-```
-
-You can save time if you know that you are only going to use, say, the dynamic libraries (ndlls) on a particular architecture on a particular platform.
-```
-neko build.n ndll-android-armv5
-```
-
-You can enable debugging in the standard runtime libraries using the debug flag, eg:
-```
-neko build.n windows -debug
-```
-which may help with native debugging.  Don't forget to rebuild without debugging for release.
-
-
-For experts, you can configure the compilation scripts that will be used for executables and library production in the 'toolchain' folder.
 
 # cppia
 
 You first need to build the cppia host.
 
 ```
-cd project
+REPO=$(pwd)
+cd ${REPO}/project
 haxe compile-cppia.hxml
+cd $REPO
 ```
 
 Then you can do `haxelib run hxcpp file.cppia`.


### PR DESCRIPTION
Problem:
Since haxe 3.3 the dll's are no longer needed to be manually built but the README still mentions this step.

Solution:
This diff updates the readme, hopefully this will avoid people from unnecessarily thinking they still have to build the dll's for their platform.