### PR TITLE
Fix isRaspberryPi check

### DIFF
--- a/tools/hxcpp/Setup.hx
+++ b/tools/hxcpp/Setup.hx
@@ -228,10 +228,16 @@ class Setup
 
    public static function isRaspberryPi()
    {
-      var proc = new Process("uname",["-a"]);
-      var str = proc.stdout.readLine();
-      proc.close();
-      return str.split(" ")[1]=="raspberrypi";
+       var modelFile = '/sys/firmware/devicetree/base/model';
+       if( !FileSystem.exists( modelFile ) )
+           return false;
+       try {
+           var model = sys.io.File.getContent( modelFile );
+           return ~/Raspberry/.match( model );
+       } catch(e:Dynamic) {
+           trace( e );
+       }
+       return false;
    }
 
    static public function startPdbServer()


### PR DESCRIPTION
`uname -a` just prints the nodename which can be anything.
