### PR TITLE
For non-winrt 64-bit Windows builds

### DIFF
--- a/toolchain/msvc64-setup.bat
+++ b/toolchain/msvc64-setup.bat
@@ -1,10 +1,10 @@
 setlocal enabledelayedexpansion
 @if exist "%HXCPP_MSVC%\..\..\VC\" (
-	@if not exist "%HXCPP_MSVC%\..\..\VC\bin\x86_amd64\vcvarsx86_amd64.bat" (
-		@echo Error: the specified MSVC version does not have vcvarsx86_amd64.bat setup script
+	@if not exist "%HXCPP_MSVC%\..\..\VC\bin\amd64\vcvars64.bat" (
+		@echo Error: the specified MSVC version does not have vcvars64.bat setup script
 	) else (
 		@echo "%HXCPP_MSVC%"
-		@call "%HXCPP_MSVC%\..\..\VC\bin\x86_amd64\vcvarsx86_amd64.bat"
+		@call "%HXCPP_MSVC%\..\..\VC\bin\amd64\vcvars64.bat"
 		@echo HXCPP_VARS
 		@set
 	)
@@ -13,30 +13,30 @@ setlocal enabledelayedexpansion
 		@set InstallDir=%%i
 	)
 	@if exist "!InstallDir!\Common7\Tools\VsDevCmd.bat" (
-		@call "!InstallDir!\Common7\Tools\VsDevCmd.bat" -arch=amd64 -app_platform=Desktop -no_logo
+		@call "!InstallDir!\Common7\Tools\VsDevCmd.bat" -arch=amd64 -host_arch=amd64 -app_platform=Desktop -no_logo
 		@echo HXCPP_VARS
 		@set
 	) else (
 		echo Warning: Could not find Visual Studio 2017 VsDevCmd
 	)
 ) else if exist "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat" (
-	@call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat" -arch=amd64 -app_platform=Desktop -no_logo
+	@call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat" -arch=amd64 -host_arch=amd64 -app_platform=Desktop -no_logo
 	@echo HXCPP_VARS
 	@set
-) else if exist "%VS140COMNTOOLS%\..\..\VC\bin\x86_amd64\vcvarsx86_amd64.bat" (
+) else if exist "%VS140COMNTOOLS%\..\..\VC\bin\amd64\vcvars64.bat" (
 	@echo "%VS140COMNTOOLS%"
-	@call "%VS140COMNTOOLS%\..\..\VC\bin\x86_amd64\vcvarsx86_amd64.bat"
+	@call "%VS140COMNTOOLS%\..\..\VC\bin\amd64\vcvars64.bat"
 	@echo HXCPP_VARS
 	@set
 	@echo HXCPP_HACK_PDBSRV=1
-) else if exist "%VS120COMNTOOLS%\..\..\VC\bin\x86_amd64\vcvarsx86_amd64.bat" (
+) else if exist "%VS120COMNTOOLS%\..\..\VC\bin\amd64\vcvars64.bat" (
 	@echo "%VS120COMNTOOLS%"
-	@call "%VS120COMNTOOLS%\..\..\VC\bin\x86_amd64\vcvarsx86_amd64.bat"
+	@call "%VS120COMNTOOLS%\..\..\VC\bin\amd64\vcvars64.bat"
 	@echo HXCPP_VARS
 	@set
-) else if exist "%VS110COMNTOOLS%\..\..\VC\bin\x86_amd64\vcvarsx86_amd64.bat" (
+) else if exist "%VS110COMNTOOLS%\..\..\VC\bin\amd64\vcvars64.bat" (
 	@echo "%VS110COMNTOOLS%"
-	@call "%VS110COMNTOOLS%\..\..\VC\bin\x86_amd64\vcvarsx86_amd64.bat"
+	@call "%VS110COMNTOOLS%\..\..\VC\bin\amd64\vcvars64.bat"
 	@echo HXCPP_VARS
 	@set
 ) else (


### PR DESCRIPTION
Use the 64-bit native compiler rather than the 32 to 64 cross compiler.
Changed the toolchain batch file to point relevant options and paths to amd64