### PR TITLE
Do not leave the stack allocated frame pointer uninitialized

### DIFF
--- a/src/hx/cppia/Cppia.h
+++ b/src/hx/cppia/Cppia.h
@@ -253,7 +253,7 @@ struct ScriptCallable : public CppiaDynamicExpr
    int argCount;
    int stackSize;
    bool hasDefaults;
-   
+
    std::vector<CppiaStackVar> args;
    std::vector<bool>          hasDefault;
    std::vector<CppiaConst>    initVals;
@@ -512,7 +512,7 @@ struct CppiaVar
    String           stringVal;
 
    void             *valPointer;
-   
+
 
    CppiaVar(bool inIsStatic);
    CppiaVar(CppiaFunction *inDynamicFunction);
@@ -783,6 +783,8 @@ public:
          ctx = inCtx;
          frame = (hx::StackFrame *)ctx->stackAlloc(sizeof(hx::StackFrame));
          frame->position = inPosition;
+         frame->variables = 0;
+         frame->catchables = 0;
          inCtx->pushFrame(frame);
       }
       ~CppiaStackFrame()
@@ -990,7 +992,7 @@ struct CrementPostDec
       inVal = Dynamic(Dynamic(inVal) - 1).mPtr;
       return result;
    }
- 
+
 };
 
 


### PR DESCRIPTION
This causes a crash at `CanBeCaught` when it is bubbling up through a cppia-allocated frame