### PR TITLE
Directory structure of "libstdc++" is different

### DIFF
--- a/toolchain/android-toolchain.xml
+++ b/toolchain/android-toolchain.xml
@@ -29,7 +29,7 @@
 
 <section unless="HXCPP_X86">
   <set name="ARCH" value="-v7" if="HXCPP_ARMV7" />
-  <set name="ABI" value="armeabi" />
+  <set name="ABI" value="armeabi-v7a" />
   <set name="PLATFORM_ARCH" value="arch-arm" />
   <set name="TOOLCHAIN" value="arm-linux-androideabi-${TOOLCHAIN_VERSION}" />
   <set name="EXEPREFIX" value="arm-linux-androideabi" />


### PR DESCRIPTION
```
user@mypc MINGW64 /d/Android/ndk-bundle/sources/cxx-stl/gnu-libstdc++/4.9/libs
$ ls
arm64-v8a/  armeabi-v7a/  mips/  mips64/  x86/  x86_64/
```