### PR TITLE
Unicode fixes

### DIFF
--- a/include/hxcpp.h
+++ b/include/hxcpp.h
@@ -48,8 +48,6 @@
 
 #include <string.h>
 
-#define HX_UTF8_STRINGS
-
 #include <wchar.h>
 
 #ifdef HX_LINUX

--- a/src/String.cpp
+++ b/src/String.cpp
@@ -1556,7 +1556,7 @@ Array<String> String::split(const String &inDelimiter) const
    Array<String> result(0,1);
    #if HX_SMART_STRINGS
    bool s0 = isUTF16Encoded();
-   bool s1 = isUTF16Encoded();
+   bool s1 = inDelimiter.isUTF16Encoded();
    if (s0 || s1)
    {
       if (s0 && s1)

--- a/src/String.cpp
+++ b/src/String.cpp
@@ -26,29 +26,17 @@ using namespace std;
 // vc 7...
 #if _MSC_VER < 1400 
 
-#ifdef HX_UTF8_STRINGS
 #define SPRINTF _snprintf
-#else
-#define SPRINTF _snwprintf
-#endif
 
 #else // vc8+
 
-#ifdef HX_UTF8_STRINGS
 #define SPRINTF _snprintf_s
-#else
-#define SPRINTF _snwprintf_s
-#endif
 
 #endif
 
 #else // not windows ..
 
-#ifdef HX_UTF8_STRINGS
 #define SPRINTF snprintf
-#else
-#define SPRINTF swmprintf
-#endif
 
 #endif
 
@@ -58,14 +46,9 @@ using namespace std;
 
 namespace hx
 {
-#ifdef HX_UTF8_STRINGS
 char HX_DOUBLE_PATTERN[20] = "%.15g";
 #define HX_INT_PATTERN "%d"
 #define HX_UINT_PATTERN "%ud"
-#else
-wchar_t HX_DOUBLE_PATTERN[20] =  L"%.15g";
-#define HX_INT_PATTERN L"%d"
-#endif
 }
 
 void __hxcpp_set_float_format(String inFormat)
@@ -1489,10 +1472,6 @@ const char16_t * String::wc_str() const
 
 const wchar_t * String::__WCStr() const
 {
-   #ifndef HX_UTF8_STRINGS
-   return __s ? __s : L"";
-   #else
-   
    const unsigned char *ptr = (const unsigned char *)__s;
    const unsigned char *end = ptr + length;
    int idx = 0;
@@ -1509,7 +1488,6 @@ const wchar_t * String::__WCStr() const
       result[idx++] = DecodeAdvanceUTF8(ptr);
    result[idx] = 0;
    return result;
-   #endif
 }
 
 

--- a/src/hx/CFFI.cpp
+++ b/src/hx/CFFI.cpp
@@ -363,11 +363,7 @@ const char * val_string(hx::Object * arg1)
 
 hx::Object * alloc_string(const char * arg1)
 {
-#ifdef HX_UTF8_STRINGS
    return Dynamic( String(arg1,strlen(arg1)).dup() ).GetPtr();
-#else
-   return Dynamic( String(arg1,strlen(arg1)) ).GetPtr();
-#endif
 }
 
 
@@ -375,11 +371,7 @@ wchar_t * val_dup_wstring(value inVal)
 {
    hx::Object *obj = (hx::Object *)inVal;
    String  s = obj->toString();
-#ifdef HX_UTF8_STRINGS
    return (wchar_t *)s.__WCStr();
-#else
-   return (char *)s.dup().__s;
-#endif
 }
 
 char * val_dup_string(value inVal)
@@ -387,12 +379,7 @@ char * val_dup_string(value inVal)
    hx::Object *obj = (hx::Object *)inVal;
    if (!obj) return 0;
 
-   #ifdef HX_UTF8_STRINGS
    return (char *)obj->toString().dup().__CStr();
-   #else
-   // Known to create a copy
-   return (wchar_t *)obj->toString().__CStr();
-   #endif
 }
 
 
