### PR TITLE
propagate nullness of Array<T> to Array<Dynamic>

### DIFF
--- a/include/cpp/VirtualArray.h
+++ b/include/cpp/VirtualArray.h
@@ -562,7 +562,7 @@ public:
 // Build dynamic array from foreign array
 template<typename SOURCE_>
 VirtualArray::VirtualArray( const Array<SOURCE_> &inRHS )
-   : super( new VirtualArray_obj( inRHS.mPtr, true) )
+   : super( hx::IsNull(inRHS) ? 0 : new VirtualArray_obj( inRHS.mPtr, true) )
 {
 }
 

--- a/include/cpp/VirtualArray.h
+++ b/include/cpp/VirtualArray.h
@@ -562,7 +562,7 @@ public:
 // Build dynamic array from foreign array
 template<typename SOURCE_>
 VirtualArray::VirtualArray( const Array<SOURCE_> &inRHS )
-   : super( hx::IsNull(inRHS) ? 0 : new VirtualArray_obj( inRHS.mPtr, true) )
+   : super( !inRHS.mPtr ? 0 : new VirtualArray_obj( inRHS.mPtr, true) )
 {
 }
 

--- a/src/Enum.cpp
+++ b/src/Enum.cpp
@@ -37,8 +37,6 @@ void EnumBase_obj::__boot()
 #if (HXCPP_API_LEVEL >= 330)
 DynamicArray EnumBase_obj::_hx_getParameters()
 {
-   if (mFixedFields==0)
-      return null();
    Array<Dynamic> result = Array_obj<Dynamic>::__new(mFixedFields);
    cpp::Variant *fixed = _hx_getFixed();
    for(int i=0;i<mFixedFields;i++)


### PR DESCRIPTION
fixed Enum.getParameters() should not return null
close #746