### PR TITLE
Fix deprecation warnings in BuildTool with Haxe 4

### DIFF
--- a/tools/hxcpp/BuildTool.hx
+++ b/tools/hxcpp/BuildTool.hx
@@ -1,6 +1,10 @@
 import CopyFile.Overwrite;
 import haxe.io.Path;
+#if haxe4
+import haxe.xml.Access as Fast;
+#else
 import haxe.xml.Fast;
+#end
 import haxe.Json;
 import sys.io.Process;
 import sys.FileSystem;


### PR DESCRIPTION
Without this, rebuilding the build tool with Haxe 4 results in a deprecation warning for each usage of `Fast`:

>Warning : This typedef is deprecated in favor of haxe.xml.Access