@@ -405,21 +392,13 @@ char *alloc_string_data(const char *inData, int inLength)
 
 hx::Object *alloc_string_len(const char *inStr,int inLen)
 {
-#ifdef HX_UTF8_STRINGS
    return Dynamic( String(inStr,inLen).dup() ).GetPtr();
-#else
-   return Dynamic( String(inStr,inLen) ).GetPtr();
-#endif
 }
 
 hx::Object *alloc_wstring_len(const wchar_t *inStr,int inLen)
 {
    String str(inStr,inLen);
-   #ifdef HX_UTF8_STRINGS
    return Dynamic(str).GetPtr();
-   #else
-   return Dynamic(str.dup()).GetPtr();
-   #endif
 }
 
 // Array access - generic

--- a/src/hx/Date.cpp
+++ b/src/hx/Date.cpp
@@ -374,13 +374,8 @@ String __internal_to_string(struct tm time)
 {
    // YYYY-MM-DD hh:mm:ss
 
-#ifndef HX_UTF8_STRINGS
-   wchar_t buf[100];
-   wcsftime(buf,100,L"%Y-%m-%d %H:%M:%S", &time);
-#else
    char buf[100];
    strftime(buf,100, "%Y-%m-%d %H:%M:%S", &time);
-#endif
    return String(buf).dup();
 }
 

--- a/src/hx/Lib.cpp
+++ b/src/hx/Lib.cpp
@@ -100,11 +100,7 @@ void hxFreeLibrary(Module inModule) { dlclose(inModule); }
 
 #endif
 
-#ifdef HX_UTF8_STRINGS
 typedef std::map<std::string,Module> LoadedModule;
-#else
-typedef std::map<std::wstring,Module> LoadedModule;
-#endif
 
 static LoadedModule sgLoadedModule;
 typedef std::vector<Module> ModuleList;

--- a/src/hx/RunLibs.cpp
+++ b/src/hx/RunLibs.cpp
@@ -13,11 +13,7 @@ int regexp_register_prims();
 int zlib_register_prims();
 
 
-#ifdef HX_UTF8_STRINGS
 std::string sgResultBuffer;
-#else
-std::wstring sgResultBuffer;
-#endif
 
 HXCPP_EXTERN_CLASS_ATTRIBUTES const HX_CHAR *hxRunLibrary()
 {

--- a/src/hx/StdLibs.cpp
+++ b/src/hx/StdLibs.cpp
@@ -38,6 +38,18 @@ typedef int64_t __int64;
 #define srand(x) srand48(x)
 #endif
 
+#ifdef HX_WINRT
+#define PRINTF WINRT_PRINTF
+#elif defined(TIZEN)
+#define PRINTF(fmt, ...) dlog_dprint(DLOG_INFO, "trace", fmt, __VA_ARGS__);
+#elif defined(HX_ANDROID) && !defined(HXCPP_EXE_LINK)
+#define PRINTF(fmt, ...) __android_log_print(ANDROID_LOG_INFO, "trace", fmt, __VA_ARGS__);
+#elif defined(WEBOS)
+#define PRINTF(fmt, ...) syslog(LOG_INFO, "trace", fmt, __VA_ARGS__);
+#else
+#define PRINTF printf
+#endif
+
 void __hx_stack_set_last_exception();
 void __hx_stack_push_last_exception();
 
@@ -292,27 +304,16 @@ void __trace(Dynamic inObj, Dynamic info)
 
    if (info==null())
    {
-   #ifdef HX_WINRT
-      WINRT_PRINTF("%s\n", message );
-   #elif defined(TIZEN)
-      dlog_dprint(DLOG_INFO, "trace","%s\n", message );
-   #elif defined(HX_ANDROID) && !defined(HXCPP_EXE_LINK)
-      __android_log_print(ANDROID_LOG_INFO, "trace","%s",message );
-   #elif defined(WEBOS)
-      syslog(LOG_INFO, "%s", message );
-   #elif defined(HX_SMART_STRINGS)
+   #if defined(HX_SMART_STRINGS)
       if (text.isUTF16Encoded())
       {
          wchar_t *converted = __hxcpp_utf16_to_wchar(text.__w, text.length);
-         printf("%S\n", converted);
+         PRINTF("%S\n", converted);
          if (converted != (wchar_t *)text.__w) free(converted);
       }
       else
-         printf("%s\n", message);
-   #else
-      printf("%s\n", message);
    #endif
-
+      PRINTF("%s\n", message);
    }
    else
    {
@@ -320,26 +321,16 @@ void __trace(Dynamic inObj, Dynamic info)
       const char *filename = Dynamic((info)->__Field(HX_CSTRING("fileName"), HX_PROP_DYNAMIC))->toString().__s;
       int line = Dynamic((info)->__Field( HX_CSTRING("lineNumber") , HX_PROP_DYNAMIC))->__ToInt();
 
-   #ifdef HX_WINRT
-      WINRT_PRINTF("%s:%d: %s\n", filename, line, message );
-   #elif defined(TIZEN)
-      AppLogInternal(filename, line, "%s\n", message );
-   #elif defined(HX_ANDROID) && !defined(HXCPP_EXE_LINK)
-      __android_log_print(ANDROID_LOG_INFO, "trace","%s:%d: %s",filename, line, message );
-   #elif defined(WEBOS)
-      syslog(LOG_INFO, "%s:%d: %s", filename, line, message );
-   #elif defined(HX_SMART_STRINGS)
+   #if defined(HX_SMART_STRINGS)
       if (text.isUTF16Encoded())
       {
          wchar_t *converted = __hxcpp_utf16_to_wchar(text.__w, text.length);
-         printf("%s:%d: %S\n",filename, line, converted);
+         PRINTF("%s:%d: %S\n", filename, line, converted);
          if (converted != (wchar_t *)text.__w) free(converted);
       }
       else
-         printf("%s:%d: %s\n",filename, line, message);
-   #else
-      printf("%s:%d: %s\n",filename, line, message);
    #endif
+      PRINTF("%s:%d: %s\n", filename, line, message);
    }
 
 }
