### PR TITLE
Sys.args with unicode

### DIFF
--- a/include/hxString.h
+++ b/include/hxString.h
@@ -39,9 +39,9 @@ public:
    #endif
 
    // Makes copy
-   static String String::create(const wchar_t *inPtr,int inLen=-1);
-   static String String::create(const char16_t *inPtr,int inLen=-1);
-   static String String::create(const char *inPtr,int inLen=-1);
+   static String create(const wchar_t *inPtr,int inLen=-1);
+   static String create(const char16_t *inPtr,int inLen=-1);
+   static String create(const char *inPtr,int inLen=-1);
 
    #ifdef __OBJC__
    inline String(NSString *inString)
@@ -167,7 +167,7 @@ public:
 
    inline bool isAsciiEncoded() const {
       #ifdef HX_SMART_STRINGS
-      return __w && !(((unsigned int *)__w)[-1] & HX_GC_STRING_CHAR16_T);
+      return !__w || !(((unsigned int *)__w)[-1] & HX_GC_STRING_CHAR16_T);
       #else
       return true;
       #endif

--- a/src/String.cpp
+++ b/src/String.cpp
@@ -1062,6 +1062,15 @@ String &String::dup()
    }
    else
    {
+      #ifdef HX_SMART_STRINGS
+      if (isUTF16Encoded())
+      {
+         const char16_t *oldString = __w;
+         __w = 0;
+         __w = (char16_t *)GCStringDup(oldString,length,&length);
+         return *this;
+      }
+      #endif
       // Take copy incase GCStringDup generates GC event
       const char *oldString = __s;
       __s = 0;

--- a/src/hx/StdLibs.cpp
+++ b/src/hx/StdLibs.cpp
@@ -516,7 +516,7 @@ Array<String> __get_args()
    if (_hxcpp_argc)
    {
       for(int i=1;i<_hxcpp_argc;i++)
-         result->push( String(_hxcpp_argv[i],strlen(_hxcpp_argv[i])).dup() );
+         result->push( String::create(_hxcpp_argv[i],strlen(_hxcpp_argv[i])).dup() );
       return result;
    }
 
@@ -532,7 +532,7 @@ Array<String> __get_args()
    int argc = *_NSGetArgc();
    char **argv = *_NSGetArgv();
    for(int i=1;i<argc;i++)
-      result->push( String(argv[i],strlen(argv[i])).dup() );
+      result->push( String::create(argv[i],strlen(argv[i])).dup() );
    #endif
 
    #else

--- a/src/hx/StdLibs.cpp
+++ b/src/hx/StdLibs.cpp
@@ -516,7 +516,7 @@ Array<String> __get_args()
    if (_hxcpp_argc)
    {
       for(int i=1;i<_hxcpp_argc;i++)
-         result->push( String::create(_hxcpp_argv[i],strlen(_hxcpp_argv[i])).dup() );
+         result->push( String::create(_hxcpp_argv[i],strlen(_hxcpp_argv[i])) );
       return result;
    }
 
@@ -532,7 +532,7 @@ Array<String> __get_args()
    int argc = *_NSGetArgc();
    char **argv = *_NSGetArgv();
    for(int i=1;i<argc;i++)
-      result->push( String::create(argv[i],strlen(argv[i])).dup() );
+      result->push( String::create(argv[i],strlen(argv[i])) );
    #endif
 
    #else


### PR DESCRIPTION
More Unicode fixes…

 - [x] `dup()` fixed for UTF-16 strings
 - [ ] should `dupConst()` be fixed also? I'm not sure what the `const` refers to there
 - [x] fix `__get_args` if `_hxcpp_argc/v` is set
 - [x] fix `__get_args` on OS X
 - [ ] fix `__get_args` for Linux and Windows - these all add to a string character by character, even though the "characters" are actually partial Unicode bytes; some temporary buffer should be allocated and then decoded into a String I assume?
