### PR TITLE
Also capture registers when compiling to Linux

### DIFF
--- a/src/hx/gc/GcRegCapture.h
+++ b/src/hx/gc/GcRegCapture.h
@@ -6,11 +6,11 @@ namespace hx
 
 // Capture Registers
 
-#if (defined(HX_WINDOWS) || defined(HX_MACOS)) && !defined(HXCPP_M64)
+#if (defined(HX_WINDOWS) || defined(HX_MACOS) || (defined(HX_LINUX) && defined(__i386__))) && !defined(HXCPP_M64)
 #define HXCPP_CAPTURE_x86
 #endif
 
-#if (defined(HX_MACOS) || (defined(HX_WINDOWS) && !defined(HX_WINRT)) || defined(_XBOX_ONE)) && defined(HXCPP_M64)
+#if (defined(HX_MACOS) || (defined(HX_WINDOWS) && !defined(HX_WINRT)) || defined(_XBOX_ONE) || (defined(HX_LINUX) && defined(__x86_64__))) && defined(HXCPP_M64)
 #define HXCPP_CAPTURE_x64
 #endif
 


### PR DESCRIPTION
There doesn't seem to have a reason for not enabling it in Linux, and doing so allows a much safer GC operation - right now we've just hit a bug where a local was only ever in the register, and hxcpp would collect it because of that