### PR TITLE
Let other MSVC locations be found even if vswhere exists

### DIFF
--- a/toolchain/msvc-setup.bat
+++ b/toolchain/msvc-setup.bat
@@ -3,11 +3,14 @@ setlocal enabledelayedexpansion
 	@call "%HXCPP_MSVC%\vcvars32.bat"
 	@echo HXCPP_VARS
 	@set
+	exit
 ) else if exist "%HXCPP_MSVC%\vsvars32.bat" (
 	@call "%HXCPP_MSVC%\vsvars32.bat"
 	@echo HXCPP_VARS
 	@set
-) else if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" (
+	exit
+)
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" (
 	for /f "usebackq tokens=*" %%i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do (
 		@set InstallDir=%%i
 	)
@@ -15,10 +18,12 @@ setlocal enabledelayedexpansion
 		@call "!InstallDir!\Common7\Tools\VsDevCmd.bat" -arch=x86 -app_platform=Desktop -no_logo
 		@echo HXCPP_VARS
 		@set
+		exit
 	) else (
 		echo Warning: Could not find Visual Studio 2017 VsDevCmd
 	)
-) else if exist "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat" (
+)
+@if exist "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat" (
 	@call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat" -arch=x86 -app_platform=Desktop -no_logo
 	@echo HXCPP_VARS
 	@set

--- a/toolchain/msvc64-setup.bat
+++ b/toolchain/msvc64-setup.bat
@@ -8,7 +8,9 @@ setlocal enabledelayedexpansion
 		@echo HXCPP_VARS
 		@set
 	)
-) else if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" (
+	exit
+)
+@if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" (
 	for /f "usebackq tokens=*" %%i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do (
 		@set InstallDir=%%i
 	)
@@ -16,10 +18,12 @@ setlocal enabledelayedexpansion
 		@call "!InstallDir!\Common7\Tools\VsDevCmd.bat" -arch=amd64 -app_platform=Desktop -no_logo
 		@echo HXCPP_VARS
 		@set
+		exit
 	) else (
 		echo Warning: Could not find Visual Studio 2017 VsDevCmd
 	)
-) else if exist "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat" (
+)
+@if exist "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat" (
 	@call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat" -arch=amd64 -app_platform=Desktop -no_logo
 	@echo HXCPP_VARS
 	@set


### PR DESCRIPTION
vswhere.exe may exist even if VS 2017 is not installed, or it's installed but the c++ tools are not. If this is the case, we should keep looking for an alternative install that works.