@@ -614,38 +605,30 @@ Array<String> __get_args()
 
 void __hxcpp_print_string(const String &inV)
 {
-   #ifdef HX_WINRT
-      WINRT_PRINTF("%s", inV.__s);
-   #elif defined(HX_SMART_STRINGS)
-      if (inV.isUTF16Encoded())
-      {
-         wchar_t *converted = __hxcpp_utf16_to_wchar(inV.__w, inV.length);
-         printf("%S", converted);
-         if (converted != (wchar_t *)inV.__w) free(converted);
-      }
-      else
-         printf("%s", inV.__s);
-   #else
-      printf("%s", inV.__s);
-   #endif
+#if defined(HX_SMART_STRINGS)
+   if (inV.isUTF16Encoded())
+   {
+      wchar_t *converted = __hxcpp_utf16_to_wchar(inV.__w, inV.length);
+      PRINTF("%S", converted);
+      if (converted != (wchar_t *)inV.__w) free(converted);
+   }
+   else
+#endif
+   PRINTF("%s", inV.__s);
 }
 
 void __hxcpp_println_string(const String &inV)
 {
-   #ifdef HX_WINRT
-      WINRT_PRINTF("%s\n", inV.__s);
-   #elif defined(HX_SMART_STRINGS)
-      if (inV.isUTF16Encoded())
-      {
-         wchar_t *converted = __hxcpp_utf16_to_wchar(inV.__w, inV.length);
-         printf("%S\n", converted);
-         if (converted != (wchar_t *)inV.__w) free(converted);
-      }
-      else
-         printf("%s\n", inV.__s);
-   #else
-      printf("%s\n", inV.__s);
-   #endif
+#if defined(HX_SMART_STRINGS)
+   if (inV.isUTF16Encoded())
+   {
+      wchar_t *converted = __hxcpp_utf16_to_wchar(inV.__w, inV.length);
+      PRINTF("%S\n", converted);
+      if (converted != (wchar_t *)inV.__w) free(converted);
+   }
+   else
+#endif
+   PRINTF("%s\n", inV.__s);
 }
 
 

