### PR TITLE
HXCPP_OPTIMIZE_LINK_INCREMENTAL and HXCPP_FAST_LINK for msvc19 toolchain

### DIFF
--- a/toolchain/finish-setup.xml
+++ b/toolchain/finish-setup.xml
@@ -27,8 +27,10 @@
 
 
 <set name="OBJDBG" value="-debug" if="debug" />
+<set name="OBJOPT" value="-fast" if="HXCPP_FAST_LINK" />
+<set name="HXCPP_OPTIMIZE_LINK_INCREMENTAL" value="1" if="HXCPP_FAST_LINK HXCPP_OPTIMIZE_LINK" unless="debug" />
 <set name="OBJOPT" value="-opt" if="HXCPP_OPTIMIZE_LINK" unless="debug" />
-<set name="OBJOPT" value="-optinc" if="HXCPP_OPTIMIZE_LINK_INCREMENTAL || HXCPP_LTO_THIN" unless="debug" />
+<set name="OBJOPT" value="-optinc" if="HXCPP_OPTIMIZE_LINK_INCREMENTAL" unless="debug" />
 <set name="OBJEXT" value="${M64}${F32}${STAT}${OBJDBG}${OBJOPT}${NOCONSOLE}${RPI}${APIFP}${PRIME}" />
 
 <set name="STD_MODULE_LINK" value="static_link" if="static_link"/>
@@ -105,6 +107,14 @@
    <set name="HX_LINK_SUFFIX" value="-19" if="MSVC19" />
    <set name="HX_TARGET_SUFFIX" value="-19" if="MSVC19 static_link" />
 
+   <section if="HXCPP_OPTIMIZE_LINK_INCREMENTAL" unless="debug || MSVC19">
+      <echo value="Warning: INCREMENTAL requies Visual Studio 2015+"/>
+      <!-- without INCREMENTAL -->
+      <unset name="HXCPP_OPTIMIZE_LINK_INCREMENTAL"/>
+      <set name="HXCPP_OPTIMIZE_LINK" value="1"/> 
+      <set name="OBJOPT" value="-opt" if="HXCPP_OPTIMIZE_LINK || HXCPP_OPTIMIZE_LINK_INCREMENTAL" unless="debug" />
+      <set name="OBJEXT" value="${M64}${F32}${STAT}${OBJDBG}${OBJOPT}${NOCONSOLE}${RPI}${APIFP}${PRIME}" />
+   </section>
 </section>
 </xml>
 

--- a/toolchain/msvc-toolchain.xml
+++ b/toolchain/msvc-toolchain.xml
@@ -43,6 +43,9 @@
 
 <set name="MSVC_ARCH" value="SSE2" unless="HXCPP_M64" />
 
+<set name="HXCPP_LTCG_INCREMENTAL" value="1" if="HXCPP_OPTIMIZE_LINK_INCREMENTAL"/>
+<unset name="HXCPP_FAST_LINK" if="HXCPP_FAST_LINK" unless="MSVC19"/>
+
 <compiler id="MSVC" exe="cl.exe" if="windows">
   <flag value="-nologo"/>
 
@@ -77,8 +80,9 @@
   <flag value="-Fd${HXCPP_BUILD_DIR}${MSVC_OBJ_DIR}/vc.pdb" unless="HXCPP_COMPILE_CACHE" tag="debug" />
   <flag value="-Od" tag="debug" />
   <flag value="-O2" tag="release" />
+  <flag value="-Zc:inline" if="HXCPP_FAST_LINK" unless="debug || HXCPP_OPTIMIZE_LINK || HXCPP_LTCG_INCREMENTAL" /><!-- not available with -Od and -GL -->
   <flag value="-Os" tag="optim-size" />
-  <flag value="-GL" if="HXCPP_OPTIMIZE_LINK" unless="debug"/>
+  <flag value="-GL" if="HXCPP_OPTIMIZE_LINK || HXCPP_LTCG_INCREMENTAL" unless="debug"/>
 
   <flag value="-FS" if="HXCPP_FORCE_PDB_SERVER" />
   <flag value="-Oy-"/>
@@ -105,8 +109,10 @@
   <flag value="-nologo"/>
   <flag value="-machine:${MACHINE}"/>
   <flag value="-dll"/>
