### PR TITLE
Dynamic constructors for long and unsigned long

### DIFF
--- a/include/Dynamic.h
+++ b/include/Dynamic.h
@@ -18,8 +18,10 @@ class HXCPP_EXTERN_CLASS_ATTRIBUTES Dynamic : public hx::ObjectPtr<hx::Object>
 public:
 
    Dynamic() {};
+   Dynamic(long inVal);
    Dynamic(int inVal);
    Dynamic(short inVal);
+   Dynamic(unsigned long inVal);
    Dynamic(unsigned int inVal);
    Dynamic(unsigned short inVal);
    Dynamic(unsigned char inVal);

--- a/src/Dynamic.cpp
+++ b/src/Dynamic.cpp
@@ -366,6 +366,12 @@ static hx::Object *fromInt(int inVal)
 }
 
 Dynamic::Dynamic(bool inVal) : super( inVal ? hx::DynTrue.mPtr : hx::DynFalse.mPtr ) { }
+
+Dynamic::Dynamic(long inVal)
+{
+   mPtr = fromInt(inVal);
+}
+
 Dynamic::Dynamic(int inVal)
 {
    mPtr = fromInt(inVal);
@@ -376,18 +382,26 @@ Dynamic::Dynamic(short inVal)
    mPtr = fromInt(inVal);
 }
 
+Dynamic::Dynamic(unsigned long inVal)
+{
+   mPtr = fromInt(inVal);
+}
+
 Dynamic::Dynamic(unsigned int inVal)
 {
    mPtr = fromInt(inVal);
 }
+
 Dynamic::Dynamic(unsigned short inVal)
 {
    mPtr = fromInt(inVal);
 }
+
 Dynamic::Dynamic(unsigned char inVal)
 {
    mPtr = fromInt(inVal);
 }
+
 Dynamic::Dynamic(signed char inVal)
 {
    mPtr = fromInt(inVal);


### PR DESCRIPTION
Resolves an `error: conversion from 'long' to 'const Dynamic' is ambiguous` when using singed integer literals in a haxe program.