--- a/src/hx/StdLibs.cpp
+++ b/src/hx/StdLibs.cpp
@@ -270,7 +270,7 @@ wchar_t *__hxcpp_utf16_to_wchar(const char16_t *str, int u16length)
 {
 #if __SIZEOF_WCHAR_T__ == 2
    // 16-bit wchar_t (e.g. Windows), no need to convert.
-   return str;
+   return (wchar_t *)str;
 #else
    // 32-bit wchar_t (e.g. Linux, OS X), convert into a temporary buffer.
    wchar_t *converted = (wchar_t *)malloc(sizeof(wchar_t) * (u16length + 1));
@@ -305,7 +305,7 @@ void __trace(Dynamic inObj, Dynamic info)
       {
          wchar_t *converted = __hxcpp_utf16_to_wchar(text.__w, text.length);
          printf("%S\n", converted);
-         if (converted != test.__w) free(converted);
+         if (converted != (wchar_t *)text.__w) free(converted);
       }
       else
          printf("%s\n", message);
@@ -333,7 +333,7 @@ void __trace(Dynamic inObj, Dynamic info)
       {
          wchar_t *converted = __hxcpp_utf16_to_wchar(text.__w, text.length);
          printf("%s:%d: %S\n",filename, line, converted);
-         if (converted != test.__w) free(converted);
+         if (converted != (wchar_t *)text.__w) free(converted);
       }
       else
          printf("%s:%d: %s\n",filename, line, message);

--- a/src/hx/StdLibs.cpp
+++ b/src/hx/StdLibs.cpp
@@ -671,17 +671,10 @@ Dynamic __hxcpp_parse_int(const String &inString)
    bool hex =  (str[0]=='0' && (str[1]=='x' || str[1]=='X'));
    HX_CHAR *end = 0;
 
-   #ifdef HX_UTF8_STRINGS
    if (hex)
       result = (long)strtoul(str+2,&end,16);
    else
       result = strtol(str,&end,10);
-   #else
-   if (hex)
-      result = (long)wcstoul(str+2,&end,16);
-   else
-      result = wcstol(str,&end,10);
-   #endif
    if (str==end)
       return null();
    return (int)result;
@@ -691,11 +684,7 @@ double __hxcpp_parse_float(const String &inString)
 {
    const HX_CHAR *str = inString.__s;
    HX_CHAR *end = (HX_CHAR *)str;
-   #ifdef HX_UTF8_STRINGS
    double result = str ? strtod(str,&end) : 0;
-   #else
-   double result =  str ? wcstod(str,&end) : 0;
-   #endif
 
    if (end==str)
       return Math_obj::NaN;

--- a/src/hx/StdLibs.cpp
+++ b/src/hx/StdLibs.cpp
@@ -615,26 +615,36 @@ Array<String> __get_args()
 void __hxcpp_print_string(const String &inV)
 {
    #ifdef HX_WINRT
-   WINRT_PRINTF("%s",inV.__s);
+      WINRT_PRINTF("%s", inV.__s);
+   #elif defined(HX_SMART_STRINGS)
+      if (inV.isUTF16Encoded())
+      {
+         wchar_t *converted = __hxcpp_utf16_to_wchar(inV.__w, inV.length);
+         printf("%S", converted);
+         if (converted != (wchar_t *)inV.__w) free(converted);
+      }
+      else
+         printf("%s", inV.__s);
    #else
-   #ifdef HX_UTF8_STRINGS
-   printf("%s",inV.__s);
-   #else
-   printf("%S",inV.__s);
-   #endif
+      printf("%s", inV.__s);
    #endif
 }
 
 void __hxcpp_println_string(const String &inV)
 {
    #ifdef HX_WINRT
-   WINRT_PRINTF("%s\n",inV.__s);
+      WINRT_PRINTF("%s\n", inV.__s);
+   #elif defined(HX_SMART_STRINGS)
+      if (inV.isUTF16Encoded())
+      {
+         wchar_t *converted = __hxcpp_utf16_to_wchar(inV.__w, inV.length);
+         printf("%S\n", converted);
+         if (converted != (wchar_t *)inV.__w) free(converted);
+      }
+      else
+         printf("%s\n", inV.__s);
    #else
-   #ifdef HX_UTF8_STRINGS
-   printf("%s\n",inV.__s);
-   #else
-   printf("%S\n",inV.__s);
-   #endif
+      printf("%s\n", inV.__s);
    #endif
 }
 


### PR DESCRIPTION
This fixes some of the issues with Unicode support, particularly on non-Windows platforms. "Smart strings" currently represent a string as either a `char *` when there are no non-ASCII characters, or otherwise a `char16_t *` (UTF-16 codepoints). Unfortunately, it seems there is still no stdlib function to print a `char16_t *` in C++, only `wchar_t *` using `%S`. Additionally, `wchar_t` does not have a specified size (it is 16 bits on Windows, 32 bits on Linux and OS X).

To fix platforms where `sizeof(char16_t) != sizeof(wchar_t)`, we could:

 - change the internal representation for Unicode strings to use `wchar_t *` - this would use the "proper" type for the strings but could introduce inconsistencies when dealing with non-BMP characters; also strings would take twice as much memory on Linux and OS X
 - convert `char16_t *` to `wchar_t *` in a temporary buffer just before outputting a Unicode string

This PR chooses the latter approach.

## TODO

 - [x] `setlocale` re-enabled - this was commented out in a `#if defined(_MSC_VER) && !defined(HX_WINRT)` block
   - [ ] check compatibility with Windows
 - [x] `char16_t *` to `wchar_t *` conversion function - `__hxcpp_utf16_to_wchar` in `StdLibs.cpp`
 - [x] fix `trace`
 - [x] fix `Sys.print`, `Sys.println`
 - [x] get rid of any remaining occurrences of `HX_UTF8_STRINGS` (should now be obsolete)
 - [x] smart strings are ignored with `HX_WINRT`, `defined(TIZEN)`, `defined(HX_ANDROID) && !defined(HXCPP_EXE_LINK)`, or `defined(WEBOS)` - the defines mostly change which function is used in place of `printf`; if they all support `%S`, the `ifdef`s should only define the `printf` function (already done for `snprintf` in `String.cpp`)
 - [x] ~~`Bytes.writeString`~~ `Output.writeString` just uses `Bytes.ofString`, which encodes the string correctly (UTF-16 into UTF-8) via `__hxcpp_bytes_of_string`
 - [x] fix `String.split` on Unicode string with non-Unicode delimiter
 - [ ] possible issues with `Bytes.getString`
   - `__hxcpp_string_of_bytes` falls back to `String::fromCharCode` for any 1-character string - see below for inconsistent results
   - fix `_hx_utf8_decode_advance` / `DecodeAdvanceUTF8` ?
     - currently reads OOB (e.g. if the last byte is `F0`, three extra bytes are read) - add an `end` argument? - would break any code using `cpp.NativeString.utf8DecodeAdvance` (assuming there even is any)
     - no error handling for invalid sequences - lenient decoder by default, use `UTF8Strict` to catch errors

## `__hxcpp_string_of_bytes` ##

```haxe
class Main {
  public static function main():Void {
    var s = [
      haxe.io.Bytes.ofHex("F3").getString(0, 1),
      haxe.io.Bytes.ofHex("60F3").getString(0, 2),
      haxe.io.Bytes.ofHex("6060F3").getString(0, 3),
      haxe.io.Bytes.ofHex("606060F3").getString(0, 4),
      haxe.io.Bytes.ofHex("60606060F3").getString(0, 5),
      haxe.io.Bytes.ofHex("6060606060F3").getString(0, 6),
      haxe.io.Bytes.ofHex("606060606060F3").getString(0, 7),
      haxe.io.Bytes.ofHex("60606060606060F3").getString(0, 8),
      haxe.io.Bytes.ofHex("6060606060606060F3").getString(0, 9),
      haxe.io.Bytes.ofHex("606060606060606060F3").getString(0, 10),
      haxe.io.Bytes.ofHex("60606060606060606060F3").getString(0, 11)
    ];
    for (i in 0...s.length) trace(s[i].length, s[i].charCodeAt(s[i].length - 1));
  }
}
```

Probably reads OOB / uninitialised memory for all cases except the first. Ouputs are inconsistent:

```
Main.hx:16: 1,243
Main.hx:16: 3,56320
Main.hx:16: 4,56320
Main.hx:16: 5,56320
Main.hx:16: 6,56320
Main.hx:16: 7,56321
Main.hx:16: 8,56454
Main.hx:16: 9,56704
Main.hx:16: 10,56320
Main.hx:16: 11,56321
Main.hx:16: 12,56390
```
