### PR TITLE
Fix return value for indexOf when it's used where a float is expected

### DIFF
--- a/src/hx/cppia/StringBuiltin.cpp
+++ b/src/hx/cppia/StringBuiltin.cpp
@@ -299,6 +299,10 @@ struct IndexOfExpr : public CppiaExpr
       start = start->link(inData);
       return this;
    }
+   Float runFloat(CppiaCtx *ctx)
+   {
+      return runInt(ctx);
+   }
    int runInt(CppiaCtx *ctx)
    {
       String val = strVal->runString(ctx);


### PR DESCRIPTION
Fixes #661 