### PR TITLE
Windows 32bit VS2017 fix

### DIFF
--- a/toolchain/msvc-setup.bat
+++ b/toolchain/msvc-setup.bat
@@ -1,4 +1,7 @@
 setlocal enabledelayedexpansion
+@if not exist "%ProgramFiles(x86)%" (
+	@set "ProgramFiles(x86)=%ProgramFiles%"
+)
 @if exist "%HXCPP_MSVC%\vcvars32.bat" (
 	@call "%HXCPP_MSVC%\vcvars32.bat"
 	@echo HXCPP_VARS


### PR DESCRIPTION
Fix compilation on Windows(7) 32 bit with Visual Studio 2017. Requires flag -DHXCPP_M32 for testing in NME 
https://github.com/HaxeFoundation/hxcpp/issues/748