### PR TITLE
loosen a few ifdefs for wider compat

### DIFF
--- a/include/hx/Thread.h
+++ b/include/hx/Thread.h
@@ -221,8 +221,10 @@ inline bool HxCreateDetachedThread(void *(*func)(void *), void *param)
 	pthread_attr_t attr;
 	if (pthread_attr_init(&attr) != 0)
 		return false;
+#ifdef PTHREAD_CREATE_DETACHED
 	if (pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED) != 0)
 		return false;
+#endif
 	if (pthread_create(&t, &attr, func, param) != 0 )
 		return false;
 	if (pthread_attr_destroy(&attr) != 0)

--- a/src/Math.cpp
+++ b/src/Math.cpp
@@ -4,13 +4,13 @@
 
 #include <stdlib.h>
 #include <time.h>
-#if defined(__unix__) || defined(__APPLE__)
-#include <unistd.h>
-#include <sys/time.h>
-#elif defined(HX_WINRT) && !defined(__cplusplus_winrt)
+#if defined(HX_WINRT) && !defined(__cplusplus_winrt)
 #include <windows.h>
 #elif defined(HX_WINDOWS)
 #include <process.h>
+#else
+#include <unistd.h>
+#include <sys/time.h>
 #endif
 
 // -------- Math ---------------------------------------
@@ -147,7 +147,7 @@ void Math_obj::__boot()
 
 #if defined(HX_WINDOWS) || defined(__SNC__)
    unsigned int t = clock();
-#elif defined(__unix__) || defined(__APPLE__)
+#else
    struct timeval tv;
    gettimeofday(&tv,0);
    unsigned int t = tv.tv_sec * 1000000 + tv.tv_usec;
@@ -163,10 +163,8 @@ void Math_obj::__boot()
   #else
    int pid = _getpid();
   #endif
-#elif defined(__unix__) || defined(__APPLE__)
-   int pid = getpid();
 #else
-   int pid = (int)&t; // As a last resort, rely on ASLR.
+   int pid = getpid();
 #endif  
 
   srand(t ^ (pid | (pid << 16)));

--- a/src/hx/Thread.cpp
+++ b/src/hx/Thread.cpp
@@ -447,7 +447,7 @@ public:
 	{
 		return (double)clock()/CLOCKS_PER_SEC;
 	}
-	#elif defined(__unix__) || defined(__APPLE__)
+	#else
 	double Now()
 	{
 		struct timeval tv;


### PR DESCRIPTION
For a game console that implements a lot of POSIX APIs but does not
define `__unix__` or `__APPLE__`.