### PR TITLE
Avoid entering GCFreeZone twice

### DIFF
--- a/src/hx/libs/std/File.cpp
+++ b/src/hx/libs/std/File.cpp
@@ -371,7 +371,6 @@ Array<unsigned char> _hx_std_file_contents_bytes( String name )
    {
       char *dest = (char *)&buffer[0];
 
-      hx::EnterGCFreeZone();
       int p = 0;
       while( len > 0 )
       {


### PR DESCRIPTION
For some reason this caused trouble for me on Switch but nowhere else but seems appropritate to fix that in any case.