### PR TITLE
DNO_RECURSE for all platforms

### DIFF
--- a/src/hx/libs/regexp/Build.xml
+++ b/src/hx/libs/regexp/Build.xml
@@ -13,7 +13,7 @@
   <compilerflag value="-DPCRE_STATIC"/>
   <compilerflag value="-DSUPPORT_UTF8"/>
   <compilerflag value="-DSUPPORT_UCP"/>
-  <compilerflag value="-DNO_RECURSE" if="windows"/>
+  <compilerflag value="-DNO_RECURSE"/>
   <compilerflag value="-I${PCRE_DIR}"/>
 
   <file name="${this_dir}/RegExp.cpp"/>


### PR DESCRIPTION
Inconsistency in regexp crossplatform behavior, because -DNO_RECURSE set only for windows platform. I had issues when regexp code works well on windows and crash on other platforms. RECURSE version has limits in text block size.