### PR TITLE
fix for Array<cpp.Pointer<T>>

### DIFF
--- a/include/Array.h
+++ b/include/Array.h
@@ -517,7 +517,9 @@ public:
    inline ELEM_ & __unsafe_set(int inIndex, ELEM_ inValue)
    {
       if (hx::ContainsPointers<ELEM_>()) { HX_OBJ_WB_GET(this, hx::PointerOf(inValue)); }
-      return * (ELEM_ *)(mBase + inIndex*sizeof(ELEM_)) = inValue;
+      ELEM_ &elem = *(ELEM_*)(mBase + inIndex*sizeof(ELEM_));
+      elem = inValue;
+      return elem;
    }
 
 
@@ -883,7 +885,7 @@ public:
 
    virtual void set(int inIndex, const cpp::Variant &inValue) { Item(inIndex) = ELEM_(inValue); }
    virtual void setUnsafe(int inIndex, const cpp::Variant &inValue) {
-      ELEM_ &elem = *(ELEM_ *)(mBase + inIndex*sizeof(ELEM_)) = ELEM_(inValue);
+      ELEM_ &elem = *(ELEM_ *)(mBase + inIndex*sizeof(ELEM_));
       elem = ELEM_(inValue);
       if (hx::ContainsPointers<ELEM_>()) { HX_OBJ_WB_GET(this,hx::PointerOf(elem)); }
    }

--- a/include/hxString.h
+++ b/include/hxString.h
@@ -93,6 +93,8 @@ public:
    String(hx::Null< ::String > inRHS) : __s(inRHS.value.__s), length(inRHS.value.length) { }
    inline String(const ::cpp::Variant &inRHS) { *this = inRHS.asString(); }
    template<typename T>
+   inline String( const ::cpp::Pointer<T> &inRHS) { fromPointer(inRHS.ptr); }
+   template<typename T>
    inline String( const hx::Native<T> &n ) { fromPointer(n.ptr); }
 
    static String emptyString;


### PR DESCRIPTION
We  could not use `Array<cpp.Pointer<T>>` with hxcpp.
For example, hxcpp generated an invalid C++ program for this:
```
class Test {
    static function main() {
         var arr: Array<cpp.Pointer<cpp.Int32>> = new Array();
    }
}
```

I fixed this problem in this commit.