### PR TITLE
Sys.stderr() points to stderr

### DIFF
--- a/src/hx/libs/std/File.cpp
+++ b/src/hx/libs/std/File.cpp
@@ -393,7 +393,7 @@ Dynamic _hx_std_file_stdout()
 Dynamic _hx_std_file_stderr()
 {
    fio *f = new fio();
-   f->create(stdout, HX_CSTRING("stderr"), false);
+   f->create(stderr, HX_CSTRING("stderr"), false);
    return f;
 }
 


### PR DESCRIPTION
#663