### PR TITLE
Add Array.resize method

### DIFF
--- a/include/Array.h
+++ b/include/Array.h
@@ -233,6 +233,7 @@ public:
    inline Dynamic __zero(const Dynamic &a0,const Dynamic &a1)  { zero(a0,a1); return null(); }
    virtual Dynamic __memcmp(const Dynamic &a0) = 0;
    virtual void __qsort(Dynamic inCompare) = 0;
+   virtual Dynamic __resize(const Dynamic &a0) = 0;
 
    #else
    inline void ____SetSize(int len)  { __SetSize(len); } 
@@ -264,6 +265,7 @@ public:
    virtual int __memcmp(const cpp::VirtualArray &a0) = 0;
    inline void __zero(const Dynamic &a0,const Dynamic &a1)  { zero(a0,a1); }
    virtual void __qsort(Dynamic inCompare) = 0;
+   virtual void __resize(int inLen) = 0;
 
    virtual void set(int inIdx, const cpp::Variant &inValue) = 0;
    virtual void setUnsafe(int inIdx, const cpp::Variant &inValue) = 0;
@@ -296,6 +298,7 @@ public:
    Dynamic blit_dyn();
    Dynamic zero_dyn();
    Dynamic memcmp_dyn();
+   Dynamic resize_dyn();
 
    void Realloc(int inLen) const;
 
@@ -726,6 +729,11 @@ public:
       }
    }
 
+   void resize(int inLen)
+   {
+      __SetSize(inLen);
+   }
+
    // Will do random pointer sorting for object pointers
    inline void sortAscending()
    {
@@ -777,7 +785,6 @@ public:
 
    template<typename TO>
    Dynamic iteratorFast() { return new hx::ArrayIterator<ELEM_,TO>(this); }
-
    
    virtual hx::ArrayStore getStoreType() const
    {
@@ -816,6 +823,7 @@ public:
    virtual Dynamic __filter(const Dynamic &func) { return filter(func); }
    virtual Dynamic __blit(const Dynamic &a0,const Dynamic &a1,const Dynamic &a2,const Dynamic &a3) { blit(a0,a1,a2,a3); return null(); }
    virtual Dynamic __memcmp(const Dynamic &a0) { return memcmp(a0); }
+   virtual Dynamic __resize(const Dynamic &a0) { resize(a0); return null(); }
    virtual void __qsort(Dynamic inCompare) { this->qsort(inCompare); };
    #else //(HXCPP_API_LEVEL < 330)
 
@@ -838,6 +846,7 @@ public:
    virtual ::String __toString() { return toString(); }
    virtual void  __unshift(const Dynamic &a0) { unshift(a0); }
    virtual cpp::VirtualArray_obj *__map(const Dynamic &func) { return map(func).mPtr; }
+   virtual void __resize(int inLen) { resize(inLen); }
 
    virtual hx::ArrayBase *__filter(const Dynamic &func) { return filter(func).mPtr; }
    virtual void __blit(int inDestElement,const cpp::VirtualArray &inSourceArray,int inSourceElement,int inElementCount)

--- a/include/cpp/VirtualArray.h
+++ b/include/cpp/VirtualArray.h
@@ -473,6 +473,7 @@ public:
    }
 
    inline void reverse() { checkBase(); if (store!=hx::arrayEmpty) base->__reverse(); }
+   inline void resize(int inLen) { checkBase(); if (store!=hx::arrayEmpty) base->__resize(inLen); }
 
    inline void qsort(Dynamic inSorter) { checkBase(); if (base) base->__qsort(inSorter); }
 
@@ -532,6 +533,7 @@ public:
    Dynamic blit_dyn();
    Dynamic zero_dyn();
    Dynamic memcmp_dyn();
+   Dynamic resize_dyn();
 };
 
 

--- a/src/Array.cpp
+++ b/src/Array.cpp
@@ -538,6 +538,7 @@ DEFINE_ARRAY_FUNC1(,sort);
 DEFINE_ARRAY_FUNC1(,unshift);
 DEFINE_ARRAY_FUNC4(,blit);
 DEFINE_ARRAY_FUNC2(,zero);
+DEFINE_ARRAY_FUNC1(,resize);
 #else
 DEFINE_ARRAY_FUNC1(return,__SetSize);
 DEFINE_ARRAY_FUNC1(return,__SetSizeExact);
@@ -547,6 +548,7 @@ DEFINE_ARRAY_FUNC1(return,sort);
 DEFINE_ARRAY_FUNC1(return,unshift);
 DEFINE_ARRAY_FUNC4(return,blit);
 DEFINE_ARRAY_FUNC2(return,zero);
+DEFINE_ARRAY_FUNC1(return,resize);
 #endif
 
 DEFINE_ARRAY_FUNC1(return,concat);
@@ -605,6 +607,7 @@ hx::Val ArrayBase::__Field(const String &inString, hx::PropertyAccess inCallProp
    if (inString==HX_CSTRING("_hx_storeType")) return (int)getStoreType();
    if (inString==HX_CSTRING("_hx_elementSize")) return (int)GetElementSize();
    if (inString==HX_CSTRING("_hx_pointer")) return cpp::CreateDynamicPointer((void *)mBase);
+   if (inString==HX_CSTRING("resize")) return resize_dyn();
    return null();
 }
 
@@ -631,6 +634,7 @@ static String sArrayFields[] = {
    HX_CSTRING("unshift"),
    HX_CSTRING("filter"),
    HX_CSTRING("map"),
+   HX_CSTRING("resize"),
    String(null())
 };
 
@@ -753,6 +757,7 @@ DEFINE_VARRAY_FUNC1(,memcmp);
 DEFINE_VARRAY_FUNC1(return,__unsafe_get);
 DEFINE_VARRAY_FUNC2(return,__unsafe_set);
 DEFINE_VARRAY_FUNC4(,blit);
+DEFINE_VARRAY_FUNC1(,resize);
 
 
 
@@ -823,6 +828,7 @@ hx::Val VirtualArray_obj::__Field(const String &inString, hx::PropertyAccess inC
    if (inString==HX_CSTRING("blit")) return blit_dyn();
    if (inString==HX_CSTRING("zero")) return zero_dyn();
    if (inString==HX_CSTRING("memcmp")) return memcmp_dyn();
+   if (inString==HX_CSTRING("resize")) return resize_dyn();
 
    if (inString==HX_CSTRING("_hx_storeType"))
    {


### PR DESCRIPTION
From https://github.com/HaxeFoundation/haxe/issues/6173

Adds a `resize` method to Array. Didn't implement this for cppia as I'm not familiar with that target.