### PR TITLE
Add missing include stdio.h

### DIFF
--- a/include/hx/Native.h
+++ b/include/hx/Native.h
@@ -6,6 +6,8 @@
 
 */
 
+#include <stdio.h>
+
 #ifndef HXCPP_H
 #define HXCPP_H
 typedef double Float;


### PR DESCRIPTION
Native.h depends on stdio for `size_t` (line 146)