-  <flag value="-debug" if="HXCPP_DEBUG_LINK"/>
-  <flag value="-LTCG" if="HXCPP_OPTIMIZE_LINK" unless="debug"/>
+  <flag value="-debug" if="HXCPP_DEBUG_LINK" unless="HXCPP_FAST_LINK"/>
+  <flag value="-debug:fastlink" if="HXCPP_FAST_LINK HXCPP_DEBUG_LINK"/>
+  <flag value="-LTCG" if="HXCPP_OPTIMIZE_LINK" unless="debug || HXCPP_LTCG_INCREMENTAL"/>
+  <flag value="-LTCG:INCREMENTAL" if="HXCPP_LTCG_INCREMENTAL" unless="debug"/>
   <lib name="${dll_import_link}" if="dll_import_link" />
   <ext value=".dll"/>
   <libdir name="obj/lib"/>
@@ -121,8 +127,10 @@
   <fromfile value="@"/>
   <flag value="-nologo"/>
   <flag value="-machine:${MACHINE}"/>
-  <flag value="-debug" if="HXCPP_DEBUG_LINK"/>
-  <flag value="-LTCG" if="HXCPP_OPTIMIZE_LINK" unless="debug"/>
+  <flag value="-debug" if="HXCPP_DEBUG_LINK" unless="HXCPP_FAST_LINK"/>
+  <flag value="-debug:fastlink" if="HXCPP_FAST_LINK HXCPP_DEBUG_LINK"/>
+  <flag value="-LTCG" if="HXCPP_OPTIMIZE_LINK" unless="debug || HXCPP_LTCG_INCREMENTAL"/>
+  <flag value="-LTCG:INCREMENTAL" if="HXCPP_LTCG_INCREMENTAL" unless="debug"/>
   <flag value="-subsystem:windows${SUBSYSTEM_VER}" if="SUBSYSTEMWINDOWS" />
   <flag value="-subsystem:console${SUBSYSTEM_VER}" if="SUBSYSTEMCONSOLE" />
   <libpathflag value="-libpath:"/>
@@ -137,8 +145,10 @@
   <fromfile value="@"/>
   <flag value="-nologo"/>
   <flag value="-machine:${MACHINE}"/>
-  <flag value="-debug" if="HXCPP_DEBUG_LINK"/>
-  <flag value="-LTCG" if="HXCPP_OPTIMIZE_LINK" unless="debug"/>
+  <flag value="-debug" if="HXCPP_DEBUG_LINK" unless="HXCPP_FAST_LINK"/>
+  <flag value="-debug:fastlink" if="HXCPP_FAST_LINK HXCPP_DEBUG_LINK"/>
+  <flag value="-LTCG" if="HXCPP_OPTIMIZE_LINK" unless="debug || HXCPP_LTCG_INCREMENTAL"/>
+  <flag value="-LTCG:INCREMENTAL" if="HXCPP_LTCG_INCREMENTAL" unless="debug"/>
   <flag value="-subsystem:windows" />
   <flag value="-MANIFEST:NO" />
   <flag value="-WINMD" />
@@ -154,7 +164,8 @@
 </linker>
 
 <linker id="static_link" exe="lib.exe" if="windows">
-  <flag value="-LTCG" if="HXCPP_OPTIMIZE_LINK" unless="debug"/>
+  <flag value="-LTCG" if="HXCPP_OPTIMIZE_LINK" unless="debug || HXCPP_LTCG_INCREMENTAL"/>
+  <flag value="-LTCG:INCREMENTAL" if="HXCPP_LTCG_INCREMENTAL" unless="debug"/>
   <fromfile value="@"/>
   <flag value="-nologo"/>
   <flag value="-IGNORE:4264" if="winrt" />


### PR DESCRIPTION
These flags are to speedup linking time on Visual Stuidio 2015 and 2017 as in [here ](https://blogs.msdn.microsoft.com/vcblog/2014/11/12/speeding-up-the-incremental-developer-build-scenario/)

**HXCPP_FAST_LINK :**
-Zc:inline (non debug, non optimize_link)
-debug:fastlink instead of -debug (for HXCPP_DEBUG_LINK)
Setting both HXCPP_OPTIMIZE_LINK and HXCPP_FAST_LINK sets HXCPP_OPTIMIZE_LINK_INCREMENTAL

**HXCPP_OPTIMIZE_LINK_INCREMENTAL :** (shadows HXCPP_OPTIMIZE_LINK )
-LTCG:INCREMENTAL instead of -LTCG

It should not affect builds that do not use these flags.  
May need more testing with HXCPP cache but so far I see no issues. 
If it is not "MSVC19", HXCPP_OPTIMIZE_LINK_INCREMENTAL becomes HXCPP_OPTIMIZE_LINK and the obj directory name is set again. HXCPP_FAST_LINK also only is set for MSVC19
HXCPP_OPTIMIZE_LINK_INCREMENTAL may be the default in some years XD

Thanks