### PR TITLE
Attempt to fix crtbegin error (clang android)

### DIFF
--- a/src/hx/AndroidCompat.cpp
+++ b/src/hx/AndroidCompat.cpp
@@ -9,7 +9,7 @@
 // These functions are inlined prior to android-ndk-platform-21, which means they
 // are missing from the libc functions on those phones, and you will get link errors.
 
-#if (HXCPP_ANDROID_PLATFORM>=21) && !defined(HXCPP_ARM64)
+#if (HXCPP_ANDROID_PLATFORM>=21) && !defined(HXCPP_ARM64) && !defined(HXCPP_ARMV7)
 extern "C" {
 
 

--- a/toolchain/android-toolchain.xml
+++ b/toolchain/android-toolchain.xml
@@ -1,6 +1,6 @@
 <xml>
 
-<!-- Android TOOLS -------------------------------------->
+<!-- Android TOOLS -->
 <!--
   Configure build via variables, otherwise defaults will be used:
      Set the path to the exact ndk to use with ANDROID_NDK_ROOT,
@@ -183,8 +183,8 @@
   <prefix value="lib"/>
 
   <flag value="-frtti"/>
-  <flag value="-nostdlib" unless="HXCPP_CLANG" />
-  <flag value="-nostdlib++" if="HXCPP_CLANG" />
+  <flag value="-nostdlib"/>
+
   <flag value="--target=${TRIPLE}" if="HXCPP_CLANG" />
   <!-- <flag value="-stdlib=libc++" if="HXCPP_CLANG" /> -->
   <flag value="-std=c++11" if="HXCPP_CPP11"/>
@@ -199,7 +199,6 @@
   <flag value="-Wl,--unresolved-symbols=ignore-in-object-files" if="dll_import" />
   <flag value="-Wl,-z,noexecstack"/>
   <flag value="--sysroot=${ANDROID_NDK_ROOT}/platforms/${PLATFORM}/${PLATFORM_ARCH}"/>
-  <!-- <flag value="--sysroot=${ANDROID_NDK_ROOT}/sysroot" if="HXCPP_CLANG"/> -->
   <flag value="-L${ANDROID_NDK_ROOT}/platforms/${PLATFORM}/${PLATFORM_ARCH}/usr/lib"/>
   <flag value="-L${ANDROID_NDK_ROOT}/sources/cxx-stl/llvm-libc++/libs/${STL_NAME}" if="HXCPP_CLANG" />
 
@@ -207,13 +206,18 @@
   <lib name="${ANDROID_NDK_ROOT}/sources/cxx-stl/gnu-libstdc++/libs/${ABI}/libgnustl_static.a" if="NDKV7" unless="HXCPP_CLANG || dll_import" />
   <lib name="${ANDROID_NDK_ROOT}/sources/cxx-stl/gnu-libstdc++/${TOOLCHAIN_VERSION}/libs/${ABI}/libgnustl_static.a" if="NDKV8+" unless="HXCPP_CLANG || dll_import" />
 
-  <lib name="${ANDROID_NDK_ROOT}/platforms/${PLATFORM}/${PLATFORM_ARCH}/usr/lib/crtbegin_so.o" unless="HXCPP_CLANG" />
+  
+  <lib name="${ANDROID_NDK_ROOT}/platforms/${PLATFORM}/${PLATFORM_ARCH}/usr/lib/crtbegin_so.o" />
   <lib name="${prebuiltBase}/lib/gcc/${EXEPREFIX}/${TOOLCHAIN_VERSION}/libgcc.a" unless="NDKV12+ || HXCPP_CLANG"/>
-  <lib name="${prebuiltBase}/lib/gcc/${EXEPREFIX}/${TOOLCHAIN_VERSION}.x/libgcc.a" if="NDKV12+" unless="HXCPP_CLANG"/>
+  <lib name="${prebuiltBase}/lib/gcc/${EXEPREFIX}/${TOOLCHAIN_VERSION}.x/libgcc.a" if="NDKV12+"/>
+
   <lib name="${ANDROID_NDK_ROOT}/platforms/${PLATFORM}/${PLATFORM_ARCH}/usr/lib/libc.so" unless="HXCPP_CLANG" />
+
   <lib name="${ANDROID_NDK_ROOT}/platforms/${PLATFORM}/${PLATFORM_ARCH}/usr/lib/libm.so"/>
+
   <lib name="-lc++_shared" if="HXCPP_CLANG" />
-  <lib name="-landroid_support" if="HXCPP_CLANG" />
+  <lib name="-landroid_support" if="HXCPP_CLANG" unless="HXCPP_ARM64" />
+  <lib name="-lc" if="HXCPP_CLANG"/>
   <lib name="-llog"/>
   <lib name="-ldl"/>
 </linker>
@@ -230,8 +234,8 @@
   <prefix value=""/>
 
   <flag value="-frtti"/>
-  <flag value="-nostdlib" unless="HXCPP_CLANG" />
-  <flag value="-nostdlib++" if="HXCPP_CLANG" />
+  <flag value="-nostdlib"/>
+
   <flag value="--target=${TRIPLE}" if="HXCPP_CLANG" />
   <!-- <flag value="-stdlib=libc++" if="HXCPP_CLANG" /> -->
   <flag value="-std=c++11" if="HXCPP_CPP11"/>
@@ -239,21 +243,23 @@
   <flag value="-Wl,--unresolved-symbols=ignore-in-object-files" if="dll_import" />
   <flag value="-Wl,-z,noexecstack"/>
   <flag value="--sysroot=${ANDROID_NDK_ROOT}/platforms/${PLATFORM}/${PLATFORM_ARCH}"/>
-  <!-- <flag value="--sysroot=${ANDROID_NDK_ROOT}/sysroot" if="HXCPP_CLANG"/> -->
   <flag value="-L${ANDROID_NDK_ROOT}/platforms/${PLATFORM}/${PLATFORM_ARCH}/usr/lib"/>
 
   <lib name="${ANDROID_NDK_ROOT}/sources/cxx-stl/gnu-libstdc++/libs/${ABI}/libstdc++.a" if="NDKV6" unless="HXCPP_CLANG dll_import" />
   <lib name="${ANDROID_NDK_ROOT}/sources/cxx-stl/gnu-libstdc++/libs/${ABI}/libgnustl_static.a" if="NDKV7" unless="HXCPP_CLANG dll_import" />
   <lib name="${ANDROID_NDK_ROOT}/sources/cxx-stl/gnu-libstdc++/${TOOLCHAIN_VERSION}/libs/${ABI}/libgnustl_static.a" if="NDKV8+" unless="HXCPP_CLANG dll_import" />
 
-  <lib name="${ANDROID_NDK_ROOT}/platforms/${PLATFORM}/${PLATFORM_ARCH}/usr/lib/crtbegin_static.o" unless="HXCPP_CLANG"/>
+  <lib name="${ANDROID_NDK_ROOT}/platforms/${PLATFORM}/${PLATFORM_ARCH}/usr/lib/crtbegin_static.o"/>
   <lib name="${prebuiltBase}/lib/gcc/${EXEPREFIX}/${TOOLCHAIN_VERSION}/libgcc.a" unless="NDKV12+ || HXCPP_CLANG" />
-  <lib name="${prebuiltBase}/lib/gcc/${EXEPREFIX}/${TOOLCHAIN_VERSION}.x/libgcc.a" if="NDKV12+" unless="HXCPP_CLANG"/>
+  <lib name="${prebuiltBase}/lib/gcc/${EXEPREFIX}/${TOOLCHAIN_VERSION}.x/libgcc.a" if="NDKV12+"/>
+
   <lib name="${ANDROID_NDK_ROOT}/platforms/${PLATFORM}/${PLATFORM_ARCH}/usr/lib/libc.so" unless="HXCPP_CLANG"/>
   <lib name="${ANDROID_NDK_ROOT}/platforms/${PLATFORM}/${PLATFORM_ARCH}/usr/lib/libm.so"/>
   <lib name="${ANDROID_NDK_ROOT}/platforms/${PLATFORM}/${PLATFORM_ARCH}/usr/lib/crtend_android.o"/>
+
   <lib name="-lc++_shared" if="HXCPP_CLANG" />
-  <lib name="-landroid_support" if="HXCPP_CLANG" />
+  <lib name="-landroid_support" if="HXCPP_CLANG" unless="HXCPP_ARM64" />
+  <lib name="-lc" if="HXCPP_CLANG"/>
   <lib name="-llog"/>
   <lib name="-ldl"/>
 </linker>


### PR DESCRIPTION
For #707 to fix the error:
```
/home/joshua/Development/Android/android-ndk-r19c/platforms/android-16/arch-arm/usr/lib/../lib/crtbegin_dynamic.o:crtbegin.c:function _start_main: error: undefined reference to 'main'
```

I was able to get the DisplayingABitmap sample to run on my device using NDK 19c (both ARMV7 and ARM64) using that fix.

Worth nothing you now need to bundle the `libc++_shared.so` file inside the APK. I did it using the template folder and adding it inside the `jniLibs` folder, there is probably a more elegant way to do it (this [link](https://developer.android.com/ndk/guides/cpp-support#libc) seems to indicate that gradle can be used for that).

I was targeting platform 21.

Feel free to close it, hope this can help get official NDK 16+