### PR TITLE
Fix duplicate LF->CRLF encoding

### DIFF
--- a/include/hx/Debug.h
+++ b/include/hx/Debug.h
@@ -317,7 +317,7 @@ Dynamic __hxcpp_dbg_checkedRethrow(Dynamic toThrow);
 // If no debugger, provide empty implementations of the debugging functions
 
 inline void __hxcpp_dbg_setEventNotificationHandler(Dynamic)
-    { hx::Throw("Debugging is not enabled for this program; try\n"
+    { hx::Throw("Debugging is not enabled for this program; try" HX_LF
                 "rebuilding it with the -D HXCPP_DEBUGGER option"); }
 inline void __hxcpp_dbg_enableCurrentThreadDebugging(bool) { }
 inline int __hxcpp_dbg_getCurrentThreadNumber() { return -1; }

--- a/include/hx/HxcppMain.h
+++ b/include/hx/HxcppMain.h
@@ -98,7 +98,7 @@
          #ifdef HX_WIN_MAIN
          MessageBoxA(0,  e==null() ? "null" : e->toString().__CStr(), "Error", 0);
          #else
-         printf("Error : %s\n",e==null() ? "null" : e->toString().__CStr());
+         printf("Error : %s" HX_LF,e==null() ? "null" : e->toString().__CStr());
          #endif
          return -1;
       }

--- a/include/hx/Macros.h
+++ b/include/hx/Macros.h
@@ -203,7 +203,7 @@ HXCPP_EXTERN_CLASS_ATTRIBUTES void SetTopOfStack(int *inTopOfStack,bool);
       } \
       catch ( ::Dynamic e){ \
          __hx_dump_stack(); \
-         printf("Error : %s\n",e->toString().__CStr()); \
+         printf("Error : %s" HX_LF,e->toString().__CStr()); \
          return -1; \
       } \
       return 0; \
@@ -311,7 +311,7 @@ extern "C" EXPORT_EXTRA int OspMain (int argc, char* pArgv[]){ \
         } \
         catch ( ::Dynamic e){ \
                 __hx_dump_stack(); \
-                printf("Error : %s\n",e->toString().__CStr()); \
+                printf("Error : %s" HX_LF,e->toString().__CStr()); \
                 return -1; \
         } \
         return 0; \
@@ -333,7 +333,7 @@ int main(int argc,char **argv){ \
 	} \
 	catch ( ::Dynamic e){ \
 		__hx_dump_stack(); \
-		printf("Error : %s\n",e->toString().__CStr()); \
+		printf("Error : %s" HX_LF,e->toString().__CStr()); \
       return -1; \
 	} \
 	return 0; \

--- a/include/hx/MacrosFixed.h
+++ b/include/hx/MacrosFixed.h
@@ -195,7 +195,7 @@ HXCPP_EXTERN_CLASS_ATTRIBUTES void SetTopOfStack(int *inTopOfStack,bool);
       } \
       catch ( ::Dynamic e){ \
          __hx_dump_stack(); \
-         printf("Error : %s\n",e->toString().__CStr()); \
+         printf("Error : %s" HX_LF,e->toString().__CStr()); \
          return -1; \
       } \
       return 0; \
@@ -303,7 +303,7 @@ extern "C" EXPORT_EXTRA int OspMain (int argc, char* pArgv[]){ \
         } \
         catch ( ::Dynamic e){ \
                 __hx_dump_stack(); \
-                printf("Error : %s\n",e->toString().__CStr()); \
+                printf("Error : %s" HX_LF,e->toString().__CStr()); \
                 return -1; \
         } \
         return 0; \
@@ -325,7 +325,7 @@ int main(int argc,char **argv){ \
 	} \
 	catch ( ::Dynamic e){ \
 		__hx_dump_stack(); \
-		printf("Error : %s\n",e->toString().__CStr()); \
+		printf("Error : %s" HX_LF,e->toString().__CStr()); \
       return -1; \
 	} \
 	return 0; \

--- a/include/hx/Thread.h
+++ b/include/hx/Thread.h
@@ -372,11 +372,11 @@ struct HxSemaphore
             // Error - something's gone wrong...
             /*
             if (result==EINVAL) 
-               printf("ERROR: Condition EINVAL\n");
+               printf("ERROR: Condition EINVAL" HX_LF);
             else if (result==EPERM)
-               printf("ERROR: Condition EPERM\n");
+               printf("ERROR: Condition EPERM" HX_LF);
             else
-               printf("ERROR: Condition unknown error\n");
+               printf("ERROR: Condition unknown error" HX_LF);
             */
             break;
          }

--- a/include/hxString.h
+++ b/include/hxString.h
@@ -216,10 +216,10 @@ public:
 
          if ( have != result )
          {
-             printf("Bad string hash for %s\n", __s );
-             printf(" Is %08x\n", result );
-             printf(" Baked %08x\n", have );
-             printf(" Mark %08x\n",   ((unsigned int *)__s)[-1]  );
+             printf("Bad string hash for %s" HX_LF, __s );
+             printf(" Is %08x" HX_LF, result );
+             printf(" Baked %08x" HX_LF, have );
+             printf(" Mark %08x" HX_LF,   ((unsigned int *)__s)[-1]  );
          }
          #endif
          if (__s[HX_GC_CONST_ALLOC_MARK_OFFSET] & HX_GC_CONST_ALLOC_MARK_BIT)

--- a/include/hxcpp.h
+++ b/include/hxcpp.h
@@ -98,6 +98,12 @@
 typedef char HX_CHAR;
 
 
+#ifdef HX_WINDOWS
+  #define HX_LF "\r\n"
+#else
+  #define HX_LF "\n"
+#endif
+
 
 #if (defined(HXCPP_DEBUG) || defined(HXCPP_DEBUGGER)) && !defined HXCPP_CHECK_POINTER
 #define HXCPP_CHECK_POINTER
@@ -105,7 +111,7 @@ typedef char HX_CHAR;
 
 #ifdef HX_WINRT
 
-#define WINRT_LOG(fmt, ...) {char buf[1024];sprintf_s(buf,1024,"****LOG: %s(%d): %s \n    [" fmt "]\n",__FILE__,__LINE__,__FUNCTION__, __VA_ARGS__);OutputDebugString(buf);}
+#define WINRT_LOG(fmt, ...) {char buf[1024];sprintf_s(buf,1024,"****LOG: %s(%d): %s " HX_LF "    [" fmt "]" HX_LF,__FILE__,__LINE__,__FUNCTION__, __VA_ARGS__);OutputDebugString(buf);}
 #define WINRT_PRINTF(fmt, ...) {char buf[2048];sprintf_s(buf,2048,fmt,__VA_ARGS__);OutputDebugString(buf);}
 
 #endif

--- a/src/hx/CFFI.cpp
+++ b/src/hx/CFFI.cpp
@@ -695,7 +695,7 @@ hx::Object * val_call0_traceexcept(hx::Object * arg1) THROWS
    catch(Dynamic e)
    {
       String s = e;
-      fprintf(stderr,"Fatal Error : %s\n",s.__CStr());
+      fprintf(stderr,"Fatal Error : %s" HX_LF,s.__CStr());
       exit(1);
    }
    return 0;

--- a/src/hx/Debug.cpp
+++ b/src/hx/Debug.cpp
@@ -83,7 +83,7 @@ static void CriticalErrorHandler(String inErr, bool allowFixup)
    ctx->dumpExceptionStack();
 #endif
 
-    DBGLOG("Critical Error: %s\n", inErr.utf8_str());
+    DBGLOG("Critical Error: %s" HX_LF, inErr.utf8_str());
 
 #if defined(HX_WINDOWS) && !defined(HX_WINRT)
     MessageBoxA(0, inErr.utf8_str(), "Critial Error - program must terminate",
@@ -286,9 +286,9 @@ void StackContext::tracePosition( )
 {
    StackFrame *frame = mStackFrames[mStackFrames.size()-1];
    #ifdef HXCPP_STACK_LINE
-   DBGLOG("%s::%s : %d\n", frame->position->className, frame->position->functionName, frame->lineNumber);
+   DBGLOG("%s::%s : %d" HX_LF, frame->position->className, frame->position->functionName, frame->lineNumber);
    #else
-   DBGLOG("%s::%s\n", frame->position->className, frame->position->functionName);
+   DBGLOG("%s::%s" HX_LF, frame->position->className, frame->position->functionName);
    #endif
 }
 
@@ -360,7 +360,7 @@ void StackContext::dumpExceptionStack()
    int size = mExceptionStack.size();
    for(int i = size - 1; i >= 0; i--)
    {
-      EXCEPTION_PRINT("Called from %s\n", mExceptionStack[i].toDisplay().utf8_str());
+      EXCEPTION_PRINT("Called from %s" HX_LF, mExceptionStack[i].toDisplay().utf8_str());
    }
 }
 
@@ -521,7 +521,7 @@ void __hxcpp_set_debugger_info(const char **inAllClasses, const char **inFullPat
 #ifndef HXCPP_PROFILER
 void __hxcpp_start_profiler(::String inDumpFile)
 {
-   DBGLOG("Warning - profiler has no effect without HXCPP_PROFILER\n");
+   DBGLOG("Warning - profiler has no effect without HXCPP_PROFILER" HX_LF);
 }
 void __hxcpp_stop_profiler() { }
 #endif

--- a/src/hx/Debugger.cpp
+++ b/src/hx/Debugger.cpp
@@ -747,7 +747,7 @@ private:
         int hash = Hash(0,className);
         hash = Hash(hash,".");
         hash = Hash(hash,functionName.c_str());
-        //printf("%s.%s -> %08x\n", className, functionName.c_str(), hash );
+        //printf("%s.%s -> %08x" HX_LF, className, functionName.c_str(), hash );
         mBreakpoints[toCopy->mBreakpointCount].hash = hash;
         calcCombinedHash();
 #else
@@ -791,7 +791,7 @@ private:
 
       mNotInAnyFileLine = ~allFileLine;
       mNotInAnyClassFunc = ~allClassFunc;
-      //printf("Combined mask -> %08x %08x\n", mNotInAnyFileLine, mNotInAnyClassFunc);
+      //printf("Combined mask -> %08x %08x" HX_LF, mNotInAnyFileLine, mNotInAnyClassFunc);
    }
 #endif
 

--- a/src/hx/Hash.h
+++ b/src/hx/Hash.h
@@ -325,7 +325,7 @@ struct Hash : public HashBase< typename ELEMENT::Key >
       bool is_new = bucket==0;
 #endif
       mask = inNewCount-1;
-      //printf("expand %d -> %d\n",bucketCount, inNewCount);
+      //printf("expand %d -> %d" HX_LF,bucketCount, inNewCount);
       bucket = (Element **)InternalRealloc(bucket,inNewCount*sizeof(ELEMENT *));
       HX_OBJ_WB_GET(this, bucket);
       //for(int b=bucketCount;b<inNewCount;b++)
@@ -368,7 +368,7 @@ struct Hash : public HashBase< typename ELEMENT::Key >
    void compact()
    {
       int newSize = bucketCount>>1;
-      // printf("compact -> %d\n", newSize);
+      // printf("compact -> %d" HX_LF, newSize);
       mask = newSize-1;
       for(int b=newSize; b<bucketCount; b++)
       {
@@ -725,7 +725,7 @@ struct Hash : public HashBase< typename ELEMENT::Key >
 
    void __Visit(hx::VisitContext *__inCtx)
    {
-      //printf(" visit hash %p\n", this);
+      //printf(" visit hash %p" HX_LF, this);
       HX_VISIT_ARRAY(bucket);
       for(int b=0;b<bucketCount;b++)
       {

--- a/src/hx/Lib.cpp
+++ b/src/hx/Lib.cpp
@@ -52,7 +52,7 @@ Module hxLoadLibrary(String inLib)
    if (gLoadDebug)
    {
       if (result)
-         printf("Loaded module : %S.\n", inLib.__WCStr());
+         printf("Loaded module : %S." HX_LF, inLib.__WCStr());
    }
    return result;
 }
@@ -82,14 +82,14 @@ Module hxLoadLibrary(String inLib)
    {
 #ifdef HX_WINRT
       if (result)
-         WINRT_LOG("Loaded : %s.\n", inLib.__CStr());
+         WINRT_LOG("Loaded : %s." HX_LF, inLib.__CStr());
       else
-         WINRT_LOG("Error loading library: (%s) %s\n", inLib.__CStr(), dlerror());
+         WINRT_LOG("Error loading library: (%s) %s" HX_LF, inLib.__CStr(), dlerror());
 #else
       if (result)
-         printf("Loaded : %s.\n", inLib.__CStr());
+         printf("Loaded : %s." HX_LF, inLib.__CStr());
       else
-         printf("Error loading library: (%s) %s\n", inLib.__CStr(), dlerror());
+         printf("Error loading library: (%s) %s" HX_LF, inLib.__CStr(), dlerror());
 #endif
    }
    return result;
@@ -226,7 +226,7 @@ static String GetFileContents(String inFile)
 #endif
    if (!file)
    {
-      // printf("Could not open %S\n", inFile.__s);
+      // printf("Could not open %S" HX_LF, inFile.__s);
       return null();
    }
 
@@ -250,7 +250,7 @@ static String FindHaxelib(String inLib)
 {
    bool loadDebug = getenv("HXCPP_LOAD_DEBUG");
 
-   // printf("FindHaxelib %S\n", inLib.__s);
+   // printf("FindHaxelib %S" HX_LF, inLib.__s);
 
    String haxepath;
    hx::strbuf convertBuf;
@@ -260,13 +260,13 @@ static String FindHaxelib(String inLib)
    if ( (stat(".haxelib",&s)==0 && (s.st_mode & S_IFDIR) ) )
       haxepath = HX_CSTRING(".haxelib");
    if (loadDebug)
-      printf( haxepath.length ? "Found local .haxelib\n" : "No local .haxelib\n");
+      printf( haxepath.length ? "Found local .haxelib" HX_LF : "No local .haxelib" HX_LF);
 
    if (haxepath.length==0)
    {
       haxepath = GetEnv("HAXELIB_PATH");
       if (loadDebug)
-         printf("HAXELIB_PATH env:%s\n", haxepath.out_str(&convertBuf));
+         printf("HAXELIB_PATH env:%s" HX_LF, haxepath.out_str(&convertBuf));
    }
 
    if (haxepath.length==0)
@@ -278,14 +278,14 @@ static String FindHaxelib(String inLib)
        #endif
        haxepath = GetFileContents(home);
        if (loadDebug)
-          printf("HAXEPATH home:%s\n", haxepath.out_str(&convertBuf));
+          printf("HAXEPATH home:%s" HX_LF, haxepath.out_str(&convertBuf));
    }
 
    if (haxepath.length==0)
    {
       haxepath = GetEnv("HAXEPATH");
       if (loadDebug)
-         printf("HAXEPATH env:%s\n", haxepath.out_str(&convertBuf));
+         printf("HAXEPATH env:%s" HX_LF, haxepath.out_str(&convertBuf));
       if (haxepath.length>0)
       {
          haxepath += HX_CSTRING("/lib");
@@ -293,12 +293,12 @@ static String FindHaxelib(String inLib)
    }
 
    if (loadDebug)
-      printf("HAXEPATH dir:%s\n", haxepath.out_str(&convertBuf));
+      printf("HAXEPATH dir:%s" HX_LF, haxepath.out_str(&convertBuf));
 
    if (haxepath.length==0)
    {
        haxepath = GetFileContents(HX_CSTRING("/etc/.haxepath"));
-       if (loadDebug) printf("HAXEPATH etc:%s\n", haxepath.out_str(&convertBuf));
+       if (loadDebug) printf("HAXEPATH etc:%s" HX_LF, haxepath.out_str(&convertBuf));
    }
 
    if (haxepath.length==0)
@@ -308,7 +308,7 @@ static String FindHaxelib(String inLib)
       #else
       haxepath = HX_CSTRING("/usr/lib/haxe/lib");
       #endif
-       if (loadDebug) printf("HAXEPATH default:%s\n", haxepath.out_str(&convertBuf));
+       if (loadDebug) printf("HAXEPATH default:%s" HX_LF, haxepath.out_str(&convertBuf));
    }
 
    String dir = haxepath + HX_CSTRING("/") + inLib + HX_CSTRING("/");
@@ -316,7 +316,7 @@ static String FindHaxelib(String inLib)
 
    String dev = dir + HX_CSTRING(".dev");
    String path = GetFileContents(dev);
-   if (loadDebug) printf("Read dev location from file :%s, got %s\n", dev.out_str(&convertBuf), path.out_str(&convertBuf1));
+   if (loadDebug) printf("Read dev location from file :%s, got %s" HX_LF, dev.out_str(&convertBuf), path.out_str(&convertBuf1));
    if (path.length==0)
    {
       path = GetFileContents(dir + HX_CSTRING(".current"));
@@ -476,7 +476,7 @@ Dynamic __loadprim(String inLib, String inPrim,int inArgCount)
       }
    }
 
-   printf("Primitive not found : %s\n", full_name.__CStr() );
+   printf("Primitive not found : %s" HX_LF, full_name.__CStr() );
    return null();
 }
 
@@ -486,7 +486,7 @@ void *__hxcpp_get_proc_address(String inLib, String inPrim,bool ,bool inQuietFai
       return (*sgRegisteredPrims)[inPrim.__CStr()];
 
    if (!inQuietFail)
-      printf("Primitive not found : %s\n", inPrim.__CStr() );
+      printf("Primitive not found : %s" HX_LF, inPrim.__CStr() );
    return 0;
 }
 
@@ -565,11 +565,11 @@ void *__hxcpp_get_proc_address(String inLib, String full_name,bool inNdllProc,bo
    if (!module && gLoadDebug)
    {
       #ifdef HX_WINRT
-      WINRT_LOG("Searching for %s...\n", inLib.out_str(&convertBuf));
+      WINRT_LOG("Searching for %s..." HX_LF, inLib.out_str(&convertBuf));
       #elif defined(ANDROID)
        __android_log_print(ANDROID_LOG_INFO, "loader", "Searching for %s...", module_name.out_str(&convertBuf));
       #else
-      printf("Searching for %s...\n", inLib.out_str(&convertBuf));
+      printf("Searching for %s..." HX_LF, inLib.out_str(&convertBuf));
       #endif
    }
 
@@ -593,9 +593,9 @@ void *__hxcpp_get_proc_address(String inLib, String full_name,bool inNdllProc,bo
          if (gLoadDebug)
          {
             #ifdef HX_WINRT
-            WINRT_LOG(" try %s...\n", testPath.out_str(&convertBuf));
+            WINRT_LOG(" try %s..." HX_LF, testPath.out_str(&convertBuf));
             #elif !defined(ANDROID)
-            printf(" try %s...\n", testPath.out_str(&convertBuf));
+            printf(" try %s..." HX_LF, testPath.out_str(&convertBuf));
             #else
             __android_log_print(ANDROID_LOG_INFO, "loader", "Try %s", testPath.out_str(&convertBuf));
             #endif
@@ -606,9 +606,9 @@ void *__hxcpp_get_proc_address(String inLib, String full_name,bool inNdllProc,bo
             if (gLoadDebug)
             {
                #ifdef HX_WINRT
-               WINRT_LOG("Found %s\n", testPath.out_str(&convertBuf));
+               WINRT_LOG("Found %s" HX_LF, testPath.out_str(&convertBuf));
                #elif !defined(ANDROID)
-               printf("Found %s\n", testPath.out_str(&convertBuf));
+               printf("Found %s" HX_LF, testPath.out_str(&convertBuf));
                #else
                __android_log_print(ANDROID_LOG_INFO, "loader", "Found %s", testPath.out_str(&convertBuf));
                #endif
@@ -627,11 +627,11 @@ void *__hxcpp_get_proc_address(String inLib, String full_name,bool inNdllProc,bo
          {
             String testPath  = haxelibPath + HX_CSTRING("/ndll/") + bin + HX_CSTRING("/") + inLib + extension;
             if (gLoadDebug)
-               printf(" try %s...\n", testPath.out_str(&convertBuf));
+               printf(" try %s..." HX_LF, testPath.out_str(&convertBuf));
             module = hxLoadLibrary(testPath);
             if (module && gLoadDebug)
             {
-               printf("Found %s\n", testPath.out_str(&convertBuf));
+               printf("Found %s" HX_LF, testPath.out_str(&convertBuf));
             }
          }
       }
@@ -673,7 +673,7 @@ void *__hxcpp_get_proc_address(String inLib, String full_name,bool inNdllProc,bo
        __android_log_print(ANDROID_LOG_ERROR, "loader", "Could not find primitive %s in %p",
         full_name.__CStr(), module);
       #else
-      fprintf(stderr,"Could not find primitive %s.\n", full_name.__CStr());
+      fprintf(stderr,"Could not find primitive %s." HX_LF, full_name.__CStr());
       #endif
       return 0;
    }
@@ -688,7 +688,7 @@ void *__hxcpp_get_proc_address(String inLib, String full_name,bool inNdllProc,bo
       __android_log_print(ANDROID_LOG_ERROR, "loader", "Could not identify primitive %s in %s",
         full_name.__CStr(), inLib.__CStr() );
       #else
-      fprintf(stderr,"Could not identify primitive %s in %s\n", full_name.__CStr(),inLib.__CStr());
+      fprintf(stderr,"Could not identify primitive %s in %s" HX_LF, full_name.__CStr(),inLib.__CStr());
       #endif
    }
 
@@ -762,7 +762,7 @@ int __hxcpp_register_prim(const char *inName,void *inProc)
    void * &proc = (*sgRegisteredPrims)[inName];
    if (proc)
    {
-      printf("Warning : duplicate symbol %s\n", inName);
+      printf("Warning : duplicate symbol %s" HX_LF, inName);
    }
    proc = inProc;
    return 0;

--- a/src/hx/Profiler.cpp
+++ b/src/hx/Profiler.cpp
@@ -158,7 +158,7 @@ public:
 
         for (int i = 0; i < size; i++) {
             ResultsEntry &re = results[i];
-            PROFILE_PRINT("%s %.2f%%/%.2f%%\n", re.fullName, re.total * scale,
+            PROFILE_PRINT("%s %.2f%%/%.2f%%" HX_LF, re.fullName, re.total * scale,
                           re.self * scale);
             if (re.children.size() == 1) {
                 continue;
@@ -167,7 +167,7 @@ public:
             int childrenSize = re.children.size();
             for (int j = 0; j < childrenSize; j++) {
                 ChildEntry &ce = re.children[j];
-                PROFILE_PRINT("   %s %.1f%%\n", ce.fullName,
+                PROFILE_PRINT("   %s %.1f%%" HX_LF, ce.fullName,
                               (100.0 * ce.self) / re.childrenPlusSelf);
             }
         }

--- a/src/hx/StdLibs.cpp
+++ b/src/hx/StdLibs.cpp
@@ -274,6 +274,7 @@ void __hxcpp_stdlibs_boot()
    // This prevents print from converting LF into CRLF on Windows.
    #ifdef HX_WINDOWS
    setmode(_fileno(stdout), _O_BINARY);
+   setmode(_fileno(stderr), _O_BINARY);
    #endif
 
    // I think this does more harm than good.
@@ -294,11 +295,7 @@ void __trace(Dynamic inObj, Dynamic info)
    hx::strbuf convertBuf;
    if (info==null())
    {
-      #ifdef HX_WINDOWS
-      PRINTF("?? %s\r\n", text.raw_ptr() ? text.out_str(&convertBuf) : "null");
-      #else
-      PRINTF("?? %s\n", text.raw_ptr() ? text.out_str(&convertBuf) : "null");
-      #endif
+      PRINTF("?? %s" HX_LF, text.raw_ptr() ? text.out_str(&convertBuf) : "null");
    }
    else
    {
@@ -306,11 +303,7 @@ void __trace(Dynamic inObj, Dynamic info)
       int line = Dynamic((info)->__Field( HX_CSTRING("lineNumber") , HX_PROP_DYNAMIC))->__ToInt();
 
       hx::strbuf convertBuf;
-      #ifdef HX_WINDOWS
-      PRINTF("%s:%d: %s\r\n", filename, line, text.raw_ptr() ? text.out_str(&convertBuf) : "null");
-      #else
-      PRINTF("%s:%d: %s\n", filename, line, text.raw_ptr() ? text.out_str(&convertBuf) : "null");
-      #endif
+      PRINTF("%s:%d: %s" HX_LF, filename, line, text.raw_ptr() ? text.out_str(&convertBuf) : "null");
    }
 
 }
@@ -593,11 +586,7 @@ void __hxcpp_print_string(const String &inV)
 void __hxcpp_println_string(const String &inV)
 {
    hx::strbuf convertBuf;
-   #ifdef HX_WINDOWS
-   PRINTF("%s\r\n", inV.out_str(&convertBuf));
-   #else
-   PRINTF("%s\n", inV.out_str(&convertBuf));
-   #endif
+   PRINTF("%s" HX_LF, inV.out_str(&convertBuf));
 }
 
 

--- a/src/hx/StdLibs.cpp
+++ b/src/hx/StdLibs.cpp
@@ -6,6 +6,7 @@
 #ifdef HX_WINDOWS
 #include <windows.h>
 #include <io.h>
+#include <fcntl.h>
 #elif defined(__unix__) || defined(__APPLE__)
 #include <sys/time.h>
 #ifndef EMSCRIPTEN
@@ -270,6 +271,11 @@ void __hxcpp_stdlibs_boot()
    setlocale(LC_ALL, "");
    setlocale(LC_NUMERIC, "C");
 
+   // This prevents print from converting LF into CRLF on Windows.
+   #ifdef HX_WINDOWS
+   setmode(_fileno(stdout), _O_BINARY);
+   #endif
+
    // I think this does more harm than good.
    //  It does not cause fread to return immediately - as perhaps desired.
    //  But it does cause some new-line characters to be lost.
@@ -288,7 +294,11 @@ void __trace(Dynamic inObj, Dynamic info)
    hx::strbuf convertBuf;
    if (info==null())
    {
+      #ifdef HX_WINDOWS
+      PRINTF("?? %s\r\n", text.raw_ptr() ? text.out_str(&convertBuf) : "null");
+      #else
       PRINTF("?? %s\n", text.raw_ptr() ? text.out_str(&convertBuf) : "null");
+      #endif
    }
    else
    {
@@ -296,8 +306,11 @@ void __trace(Dynamic inObj, Dynamic info)
       int line = Dynamic((info)->__Field( HX_CSTRING("lineNumber") , HX_PROP_DYNAMIC))->__ToInt();
 
       hx::strbuf convertBuf;
-      //PRINTF("%s:%d: %s\n", filename, line, text.raw_ptr() ? text.out_str(&convertBuf) : "null");
+      #ifdef HX_WINDOWS
+      PRINTF("%s:%d: %s\r\n", filename, line, text.raw_ptr() ? text.out_str(&convertBuf) : "null");
+      #else
       PRINTF("%s:%d: %s\n", filename, line, text.raw_ptr() ? text.out_str(&convertBuf) : "null");
+      #endif
    }
 
 }
@@ -580,7 +593,11 @@ void __hxcpp_print_string(const String &inV)
 void __hxcpp_println_string(const String &inV)
 {
    hx::strbuf convertBuf;
+   #ifdef HX_WINDOWS
+   PRINTF("%s\r\n", inV.out_str(&convertBuf));
+   #else
    PRINTF("%s\n", inV.out_str(&convertBuf));
+   #endif
 }
 
 

--- a/src/hx/Telemetry.cpp
+++ b/src/hx/Telemetry.cpp
@@ -132,7 +132,7 @@ public:
         for (i=namesStashed; i<size; i++) {
           stash->names->push_back(names.at(i));
         }
-        //printf("Stash pushed %d names, %d\n", (size-namesStashed), stash->names->size());
+        //printf("Stash pushed %d names, %d" HX_LF, (size-namesStashed), stash->names->size());
         namesStashed = names.size();
       }
 
@@ -173,7 +173,7 @@ public:
       front = &stashed.front();
       gStashMutex.Unlock();
 
-      //printf(" -- dumped stash, allocs=%d, alloc[max]=%d\n", front->allocations->size(), front->allocations->size()>0 ? front->allocations->at(front->allocations->size()-1) : 0);
+      //printf(" -- dumped stash, allocs=%d, alloc[max]=%d" HX_LF, front->allocations->size(), front->allocations->size()>0 ? front->allocations->at(front->allocations->size()-1) : 0);
 
       return front;
     }
@@ -213,9 +213,9 @@ public:
                  vtt==vtFunction ||
                  vtt==vtEnum ||
                  vtt==vtAbstractBase) {
-          //printf("About to resolve...\n");
+          //printf("About to resolve..." HX_LF);
           type = _last_obj->__GetClass()->mName; //__CStr();
-          //printf("Updating last allocation %016lx type to %s\n", _last_obj, type);
+          //printf("Updating last allocation %016lx type to %s" HX_LF, _last_obj, type);
         }
       }
       alloc_mutex.Unlock();
@@ -240,13 +240,13 @@ public:
         if (telemetry) {
           telemetry->reclaim(obj_id);
           alloc_map.erase(exist);
-          //printf("Tracking collection %016lx, id=%016lx\n", obj, obj_id);
+          //printf("Tracking collection %016lx, id=%016lx" HX_LF, obj, obj_id);
         } else {
-          printf("HXT ERR: we shouldn't get: Telemetry lookup failed!\n");
+          printf("HXT ERR: we shouldn't get: Telemetry lookup failed!" HX_LF);
         }
       } else {
         // Ignore, assume object was already reclaimed
-        //printf("HXT ERR: we shouldn't get: Reclaim a non-tracked object %016lx, id=%016lx -- was there an object ID collision?\n", obj, obj_id);
+        //printf("HXT ERR: we shouldn't get: Reclaim a non-tracked object %016lx, id=%016lx -- was there an object ID collision?" HX_LF, obj, obj_id);
       }
     }
 
@@ -420,7 +420,7 @@ int hx::Telemetry::ComputeCallStackId() {
     int i=0;
     while (i<size) {
         int name_id = callstack.at(i++);
-        //printf("Finding child with id=%d, asime now %#010x\n", name_id, asime);
+        //printf("Finding child with id=%d, asime now %#010x" HX_LF, name_id, asime);
         std::map<int, AllocStackIdMapEntry*>::iterator lb = asime->children.lower_bound(name_id);
          
         if (lb != asime->children.end() && !(asime->children.key_comp()(name_id, lb->first)))
@@ -441,11 +441,11 @@ int hx::Telemetry::ComputeCallStackId() {
         allocStacks.push_back(size);
         int i = size-1;
         while (i>=0) allocStacks.push_back(callstack.at(i--));
-        //printf("new callstackid %d\n", allocStackIdNext);
+        //printf("new callstackid %d" HX_LF, allocStackIdNext);
         allocStackIdNext++;
     } else {
         stackId = asime->terminationStackId;
-        //printf("existing callstackid %d\n", stackId);
+        //printf("existing callstackid %d" HX_LF, stackId);
     }
 
     return stackId;
@@ -496,7 +496,7 @@ void hx::Telemetry::HXTAllocation(void* obj, size_t inSize, const char* type)
 #ifdef HXCPP_TELEMETRY_DEBUG
     std::map<void*, hx::Telemetry*>::iterator exist = alloc_map.find(obj);
     if (exist != alloc_map.end()) {
-      printf("HXT ERR: Object id collision! at on %016lx, id=%016lx\n", obj, obj_id);
+      printf("HXT ERR: Object id collision! at on %016lx, id=%016lx" HX_LF, obj, obj_id);
       throw "uh oh";
       alloc_mutex.Unlock();
       return;
@@ -522,7 +522,7 @@ void hx::Telemetry::HXTAllocation(void* obj, size_t inSize, const char* type)
 
     //__hxcpp_set_hxt_finalizer(obj, (void*)Telemetry::HXTReclaim);
 
-    //printf("Tracking alloc %s at %016lx, id=%016lx, s=%d for telemetry %016lx, ts=%f\n", type, obj, obj_id, inSize, this, __hxcpp_time_stamp());
+    //printf("Tracking alloc %s at %016lx, id=%016lx, s=%d for telemetry %016lx, ts=%f" HX_LF, type, obj, obj_id, inSize, this, __hxcpp_time_stamp());
 
     alloc_mutex.Unlock();
 }
@@ -544,13 +544,13 @@ void hx::Telemetry::HXTRealloc(void* old_obj, void* new_obj, int new_size)
       t->allocation_data->push_back(new_obj_id);
       t->allocation_data->push_back(new_size);
 
-      //printf("Object at %016lx moving to %016lx, new_size = %d bytes\n", old_obj, new_obj, new_size);
+      //printf("Object at %016lx moving to %016lx, new_size = %d bytes" HX_LF, old_obj, new_obj, new_size);
 
       // HXT debug: Check for id collision
 #ifdef HXCPP_TELEMETRY_DEBUG
       std::map<void*, hx::Telemetry*>::iterator exist_new = alloc_map.find(new_obj);
       if (exist_new != alloc_map.end()) {
-        printf("HXT ERR: Object id collision (reloc)! at on %016lx, id=%016lx\n", (unsigned long)new_obj, (unsigned long)new_obj_id);
+        printf("HXT ERR: Object id collision (reloc)! at on %016lx, id=%016lx" HX_LF, (unsigned long)new_obj, (unsigned long)new_obj_id);
         throw "uh oh";
       }
 #endif
@@ -558,7 +558,7 @@ void hx::Telemetry::HXTRealloc(void* old_obj, void* new_obj, int new_size)
       //__hxcpp_set_hxt_finalizer(old_obj, (void*)0); // remove old finalizer -- should GCInternal.InternalRealloc do this?
       HXTReclaimInternal(old_obj); // count old as reclaimed
     } else {
-      //printf("Not tracking re-alloc of untracked %016lx, id=%016lx\n", old_obj, old_obj_id);
+      //printf("Not tracking re-alloc of untracked %016lx, id=%016lx" HX_LF, old_obj, old_obj_id);
       alloc_mutex.Unlock();
       return;
     }
@@ -566,7 +566,7 @@ void hx::Telemetry::HXTRealloc(void* old_obj, void* new_obj, int new_size)
     alloc_map[new_obj] = this;
     //__hxcpp_set_hxt_finalizer(new_obj, (void*)HXTReclaim);
 
-    //printf("Tracking re-alloc from %016lx, id=%016lx to %016lx, id=%016lx at %f\n", old_obj, old_obj_id, new_obj, new_obj_id, __hxcpp_time_stamp());
+    //printf("Tracking re-alloc from %016lx, id=%016lx to %016lx, id=%016lx at %f" HX_LF, old_obj, old_obj_id, new_obj, new_obj_id, __hxcpp_time_stamp());
 
     alloc_mutex.Unlock();
 }

--- a/src/hx/cppia/ArrayBuiltin.cpp
+++ b/src/hx/cppia/ArrayBuiltin.cpp
@@ -328,7 +328,7 @@ struct ArraySetter : public ArrayBuiltinBase
          }
          else
          {
-            printf("Unknown element size\n");
+            printf("Unknown element size" HX_LF);
          }
 
 
@@ -969,7 +969,7 @@ struct ArrayBuiltin : public ArrayBuiltinBase
                break;
       
             default: ;
-               printf("make setter %d\n", op);
+               printf("make setter %d" HX_LF, op);
                throw "setter not implemented";
          }
 
@@ -1262,7 +1262,7 @@ struct ArrayBuiltin : public ArrayBuiltinBase
                }
                else
                {
-                  printf("Unknown element size\n");
+                  printf("Unknown element size" HX_LF);
                }
 
                if (destType!=etNull)
@@ -1357,7 +1357,7 @@ struct ArrayBuiltin : public ArrayBuiltinBase
                }
                else
                {
-                  printf("Unknown element size\n");
+                  printf("Unknown element size" HX_LF);
                }
 
 
@@ -1469,7 +1469,7 @@ struct ArrayBuiltin : public ArrayBuiltinBase
                }
                else
                {
-                  printf("Unknown element size\n");
+                  printf("Unknown element size" HX_LF);
                }
                compiler->comeFrom(writtenNull);
 
@@ -1600,7 +1600,7 @@ struct ArrayBuiltin : public ArrayBuiltinBase
                }
                else
                {
-                  printf("Unknown element size\n");
+                  printf("Unknown element size" HX_LF);
                }
                compiler->comeFrom(writtenNull);
 

--- a/src/hx/cppia/ArrayVirtual.cpp
+++ b/src/hx/cppia/ArrayVirtual.cpp
@@ -513,7 +513,7 @@ struct ArrayBuiltinAny : public ArrayBuiltinBase
                break;
       
             default: ;
-               printf("make setter %d\n", op);
+               printf("make setter %d" HX_LF, op);
                throw "setter not implemented";
          }
 

--- a/src/hx/cppia/Cppia.cpp
+++ b/src/hx/cppia/Cppia.cpp
@@ -68,9 +68,9 @@ StackLayout::StackLayout(StackLayout *inParent) :
 
 void StackLayout::dump(Array<String> &inStrings, std::string inIndent)
 {
-   printf("%sCapture:\n",inIndent.c_str());
+   printf("%sCapture:" HX_LF,inIndent.c_str());
    for(int i=0;i<captureVars.size();i++)
-      printf("%s %s\n", inIndent.c_str(), inStrings[captureVars[i]->nameId].out_str() );
+      printf("%s %s" HX_LF, inIndent.c_str(), inStrings[captureVars[i]->nameId].out_str() );
    if (parent)
       parent->dump(inStrings,inIndent + "   ");
 }
@@ -815,10 +815,10 @@ struct CallFunExpr : public CppiaExpr
    static void SLJIT_CALL callScriptable(CppiaCtx *inCtx, ScriptCallable *inScriptable)
    {
       // compiled?
-      printf("callScriptable %p(%p) -> %p\n", inCtx, CppiaCtx::getCurrent(), inScriptable );
-      printf(" name = %s\n", inScriptable->getName());
+      printf("callScriptable %p(%p) -> %p" HX_LF, inCtx, CppiaCtx::getCurrent(), inScriptable );
+      printf(" name = %s" HX_LF, inScriptable->getName());
       inScriptable->runFunction(inCtx);
-      printf(" Done scipt callable\n");
+      printf(" Done scipt callable" HX_LF);
    }
 
 
@@ -1101,7 +1101,7 @@ struct SetExpr : public CppiaExpr
       CppiaExpr *result = lvalue->makeSetter(op,value);
       if (!result)
       {
-         printf("Could not makeSetter.\n");
+         printf("Could not makeSetter." HX_LF);
          inModule.where(lvalue);
          throw "Bad Set expr";
       }
@@ -1260,7 +1260,7 @@ struct CastExpr : public CppiaDynamicExpr
          arrayType = t->arrayType;
          if (arrayType==arrNotArray)
          {
-            printf("Cast to %d, %s\n", typeId, t->name.out_str());
+            printf("Cast to %d, %s" HX_LF, typeId, t->name.out_str());
             throw "Data cast to non-array";
          }
       }
@@ -1432,7 +1432,7 @@ struct ToInterface : public CppiaDynamicExpr
    #if (HXCPP_API_LEVEL >= 330)
    CppiaExpr *link(CppiaModule &inModule)
    {
-      DBGLOG("Api 330 - no cast required\n");
+      DBGLOG("Api 330 - no cast required" HX_LF);
       CppiaExpr *linked = value->link(inModule);
       delete this;
       return linked;
@@ -1454,12 +1454,12 @@ struct ToInterface : public CppiaDynamicExpr
          }
          else if (!fromType->cppiaClass)
          {
-            DBGLOG("native -> native\n");
+            DBGLOG("native -> native" HX_LF);
             useNative = true;
          }
          else
          {
-            DBGLOG("cppia class, native interface\n");
+            DBGLOG("cppia class, native interface" HX_LF);
             cppiaVTable = fromType->cppiaClass->getInterfaceVTable(toType->interfaceBase->name);
          }
          value = value->link(inModule);
@@ -1467,7 +1467,7 @@ struct ToInterface : public CppiaDynamicExpr
       }
 
 
-      DBGLOG("cppia class, cppia interface - no cast required\n");
+      DBGLOG("cppia class, cppia interface - no cast required" HX_LF);
 
       CppiaExpr *linked = value->link(inModule);
       delete this;
@@ -1628,7 +1628,7 @@ struct NewExpr : public CppiaDynamicExpr
          return type->cppiaClass->createInstance(ctx,args);
       }
 
-      printf("Can't create non haxe type\n");
+      printf("Can't create non haxe type" HX_LF);
       return 0;
    }
 
@@ -1649,7 +1649,7 @@ struct NewExpr : public CppiaDynamicExpr
             case arrAny:func = (void *)createArrayAny; break;
             case arrObject:func = (void *)createArrayObject; break;
             default:
-               printf("Unknown array creation\n");
+               printf("Unknown array creation" HX_LF);
                return;
          }
 
@@ -1995,7 +1995,7 @@ struct CallStatic : public CppiaExpr
          ScriptCallable *func = (ScriptCallable *)type->cppiaClass->findFunction(true,fieldId);
          if (!func)
          {
-            printf("Could not find static function %s in %s\n", field.out_str(), type->name.out_str());
+            printf("Could not find static function %s in %s" HX_LF, field.out_str(), type->name.out_str());
          }
          else
          {
@@ -2008,13 +2008,13 @@ struct CallStatic : public CppiaExpr
          ScriptNamedFunction func = type->haxeBase->findStaticFunction(field);
          if (func.signature)
          {
-            //printf(" found function %s\n", func.signature );
+            //printf(" found function %s" HX_LF, func.signature );
             replace = new CallHaxe( this, func, 0, args, true );
          }
          else
          {
             //const StaticInfo *info = type->haxeClass->GetStaticStorage(field);
-            //printf("INFO %s -> %p\n", field.out_str(),  info);
+            //printf("INFO %s -> %p" HX_LF, field.out_str(),  info);
             // TODO - create proper glue for static functions
             Dynamic func = type->haxeClass.mPtr->__Field( field, HX_PROP_NEVER );
             if (func.mPtr)
@@ -2029,7 +2029,7 @@ struct CallStatic : public CppiaExpr
          replace = new CallDynamicFunction(inModule, this, String::fromCharCode_dyn(), args );
          
 
-      //printf(" static call to %s::%s (%d)\n", type->name.out_str(), field.out_str(), type->cppiaClass!=0);
+      //printf(" static call to %s::%s (%d)" HX_LF, type->name.out_str(), field.out_str(), type->cppiaClass!=0);
       if (replace)
       {
          delete this;
@@ -2037,7 +2037,7 @@ struct CallStatic : public CppiaExpr
          return replace;
       }
 
-      printf("Unknown static call to %s::%s (%d)\n", type->name.out_str(), field.out_str(), type->cppiaClass!=0);
+      printf("Unknown static call to %s::%s (%d)" HX_LF, type->name.out_str(), field.out_str(), type->cppiaClass!=0);
       inModule.where(this);
       throw "Bad link";
       return this;
@@ -2764,7 +2764,7 @@ struct FieldByName : public CppiaDynamicExpr
    {
       if (crement==coNone && assign==aoNone)
       {
-         printf("FieldAccess without set\n");
+         printf("FieldAccess without set" HX_LF);
          return;
       }
 
@@ -2809,7 +2809,7 @@ struct FieldByName : public CppiaDynamicExpr
                case coPostDec: func = (void *)postDecByName; break;
                case coPreDec: func = (void *)preDecByName; break;
                default:
-                  printf("Error in crement?\n");
+                  printf("Error in crement?" HX_LF);
                   CppiaTrap();
             }
             compiler->callNative(func, objSrc, (void *)&name, gotVal );
@@ -2859,7 +2859,7 @@ struct FieldByName : public CppiaDynamicExpr
                }
                break;
             default:
-               printf("Unknown set type %d\n", destType);
+               printf("Unknown set type %d" HX_LF, destType);
                CppiaTrap();
          }
       }
@@ -2895,7 +2895,7 @@ struct FieldByName : public CppiaDynamicExpr
                   }
                   break;
                default:
-                  printf("Unknown add type %d\n", destType);
+                  printf("Unknown add type %d" HX_LF, destType);
                   CppiaTrap();
              }
          }
@@ -3017,7 +3017,7 @@ struct GetFieldByName : public CppiaDynamicExpr
             inModule.where(this);
             if (type->cppiaClass)
                type->cppiaClass->dump();
-            printf("Could not link static %s::%s (%d)\n", type->name.c_str(), inModule.strings[nameId].out_str(), nameId );
+            printf("Could not link static %s::%s (%d)" HX_LF, type->name.c_str(), inModule.strings[nameId].out_str(), nameId );
             throw "Bad link";
          }
          name = inModule.strings[nameId];
@@ -3054,7 +3054,7 @@ struct GetFieldByName : public CppiaDynamicExpr
          ScriptCallable *func = vtable[vtableSlot];
          if (func==0)
          {
-            printf("Could not find vtable entry %s intf=%d (%d)\n", name.out_str(), isInterface, vtableSlot);
+            printf("Could not find vtable entry %s intf=%d (%d)" HX_LF, name.out_str(), isInterface, vtableSlot);
             return 0;
          }
 
@@ -3278,7 +3278,7 @@ struct CallMember : public CppiaExpr
    {
       classId = stream.getInt();
       fieldId = inCall==callSuperNew ? 0 : stream.getInt();
-      //printf("fieldId = %d (%s)\n",fieldId,stream.module->strings[ fieldId ].out_str());
+      //printf("fieldId = %d (%s)" HX_LF,fieldId,stream.module->strings[ fieldId ].out_str());
       int n = stream.getInt();
       thisExpr = inCall==callObject ? createCppiaExpr(stream) : 0;
       callSuperField = inCall==callSuper;
@@ -3293,22 +3293,22 @@ struct CallMember : public CppiaExpr
 
       if (type->cppiaClass)
       {
-         //printf("Using cppia super %p %p\n", type->cppiaClass->newFunc, type->cppiaClass->newFunc->funExpr);
+         //printf("Using cppia super %p %p" HX_LF, type->cppiaClass->newFunc, type->cppiaClass->newFunc->funExpr);
          CppiaExpr *replace = new CallFunExpr( this, 0, (ScriptCallable*)type->cppiaClass->newFunc->funExpr, args, true );
          replace->link(inModule);
          delete this;
          return replace;
       }
-      //printf("Using haxe super\n");
+      //printf("Using haxe super" HX_LF);
       HaxeNativeClass *superReg = HaxeNativeClass::findClass(type->name.utf8_str());
       if (!superReg)
       {
-         printf("No class registered for %s\n", type->name.out_str());
+         printf("No class registered for %s" HX_LF, type->name.out_str());
          throw "Unknown super call";
       }
       if (!superReg->construct.execute)
       {
-         //printf("Call super - nothing to do...\n");
+         //printf("Call super - nothing to do..." HX_LF);
          CppiaExpr *replace = new CppiaExpr(this);
          delete this;
          return replace;
@@ -3330,7 +3330,7 @@ struct CallMember : public CppiaExpr
       TypeData *type = inModule.types[classId];
       String field = inModule.strings[fieldId];
 
-      //printf("  linking call %s::%s\n", type->name.out_str(), field.out_str());
+      //printf("  linking call %s::%s" HX_LF, type->name.out_str(), field.out_str());
 
       CppiaExpr *replace = 0;
       
@@ -3341,7 +3341,7 @@ struct CallMember : public CppiaExpr
          {
             if (field!=HX_CSTRING("__SetField") && field!=HX_CSTRING("__Field") && field!=HX_CSTRING("__Index"))
             {
-               printf("Bad array field '%s'\n", field.out_str());
+               printf("Bad array field '%s'" HX_LF, field.out_str());
                inModule.where(this);
                throw "Unknown array field";
             }
@@ -3362,7 +3362,7 @@ struct CallMember : public CppiaExpr
          {
             int vtableSlot = type->cppiaClass->findFunctionSlot(fieldId);
 
-            //printf("   vslot %d\n", vtableSlot);
+            //printf("   vslot %d" HX_LF, vtableSlot);
             if (vtableSlot!=-1)
             {
                CppiaFunction *funcProto = type->cppiaClass->findVTableFunction(fieldId);
@@ -3380,7 +3380,7 @@ struct CallMember : public CppiaExpr
             {
                if (!strcmp(nativeInterfaceFuncs[i]->name,field.utf8_str()))
                {
-                  //printf(" found native interface function %s\n", field.out_str() );
+                  //printf(" found native interface function %s" HX_LF, field.out_str() );
                   replace = new CallHaxe( this, *nativeInterfaceFuncs[i], thisExpr, args );
                   break;
                }
@@ -3395,9 +3395,9 @@ struct CallMember : public CppiaExpr
          if (func.signature)
          {
             if (callSuperField && !func.superExecute)
-               printf("Warning - calling super host '%s' from cppia can lead to infinte recursion\n", field.utf8_str());
+               printf("Warning - calling super host '%s' from cppia can lead to infinte recursion" HX_LF, field.utf8_str());
 
-            //printf(" found function %s\n", func.signature );
+            //printf(" found function %s" HX_LF, func.signature );
             replace = new CallHaxe( this, func, thisExpr, args, false, callSuperField && func.superExecute);
          }
       }
@@ -3407,7 +3407,7 @@ struct CallMember : public CppiaExpr
          ScriptNamedFunction func = type->interfaceBase->findFunction(field.utf8_str());
          if (func.signature)
          {
-            //printf(" found function %s\n", func.signature );
+            //printf(" found function %s" HX_LF, func.signature );
             replace = new CallHaxe( this, func, thisExpr, args );
          }
       }
@@ -3452,7 +3452,7 @@ struct CallMember : public CppiaExpr
             ScriptFunction func = type->haxeBase->findFunction(baseFunc);
             if (func.signature)
             {
-               //printf(" replacing %s.%s, signature %s\n", type->name.out_str(), field.out_str(), func.signature);
+               //printf(" replacing %s.%s, signature %s" HX_LF, type->name.out_str(), field.out_str(), func.signature);
                replace = new CallHaxe( this, func, thisExpr, args );
             }
          }
@@ -3467,7 +3467,7 @@ struct CallMember : public CppiaExpr
 
       if (!type->isDynamic)
       {
-         printf("   CallMember %s (%p %p) '%s' fallback\n", type->name.out_str(), type->haxeClass.mPtr, type->cppiaClass, field.out_str());
+         printf("   CallMember %s (%p %p) '%s' fallback" HX_LF, type->name.out_str(), type->haxeClass.mPtr, type->cppiaClass, field.out_str());
       }
 
       {
@@ -3478,8 +3478,8 @@ struct CallMember : public CppiaExpr
       }
 
       /*
-      printf("Could not link %s::%s\n", type->name.c_str(), field.out_str() );
-      printf("%p %p\n", type->cppiaClass, type->haxeBase);
+      printf("Could not link %s::%s" HX_LF, type->name.c_str(), field.out_str() );
+      printf("%p %p" HX_LF, type->cppiaClass, type->haxeBase);
       if (type->cppiaClass)
          type->cppiaClass->dump();
       if (type->haxeBase)
@@ -3852,7 +3852,7 @@ void genSetter(CppiaCompiler *compiler, const JitVal &ioValue, ExprType exprType
 
       default:
          inExpr->genCode(compiler, sJitTemp2, etInt);
-         printf("Gen setter %d\n", inOp);
+         printf("Gen setter %d" HX_LF, inOp);
    }
 }
 #endif
@@ -4101,7 +4101,7 @@ struct MemReferenceSetter : public CppiaExpr
             }
             break;
 
-         default: printf("unknown REFMODE\n");
+         default: printf("unknown REFMODE" HX_LF);
       }
    }
 
@@ -4661,7 +4661,7 @@ struct GetFieldByLinkage : public CppiaExpr
          {
             offset = store->offset;
             storeType = store->type;
-            DBGLOG(" found haxe var %s::%s = %d (%d)\n", type->haxeClass->mName.out_str(), field.out_str(), offset, storeType);
+            DBGLOG(" found haxe var %s::%s = %d (%d)" HX_LF, type->haxeClass->mName.out_str(), field.out_str(), offset, storeType);
          }
       }
 
@@ -4672,7 +4672,7 @@ struct GetFieldByLinkage : public CppiaExpr
          {
             offset = var->offset;
             storeType = var->storeType;
-            DBGLOG(" found script var %s = %d (%d)\n", field.out_str(), offset, storeType);
+            DBGLOG(" found script var %s = %d (%d)" HX_LF, field.out_str(), offset, storeType);
          }
       }
 
@@ -4753,11 +4753,11 @@ struct GetFieldByLinkage : public CppiaExpr
       //  out to actaully be Dynamic (eg template types)
       if (!type->isInterface && !type->isDynamic && !forceNamedAccess)
       {
-         printf("   GetFieldByLinkage %s (%p %p %p) '%s' fallback\n", type->name.out_str(), object, type->haxeClass.mPtr, type->cppiaClass, field.out_str());
+         printf("   GetFieldByLinkage %s (%p %p %p) '%s' fallback" HX_LF, type->name.out_str(), object, type->haxeClass.mPtr, type->cppiaClass, field.out_str());
          if (type->cppiaClass)
             type->cppiaClass->dump();
          else
-           printf(" - is Native class\n");
+           printf(" - is Native class" HX_LF);
       }
 
       CppiaExpr *result = new GetFieldByName(this, fieldId, object, false);
@@ -4785,7 +4785,7 @@ struct StringVal : public CppiaExprWithValue
    CppiaExpr *link(CppiaModule &inModule)
    {
       strVal = inModule.strings[stringId];
-      //printf("Linked %d -> %s\n", stringId, strVal.out_str());
+      //printf("Linked %d -> %s" HX_LF, stringId, strVal.out_str());
       return CppiaExprWithValue::link(inModule);
    }
    ::String    runString(CppiaCtx *ctx)
@@ -5047,7 +5047,7 @@ struct ArrayDef : public CppiaDynamicExpr
       arrayType = type->arrayType;
       if (!arrayType)
       {
-         printf("ArrayDef of non array-type %s\n", type->name.out_str());
+         printf("ArrayDef of non array-type %s" HX_LF, type->name.out_str());
          throw "Bad ArrayDef";
       }
       LinkExpressions(items,inModule);
@@ -5183,7 +5183,7 @@ struct ArrayDef : public CppiaDynamicExpr
             break;
 
          default:
-            printf("unknown array creation\n");
+            printf("unknown array creation" HX_LF);
       }
       JitTemp array(compiler, jtPointer);
       compiler->move( array, sJitReturnReg );
@@ -5273,7 +5273,7 @@ struct ArrayDef : public CppiaDynamicExpr
                break;
 
             default:
-               printf("todo other array -init\n");
+               printf("todo other array -init" HX_LF);
          }
       }
 
@@ -5621,13 +5621,13 @@ struct ArrayAccessI : public CppiaDynamicExpr
       __get = type->haxeBase->findFunction("__get");
       if (!__get.execute)
       {
-         printf("Class %s missing __get\n", type->name.out_str());
+         printf("Class %s missing __get" HX_LF, type->name.out_str());
          throw "Bad array access - __get";
       }
       __set = type->haxeBase->findFunction("__set");
       if (!__set.execute)
       {
-         printf("Class %s missing __set\n", type->name.out_str());
+         printf("Class %s missing __set" HX_LF, type->name.out_str());
          throw "Bad array access - __set";
       }
 
@@ -5651,7 +5651,7 @@ struct ArrayAccessI : public CppiaDynamicExpr
       if (value)
          value = value->link(inModule);
 
-      DBGLOG("Created ARRAYI wrapper %s %d %s / %s\n", type->name.out_str(), accessType, __get.signature, __set.signature);
+      DBGLOG("Created ARRAYI wrapper %s %d %s / %s" HX_LF, type->name.out_str(), accessType, __get.signature, __set.signature);
 
       return this;
    }
@@ -6365,7 +6365,7 @@ struct SwitchExpr : public CppiaExpr
             }
             else
             {
-               printf("Missing switch type\n");
+               printf("Missing switch type" HX_LF);
                CppiaTrap();
             }
          }
@@ -6542,7 +6542,7 @@ struct VarRef : public CppiaExpr
       {
          // link to cppia static...
 
-         printf("Could not link var %d %s.\n", varId, inModule.strings[ getStackVarNameId(varId) ].out_str() );
+         printf("Could not link var %d %s." HX_LF, varId, inModule.strings[ getStackVarNameId(varId) ].out_str() );
          inModule.layout->dump(inModule.strings,"");
          inModule.where(this);
          throw "Unknown variable";
@@ -6584,7 +6584,7 @@ struct VarRef : public CppiaExpr
          return replace;
       }
 
-      printf("Unknown var ref!\n");
+      printf("Unknown var ref!" HX_LF);
       return this;
    }
 };
@@ -7709,7 +7709,7 @@ struct CrementExpr : public CppiaExpr
       CppiaExpr *replace = lvalue->makeCrement( op );
       if (!replace)
       {
-         printf("Could not create increment operator\n");
+         printf("Could not create increment operator" HX_LF);
          inModule.where(lvalue);
          throw "Bad increment";
       }
@@ -7910,7 +7910,7 @@ CppiaExpr *createCppiaExpr(CppiaStream &stream)
    int fileId = stream.getFileId();
    int line = stream.getLineId();
    std::string tok = stream.getToken();
-   //DBGLOG(" expr %s\n", tok.c_str() );
+   //DBGLOG(" expr %s" HX_LF, tok.c_str() );
 
    CppiaExpr *result = 0;
    if (tok=="FUN")
@@ -8170,10 +8170,10 @@ void TypeData::link(CppiaModule &inModule)
       int scriptId = getScriptId(haxeClass);
       if (scriptId>0 && scriptId!=inModule.scriptId)
       {
-         DBGLOG("Reference to old script %s - ignoring\n", haxeClass.mPtr->mName.out_str());
+         DBGLOG("Reference to old script %s - ignoring" HX_LF, haxeClass.mPtr->mName.out_str());
          haxeClass.mPtr = 0;
       }
-      DBGLOG("Link %s, haxe=%s\n", name.out_str(), haxeClass.mPtr ? haxeClass.mPtr->mName.out_str() : "?" );
+      DBGLOG("Link %s, haxe=%s" HX_LF, name.out_str(), haxeClass.mPtr ? haxeClass.mPtr->mName.out_str() : "?" );
       if (!haxeClass.mPtr && !cppiaClass && name==HX_CSTRING("int"))
       {
          name = HX_CSTRING("Int");
@@ -8225,13 +8225,13 @@ void TypeData::link(CppiaModule &inModule)
             }
          }
 
-         DBGLOG("array type %d\n",arrayType);
+         DBGLOG("array type %d" HX_LF,arrayType);
       }
       else if (!haxeClass.mPtr && cppiaSuperType)
       {
          haxeBase = cppiaSuperType->haxeBase;
          haxeClass.mPtr = cppiaSuperType->haxeClass.mPtr;
-         DBGLOG("extends %s\n", cppiaSuperType->name.out_str());
+         DBGLOG("extends %s" HX_LF, cppiaSuperType->name.out_str());
       }
       else if (!haxeClass.mPtr)
       {
@@ -8240,12 +8240,12 @@ void TypeData::link(CppiaModule &inModule)
          /*
          if (!isInterface && (*sScriptRegistered)[name.utf8_str()])
          {
-            printf("Base class %s\n", name.out_str());
+            printf("Base class %s" HX_LF, name.out_str());
             (*sScriptRegistered)[name.utf8_str()]->dump();
             throw "New class, but with existing def";
          }
          */
-         DBGLOG(isInterface ? "interface base\n" : "base\n");
+         DBGLOG(isInterface ? "interface base" HX_LF : "base" HX_LF);
       }
       else
       {
@@ -8254,18 +8254,18 @@ void TypeData::link(CppiaModule &inModule)
          {
             if (isInterface)
             {
-               DBGLOG("interface base\n");
+               DBGLOG("interface base" HX_LF);
                haxeBase = 0;
             }
             else
             {
-               DBGLOG("assumed base (todo - register)\n");
+               DBGLOG("assumed base (todo - register)" HX_LF);
                haxeBase = HaxeNativeClass::hxObject();
             }
          }
          else
          {
-            DBGLOG("\n");
+            DBGLOG(HX_LF);
          }
       }
 

--- a/src/hx/cppia/CppiaClasses.cpp
+++ b/src/hx/cppia/CppiaClasses.cpp
@@ -100,7 +100,7 @@ struct CppiaEnumConstructor
    {
       bool ok = args.size() && args.size()==inArgs.size();
       if (!ok)
-         printf("Bad enum arg count\n");
+         printf("Bad enum arg count" HX_LF);
 
       #if (HXCPP_API_LEVEL >= 330)
       compiler->callNative( (void *)createEnumBase, (void *)this );
@@ -231,7 +231,7 @@ struct EnumField : public CppiaDynamicExpr
          enumClass = hx::Class_obj::Resolve(type->name);
          if (!enumClass.mPtr)
          {
-            printf("Could not find enum %s\n", type->name.out_str() );
+            printf("Could not find enum %s" HX_LF, type->name.out_str() );
             throw "Bad enum";
          }
          enumName = inModule.strings[fieldId];
@@ -552,7 +552,7 @@ bool CppiaClassInfo::getField(hx::Object *inThis, String inName, hx::PropertyAcc
          return true;
    }
 
-   //printf("Get field not found (%s) %s\n", inThis->toString().out_str(),inName.out_str());
+   //printf("Get field not found (%s) %s" HX_LF, inThis->toString().out_str(),inName.out_str());
    return false;
 }
 
@@ -563,7 +563,7 @@ bool CppiaClassInfo::setField(hx::Object *inThis, String inName, Dynamic inValue
 
    if (inCallProp)
    {
-      //printf("Set field %s %s = %s\n", inThis->toString().out_str(), inName.out_str(), inValue->toString().out_str());
+      //printf("Set field %s %s = %s" HX_LF, inThis->toString().out_str(), inName.out_str(), inValue->toString().out_str());
       ScriptCallable *setter = findMemberSetter(inName);
       if (setter)
       {
@@ -610,7 +610,7 @@ bool CppiaClassInfo::setField(hx::Object *inThis, String inName, Dynamic inValue
    }
 
    // Fall though to haxe base
-   //printf("Set field not found (%s) %s map=%p o=%d\n", inThis->toString().out_str(),inName.out_str(), map, dynamicMapOffset);
+   //printf("Set field not found (%s) %s map=%p o=%d" HX_LF, inThis->toString().out_str(),inName.out_str(), map, dynamicMapOffset);
 
    return false;
 }
@@ -657,22 +657,22 @@ CppiaVar *CppiaClassInfo::findVar(bool inStatic,int inId)
 
 void CppiaClassInfo::dumpVars(const char *inMessage, std::vector<CppiaVar *> &vars)
 {
-   printf(" %s:\n", inMessage);
+   printf(" %s:" HX_LF, inMessage);
    for(int i=0;i<vars.size();i++)
-      printf("   %d] %s (%d)\n", i, cppia.strings[ vars[i]->nameId ].out_str(), vars[i]->nameId );
+      printf("   %d] %s (%d)" HX_LF, i, cppia.strings[ vars[i]->nameId ].out_str(), vars[i]->nameId );
 }
 
 void CppiaClassInfo::dumpFunctions(const char *inMessage, std::vector<CppiaFunction *> &funcs)
 {
-   printf(" %s:\n", inMessage);
+   printf(" %s:" HX_LF, inMessage);
    for(int i=0;i<funcs.size();i++)
-      printf("   %d] %s (%d)\n", i, cppia.strings[ funcs[i]->nameId ].out_str(), funcs[i]->nameId);
+      printf("   %d] %s (%d)" HX_LF, i, cppia.strings[ funcs[i]->nameId ].out_str(), funcs[i]->nameId);
 }
 
 
 void CppiaClassInfo::dump()
 {
-   printf("Class %s\n", name.c_str());
+   printf("Class %s" HX_LF, name.c_str());
    dumpFunctions("Member functions",memberFunctions);
    dumpFunctions("Static functions",staticFunctions);
    dumpVars("Member vars",memberVars);
@@ -733,7 +733,7 @@ bool CppiaClassInfo::load(CppiaStream &inStream)
       isEnum = true;
    else
    {
-      DBGLOG("Invalid class field op %d\n", op);
+      DBGLOG("Invalid class field op %d" HX_LF, op);
       throw "Bad class type";
    }
 
@@ -749,7 +749,7 @@ bool CppiaClassInfo::load(CppiaStream &inStream)
        implements[i] = inStream.getInt();
 
     name = cppia.typeStr(typeId);
-    DBGLOG("Class %s %s\n", name.c_str(), isEnum ? "enum" : isInterface ? "interface" : "class" );
+    DBGLOG("Class %s %s" HX_LF, name.c_str(), isEnum ? "enum" : isInterface ? "interface" : "class" );
 
     bool isNew = //(resolved == null() || !IsCppiaClass(resolved) ) &&
                 (!HaxeNativeClass::findClass(name) && !HaxeNativeInterface::findInterface(name) );
@@ -759,7 +759,7 @@ bool CppiaClassInfo::load(CppiaStream &inStream)
        hx::Class cls =  hx::Class_obj::Resolve(String(name.c_str()));
        if (cls.mPtr && getScriptId(cls)==0)
        {
-          DBGLOG("Found existing enum %s - ignore\n", name.c_str());
+          DBGLOG("Found existing enum %s - ignore" HX_LF, name.c_str());
           isNew = false;
        }
     }
@@ -770,7 +770,7 @@ bool CppiaClassInfo::load(CppiaStream &inStream)
     }
     else
     {
-       DBGLOG("Already has registered %s - ignore\n",name.c_str());
+       DBGLOG("Already has registered %s - ignore" HX_LF,name.c_str());
     }
 
     inStream.module->creatingClass = name.c_str();
@@ -886,7 +886,7 @@ void **CppiaClassInfo::createInterfaceVTable(int inTypeId)
 
 hx::Class *CppiaClassInfo::getSuperClass()
 {
-   DBGLOG("getSuperClass %s %d\n", name.c_str(), superId);
+   DBGLOG("getSuperClass %s %d" HX_LF, name.c_str(), superId);
    if (!superId)
       return 0;
 
@@ -897,7 +897,7 @@ hx::Class *CppiaClassInfo::getSuperClass()
       return &superType->cppiaClass->mClass;
    if (!superType->haxeClass.mPtr)
    {
-      printf("Invalid super class '%s' for '%s'.\n", superType->name.c_str(), name.c_str());
+      printf("Invalid super class '%s' for '%s'." HX_LF, superType->name.c_str(), name.c_str());
       throw "Missing super class";
    }
 
@@ -967,7 +967,7 @@ void CppiaClassInfo::linkTypes()
                nativeInterfaceFunctions.push_back(f);
                int slot = cppia.getInterfaceSlot(f->name);
                if (slot<0)
-                  printf("Interface slot '%s' not found\n",f->name);
+                  printf("Interface slot '%s' not found" HX_LF,f->name);
                if (slot>interfaceSlotSize)
                   interfaceSlotSize = slot;
             }
@@ -981,15 +981,15 @@ void CppiaClassInfo::linkTypes()
    DBGLOG(" Linking class '%s' ", type->name.out_str());
    if (!superType)
    {
-      DBGLOG("script base\n");
+      DBGLOG("script base" HX_LF);
    }
    else if (cppiaSuper)
    {
-      DBGLOG("extends script '%s'\n", superType->name.out_str());
+      DBGLOG("extends script '%s'" HX_LF, superType->name.out_str());
    }
    else
    {
-      DBGLOG("extends haxe '%s'\n", superType->name.out_str());
+      DBGLOG("extends haxe '%s'" HX_LF, superType->name.out_str());
    }
 
    // Link class before we combine the function list...
@@ -1017,7 +1017,7 @@ void CppiaClassInfo::linkTypes()
       {
          for(int j=0;j<combinedVars.size();j++)
             if (combinedVars[j]->nameId==memberVars[i]->nameId)
-               printf("Warning duplicate member var %s\n", cppia.strings[memberVars[i]->nameId].out_str());
+               printf("Warning duplicate member var %s" HX_LF, cppia.strings[memberVars[i]->nameId].out_str());
          combinedVars.push_back(memberVars[i]);
       }
       memberVars.swap(combinedVars);
@@ -1069,16 +1069,16 @@ void CppiaClassInfo::linkTypes()
    if (haxeBase)
    {
       // Calculate table offsets...
-      DBGLOG("  base haxe size %s = %d\n", haxeBase->name.c_str(), classSize);
+      DBGLOG("  base haxe size %s = %d" HX_LF, haxeBase->name.c_str(), classSize);
       for(int i=0;i<memberVars.size();i++)
       {
          if (memberVars[i]->offset)
          {
-            DBGLOG("   super var %s @ %d\n", cppia.identStr(memberVars[i]->nameId), memberVars[i]->offset);
+            DBGLOG("   super var %s @ %d" HX_LF, cppia.identStr(memberVars[i]->nameId), memberVars[i]->offset);
          }
          else
          {
-            DBGLOG("   link var %s @ %d\n", cppia.identStr(memberVars[i]->nameId), classSize);
+            DBGLOG("   link var %s @ %d" HX_LF, cppia.identStr(memberVars[i]->nameId), classSize);
             memberVars[i]->linkVarTypes(cppia,classSize);
             containsPointers = containsPointers || memberVars[i]->hasPointer();
          }
@@ -1088,11 +1088,11 @@ void CppiaClassInfo::linkTypes()
          containsPointers = true;
          if (dynamicFunctions[i]->offset)
          {
-            DBGLOG("   super dynamic function %s @ %d\n", cppia.identStr(dynamicFunctions[i]->nameId), dynamicFunctions[i]->offset);
+            DBGLOG("   super dynamic function %s @ %d" HX_LF, cppia.identStr(dynamicFunctions[i]->nameId), dynamicFunctions[i]->offset);
          }
          else
          {
-            DBGLOG("   link dynamic function %s @ %d\n", cppia.identStr(dynamicFunctions[i]->nameId), classSize);
+            DBGLOG("   link dynamic function %s @ %d" HX_LF, cppia.identStr(dynamicFunctions[i]->nameId), classSize);
             dynamicFunctions[i]->linkVarTypes(cppia,classSize);
          }
       }
@@ -1111,28 +1111,28 @@ void CppiaClassInfo::linkTypes()
    }
 
 
-   DBGLOG("  script member vars size = %d\n", extraData);
+   DBGLOG("  script member vars size = %d" HX_LF, extraData);
  
    for(int i=0;i<staticVars.size();i++)
    {
-      DBGLOG("   link static var %s\n", cppia.identStr(staticVars[i]->nameId));
+      DBGLOG("   link static var %s" HX_LF, cppia.identStr(staticVars[i]->nameId));
       staticVars[i]->linkVarTypes(cppia);
    }
 
    for(int i=0;i<staticDynamicFunctions.size();i++)
    {
-      DBGLOG("   link dynamic static var %s\n", cppia.identStr(staticDynamicFunctions[i]->nameId));
+      DBGLOG("   link dynamic static var %s" HX_LF, cppia.identStr(staticDynamicFunctions[i]->nameId));
       staticDynamicFunctions[i]->linkVarTypes(cppia);
    }
 
 
    // Combine vtable positions...
-   DBGLOG("  format haxe callable vtable (%d)....\n", (int)memberFunctions.size());
+   DBGLOG("  format haxe callable vtable (%d)...." HX_LF, (int)memberFunctions.size());
    std::vector<std::string> table;
    if (haxeBase)
       haxeBase->addVtableEntries(table);
    for(int i=0;i<table.size();i++)
-      DBGLOG("   base table[%d] = %s\n", i, table[i].c_str() );
+      DBGLOG("   base table[%d] = %s" HX_LF, i, table[i].c_str() );
 
 
    int vtableSlot = table.size();
@@ -1155,16 +1155,16 @@ void CppiaClassInfo::linkTypes()
             if (idx>interfaceSlotSize)
                interfaceSlotSize = idx;
             idx = -idx;
-            DBGLOG("Using interface vtable[%d] = %s\n", idx, memberFunctions[i]->name.c_str() );
+            DBGLOG("Using interface vtable[%d] = %s" HX_LF, idx, memberFunctions[i]->name.c_str() );
          }
          else
          {
             idx = vtableSlot++;
-            DBGLOG("   cppia slot [%d] = %s\n", idx, memberFunctions[i]->name.c_str() );
+            DBGLOG("   cppia slot [%d] = %s" HX_LF, idx, memberFunctions[i]->name.c_str() );
          }
       }
       else
-         DBGLOG("   override slot [%d] = %s\n", idx, memberFunctions[i]->name.c_str() );
+         DBGLOG("   override slot [%d] = %s" HX_LF, idx, memberFunctions[i]->name.c_str() );
       memberFunctions[i]->setVTableSlot(idx);
    }
 
@@ -1196,7 +1196,7 @@ void CppiaClassInfo::linkTypes()
                   nativeInterfaceFunctions.push_back(f);
                   int slot = cppia.getInterfaceSlot(f->name);
                   if (slot<0)
-                     printf("Interface slot '%s' not found\n",f->name);
+                     printf("Interface slot '%s' not found" HX_LF,f->name);
                   if (slot>interfaceSlotSize)
                      interfaceSlotSize = slot;
                }
@@ -1214,7 +1214,7 @@ void CppiaClassInfo::linkTypes()
          {
             int slot = cppia.getInterfaceSlot(intfFuncs[f]->name);
             if (slot<0)
-               printf("Interface slot '%s' not found\n",intfFuncs[f]->name.c_str());
+               printf("Interface slot '%s' not found" HX_LF,intfFuncs[f]->name.c_str());
             if (slot>interfaceSlotSize)
                interfaceSlotSize = slot;
          }
@@ -1230,7 +1230,7 @@ void CppiaClassInfo::linkTypes()
    vtable += interfaceSlotSize;
    *vtable++ = this;
 
-   DBGLOG("  vtable size %d -> %p\n", vtableSlot, vtable);
+   DBGLOG("  vtable size %d -> %p" HX_LF, vtableSlot, vtable);
 
    // Extract special function ...
    for(int i=0;i<staticFunctions.size(); )
@@ -1277,7 +1277,7 @@ void CppiaClassInfo::linkTypes()
       newFunc = cppiaSuper->newFunc;
    }
 
-   DBGLOG("  this constructor %p\n", newFunc);
+   DBGLOG("  this constructor %p" HX_LF, newFunc);
 }
 
 #ifdef CPPIA_JIT
@@ -1285,7 +1285,7 @@ void CppiaClassInfo::compile()
 {
    for(int i=0;i<staticFunctions.size();i++)
    {
-      DBGLOG(" Compile %s::%s\n", name.c_str(), staticFunctions[i]->name.c_str() );
+      DBGLOG(" Compile %s::%s" HX_LF, name.c_str(), staticFunctions[i]->name.c_str() );
       staticFunctions[i]->compile();
    }
    if (newFunc)
@@ -1294,7 +1294,7 @@ void CppiaClassInfo::compile()
    // Functions
    for(int i=0;i<memberFunctions.size();i++)
    {
-      DBGLOG(" Compile member %s::%s\n", name.c_str(), memberFunctions[i]->name.c_str() );
+      DBGLOG(" Compile member %s::%s" HX_LF, name.c_str(), memberFunctions[i]->name.c_str() );
       memberFunctions[i]->compile();
    }
 }
@@ -1305,7 +1305,7 @@ void CppiaClassInfo::link()
    int newPos = -1;
    for(int i=0;i<staticFunctions.size();i++)
    {
-      DBGLOG(" Link %s::%s\n", name.c_str(), staticFunctions[i]->name.c_str() );
+      DBGLOG(" Link %s::%s" HX_LF, name.c_str(), staticFunctions[i]->name.c_str() );
       staticFunctions[i]->link();
    }
    if (newFunc)
@@ -1317,7 +1317,7 @@ void CppiaClassInfo::link()
    // Functions
    for(int i=0;i<memberFunctions.size();i++)
    {
-      DBGLOG(" Link member %s::%s\n", name.c_str(), memberFunctions[i]->name.c_str() );
+      DBGLOG(" Link member %s::%s" HX_LF, name.c_str(), memberFunctions[i]->name.c_str() );
       memberFunctions[i]->link();
    }
 
@@ -1333,7 +1333,7 @@ void CppiaClassInfo::link()
       if (interfaceSlotSize)
       {
          int interfaceSlot = cppia.findInterfaceSlot( memberFunctions[i]->name );
-         DBGLOG("Set %s : %s to %d @%p\n", name.c_str(), memberFunctions[i]->name.c_str(), interfaceSlot, vtable);
+         DBGLOG("Set %s : %s to %d @%p" HX_LF, name.c_str(), memberFunctions[i]->name.c_str(), interfaceSlot, vtable);
          if (interfaceSlot>0 && interfaceSlot<interfaceSlotSize)
             vtable[ -interfaceSlot ] = memberFunctions[i]->funExpr;
       }
@@ -1368,7 +1368,7 @@ void CppiaClassInfo::link()
                dump();
                throw Dynamic(HX_CSTRING("Could not find getter for ") + var.name);
             }
-            DBGLOG("  found getter for %s.%s\n", name.c_str(), var.name.out_str());
+            DBGLOG("  found getter for %s.%s" HX_LF, name.c_str(), var.name.out_str());
             memberGetters[var.name.utf8_str()] = getter;
          }
          if (var.writeAccess == CppiaVar::accCall || var.writeAccess==CppiaVar::accCallNative)
@@ -1376,7 +1376,7 @@ void CppiaClassInfo::link()
             ScriptCallable *setter = findFunction(false,HX_CSTRING("set_") + var.name);
             if (!setter)
                throw Dynamic(HX_CSTRING("Could not find setter for ") + var.name);
-            DBGLOG("  found setter for %s.%s\n", name.c_str(), var.name.out_str());
+            DBGLOG("  found setter for %s.%s" HX_LF, name.c_str(), var.name.out_str());
             memberSetters[var.name.utf8_str()] = setter;
          }
 
@@ -1394,7 +1394,7 @@ void CppiaClassInfo::link()
          ScriptCallable *getter = findFunction(true,HX_CSTRING("get_") + var.name);
          if (!getter)
             throw Dynamic(HX_CSTRING("Could not find getter for ") + var.name);
-         DBGLOG("  found getter for %s.%s\n", name.c_str(), var.name.out_str());
+         DBGLOG("  found getter for %s.%s" HX_LF, name.c_str(), var.name.out_str());
          staticGetters[var.name.utf8_str()] = getter;
       }
       if (var.writeAccess == CppiaVar::accCall || var.writeAccess == CppiaVar::accCallNative)
@@ -1402,7 +1402,7 @@ void CppiaClassInfo::link()
          ScriptCallable *setter = findFunction(true,HX_CSTRING("set_") + var.name);
          if (!setter)
             throw Dynamic(HX_CSTRING("Could not find setter for ") + var.name);
-         DBGLOG("  found setter for %s.%s\n", name.c_str(), var.name.out_str());
+         DBGLOG("  found setter for %s.%s" HX_LF, name.c_str(), var.name.out_str());
          staticSetters[var.name.utf8_str()] = setter;
       }
 
@@ -1413,7 +1413,7 @@ void CppiaClassInfo::link()
    if (enumMeta)
       enumMeta = enumMeta->link(cppia);
 
-   //printf("Found haxeBase %s = %p / %d\n", cppia.types[typeId]->name.out_str(), haxeBase, dataSize );
+   //printf("Found haxeBase %s = %p / %d" HX_LF, cppia.types[typeId]->name.out_str(), haxeBase, dataSize );
 }
 
 void CppiaClassInfo::init(CppiaCtx *ctx, int inPhase)
@@ -1485,7 +1485,7 @@ Dynamic CppiaClassInfo::getStaticValue(const String &inName,hx::PropertyAccess  
          return var.getStaticValue();
    }
 
-   printf("Get static field not found (%s) %s\n", name.c_str(),inName.out_str());
+   printf("Get static field not found (%s) %s" HX_LF, name.c_str(),inName.out_str());
    return null();
 }
 
@@ -1550,7 +1550,7 @@ Dynamic CppiaClassInfo::setStaticValue(const String &inName,const Dynamic &inVal
       }
    }
 
-   printf("Set static field not found (%s) %s\n", name.c_str(), inName.out_str());
+   printf("Set static field not found (%s) %s" HX_LF, name.c_str(), inName.out_str());
    return null();
 
 }
@@ -1701,7 +1701,7 @@ public:
    {
       mName = inName;
       mSuper = info->getSuperClass();
-      DBGLOG("LINK %p ########################### %s -> %p\n", this, mName.out_str(), mSuper );
+      DBGLOG("LINK %p ########################### %s -> %p" HX_LF, this, mName.out_str(), mSuper );
       //mStatics = Array_obj<String>::__new(0,0);
 
       bool overwrite = false;

--- a/src/hx/cppia/CppiaCompiler.cpp
+++ b/src/hx/cppia/CppiaCompiler.cpp
@@ -12,40 +12,40 @@ namespace hx
 
 static void test_func(CppiaCtx *inCtx)
 {
-   printf("Test!\n");
+   printf("Test!" HX_LF);
 }
 
 static void SLJIT_CALL my_trace_func(const char *inText)
 {
-   printf("trace: %s\n", inText);
+   printf("trace: %s" HX_LF, inText);
 }
 static void SLJIT_CALL my_trace_strings(const char *inText, const char *inValue)
 {
-   printf("%s%s\n", inText, inValue);
+   printf("%s%s" HX_LF, inText, inValue);
 }
 static void SLJIT_CALL my_trace_string(const char *inText, String *inValue)
 {
-   printf("%s%s\n", inText, inValue->out_str());
+   printf("%s%s" HX_LF, inText, inValue->out_str());
 }
 
 static void SLJIT_CALL my_trace_ptr_func(const char *inText, hx::Object **inPtr)
 {
-   printf("%s = %p\n",inText, inPtr);
-   //printf("*= %s\n", (*inPtr)->toString().out_str());
+   printf("%s = %p" HX_LF,inText, inPtr);
+   //printf("*= %s" HX_LF, (*inPtr)->toString().out_str());
    //*(int *)0=0;
 }
 static void SLJIT_CALL my_trace_int_func(const char *inText, int inValue)
 {
-   printf("%s = %d\n",inText, inValue);
+   printf("%s = %d" HX_LF,inText, inValue);
 }
 static void SLJIT_CALL my_trace_float_func(const char *inText, double *inValue)
 {
-   printf("%s = %f\n",inText, *inValue);
+   printf("%s = %f" HX_LF,inText, *inValue);
 }
 
 static void SLJIT_CALL my_trace_obj_func(const char *inText, hx::Object *inPtr)
 {
-   printf("%s = %s\n",inText, inPtr ? inPtr->__ToString().out_str() : "NULL" );
+   printf("%s = %s" HX_LF,inText, inPtr ? inPtr->__ToString().out_str() : "NULL" );
 }
 
 static hx::Object *SLJIT_CALL intToObj(int inVal)
@@ -924,7 +924,7 @@ public:
 
 
             default:
-               printf("TODO - other to string\n");
+               printf("TODO - other to string" HX_LF);
          }
       }
       else if (inToType==etFloat)

--- a/src/hx/cppia/CppiaCtx.cpp
+++ b/src/hx/cppia/CppiaCtx.cpp
@@ -13,7 +13,7 @@ namespace hx
 
 #ifdef DEBUG_RETURN_TYPE
    #define DEBUG_RETURN_TYPE_CHECK \
-       if (gLastRet!=CHECK && CHECK!=etVoid) { printf("BAD RETURN TYPE, got %d, expected %d!\n",gLastRet,CHECK); CPPIA_CHECK(0); }
+       if (gLastRet!=CHECK && CHECK!=etVoid) { printf("BAD RETURN TYPE, got %d, expected %d!" HX_LF,gLastRet,CHECK); CPPIA_CHECK(0); }
 #else
    #define DEBUG_RETURN_TYPE_CHECK
 #endif
@@ -37,7 +37,7 @@ int StackContext::runInt(void *vtable)
 {
    if (breakContReturn) return 0;
    GET_RETURN_VAL(return getInt(), etInt );
-   //printf("No Int return?\n");
+   //printf("No Int return?" HX_LF);
    // Should not really get here...
    return 0;
 }
@@ -46,7 +46,7 @@ Float StackContext::runFloat(void *vtable)
    if (breakContReturn) return 0;
    GET_RETURN_VAL(return getFloat(),etFloat );
    // Should not really get here...
-   //printf("No Float return?\n");
+   //printf("No Float return?" HX_LF);
    return 0;
 }
 String StackContext::runString(void *vtable)
@@ -54,21 +54,21 @@ String StackContext::runString(void *vtable)
    if (breakContReturn) return String();
    GET_RETURN_VAL(return getString(),etString );
    // Should not really get here...
-   //printf("No String return?\n");
+   //printf("No String return?" HX_LF);
    return null();
 }
 Dynamic StackContext::runObject(void *vtable)
 {
    if (breakContReturn) return null();
    GET_RETURN_VAL(return getObject(),etObject );
-   //printf("No Object return?\n");
+   //printf("No Object return?" HX_LF);
    return null();
 }
 hx::Object *StackContext::runObjectPtr(void *vtable)
 {
    if (breakContReturn) return 0;
    GET_RETURN_VAL(return getObjectPtr(),etObject );
-   //printf("No Object return?\n");
+   //printf("No Object return?" HX_LF);
    return 0;
 }
 

--- a/src/hx/cppia/CppiaFunction.cpp
+++ b/src/hx/cppia/CppiaFunction.cpp
@@ -194,7 +194,7 @@ CppiaExpr *ScriptCallable::link(CppiaModule &inModule)
    #endif
 
    #ifdef CPPIA_JIT
-   //printf("Compile?\n");
+   //printf("Compile?" HX_LF);
    #endif
 
    return this;
@@ -303,8 +303,8 @@ void ScriptCallable::genArgs(CppiaCompiler *compiler, CppiaExpr *inThis, Express
 
    if (badCount)
    {
-      printf("Arg count mismatch %d!=%d ?\n", argCount, (int)inArgs.size());
-      printf(" %s at %s:%d %s\n", getName(), filename, line, functionName);
+      printf("Arg count mismatch %d!=%d ?" HX_LF, argCount, (int)inArgs.size());
+      printf(" %s at %s:%d %s" HX_LF, getName(), filename, line, functionName);
       CPPIA_CHECK(0);
       throw Dynamic(HX_CSTRING("Arg count error"));
       //return;
@@ -390,8 +390,8 @@ void ScriptCallable::pushArgs(CppiaCtx *ctx, hx::Object *inThis, Expressions &in
 
    if (badCount)
    {
-      printf("Arg count mismatch %d!=%d ?\n", argCount, (int)inArgs.size());
-      printf(" %s at %s:%d %s\n", getName(), filename, line, functionName);
+      printf("Arg count mismatch %d!=%d ?" HX_LF, argCount, (int)inArgs.size());
+      printf(" %s at %s:%d %s" HX_LF, getName(), filename, line, functionName);
       CPPIA_CHECK(0);
       throw Dynamic(HX_CSTRING("Arg count error"));
       //return;
@@ -509,9 +509,9 @@ void ScriptCallable::runFunction(CppiaCtx *ctx)
    if (compiled)
    {
       AutoFrame frame(ctx);
-      //printf("Running compiled code...\n");
+      //printf("Running compiled code..." HX_LF);
       compiled(ctx);
-      //printf("Done.\n");
+      //printf("Done." HX_LF);
    }
    else
    #endif
@@ -544,9 +544,9 @@ void ScriptCallable::runFunctionClosure(CppiaCtx *ctx)
    if (compiled)
    {
       AutoFrame frame(ctx);
-      //printf("Running compiled code...\n");
+      //printf("Running compiled code..." HX_LF);
       compiled(ctx);
-      //printf("Done.\n");
+      //printf("Done." HX_LF);
    }
    else
    #endif
@@ -764,7 +764,7 @@ public:
          }
          return null();
       }
-      //printf("Not compiled %d!\n", function->captureVars.size());
+      //printf("Not compiled %d!" HX_LF, function->captureVars.size());
       //todo - compiled?
       #endif
 
@@ -969,7 +969,7 @@ void CppiaFunction::load(CppiaStream &stream,bool inExpectBody)
    stream.module->creatingFunction = name.c_str();
    returnType = stream.getInt();
    argCount = stream.getInt();
-   DBGLOG("  Function %s(%d) : %s %s%s\n", name.c_str(), argCount, cppia.typeStr(returnType), isStatic?"static":"instance", isDynamic ? " DYNAMIC": "");
+   DBGLOG("  Function %s(%d) : %s %s%s" HX_LF, name.c_str(), argCount, cppia.typeStr(returnType), isStatic?"static":"instance", isDynamic ? " DYNAMIC": "");
    args.resize(argCount);
    for(int a=0;a<argCount;a++)
    {
@@ -977,7 +977,7 @@ void CppiaFunction::load(CppiaStream &stream,bool inExpectBody)
       arg.nameId = stream.getInt();
       arg.optional = stream.getBool();
       arg.typeId = stream.getInt();
-      DBGLOG("    arg %c%s:%s\n", arg.optional?'?':' ', cppia.identStr(arg.nameId), cppia.typeStr(arg.typeId) );
+      DBGLOG("    arg %c%s:%s" HX_LF, arg.optional?'?':' ', cppia.identStr(arg.nameId), cppia.typeStr(arg.typeId) );
    }
    if (inExpectBody)
       funExpr = (ScriptCallable *)createCppiaExpr(stream);

--- a/src/hx/cppia/CppiaModule.cpp
+++ b/src/hx/cppia/CppiaModule.cpp
@@ -61,14 +61,14 @@ CppiaModule::~CppiaModule()
 
 void CppiaModule::link()
 {
-   DBGLOG("Resolve registered - super\n");
+   DBGLOG("Resolve registered - super" HX_LF);
    HaxeNativeClass::link();
    
-   DBGLOG("Resolve typeIds\n");
+   DBGLOG("Resolve typeIds" HX_LF);
    for(int t=0;t<types.size();t++)
       types[t]->link(*this);
 
-   DBGLOG("Resolve inherited atributes\n");
+   DBGLOG("Resolve inherited atributes" HX_LF);
    for(int i=0;i<classes.size();i++)
    {
       classes[i]->linkTypes();
@@ -127,7 +127,7 @@ CppiaClassInfo *CppiaModule::findClass( ::String inName)
 
 void CppiaModule::mark(hx::MarkContext *__inCtx)
 {
-   DBGLOG(" --- MARK --- \n");
+   DBGLOG(" --- MARK --- " HX_LF);
    HX_MARK_MEMBER(strings);
    for(int i=0;i<types.size();i++)
    {
@@ -205,8 +205,8 @@ int CppiaModule::findInterfaceSlot(const std::string &inName)
 void CppiaModule::where(CppiaExpr *e)
 {
    if (linkingClass && layout)
-      printf(" in %s::%p\n", linkingClass->name.c_str(), layout);
-   printf("   %s at %s:%d %s\n", e->getName(), e->filename, e->line, e->functionName);
+      printf(" in %s::%p" HX_LF, linkingClass->name.c_str(), layout);
+   printf("   %s at %s:%d %s" HX_LF, e->getName(), e->filename, e->line, e->functionName);
 }
 
 
@@ -303,7 +303,7 @@ public:
       booted = true;
       try
       {
-         DBGLOG("--- Boot --------------------------------------------\n");
+         DBGLOG("--- Boot --------------------------------------------" HX_LF);
          CppiaCtx *ctx = CppiaCtx::getCurrent();
          cppia->boot(ctx);
       }
@@ -324,7 +324,7 @@ public:
          try
          {
             //__hxcpp_enable(false);
-            DBGLOG("--- Run --------------------------------------------\n");
+            DBGLOG("--- Run --------------------------------------------" HX_LF);
             CppiaCtx *ctx = CppiaCtx::getCurrent();
             ctx->runVoid(cppia->main);
             if (ctx->exception)
@@ -386,12 +386,12 @@ CppiaLoadedModule LoadCppia(const unsigned char *inData, int inDataLength)
 
       int typeCount = stream.getAsciiInt();
       cppia.types.resize(typeCount);
-      DBGLOG("Type count : %d\n", typeCount);
+      DBGLOG("Type count : %d" HX_LF, typeCount);
       for(int t=0;t<typeCount;t++)
          cppia.types[t] = new TypeData(stream.readString());
 
       int classCount = stream.getAsciiInt();
-      DBGLOG("Class count : %d\n", classCount);
+      DBGLOG("Class count : %d" HX_LF, classCount);
 
       if (stream.binary)
       {
@@ -411,7 +411,7 @@ CppiaLoadedModule LoadCppia(const unsigned char *inData, int inDataLength)
       tok = stream.getToken();
       if (tok=="MAIN")
       {
-         DBGLOG("Main...\n");
+         DBGLOG("Main..." HX_LF);
          cppia.main = new ScriptCallable(createCppiaExpr(stream));
          cppia.main->className = "cppia";
          cppia.main->functionName = "__cppia_main";
@@ -476,7 +476,7 @@ CppiaLoadedModule LoadCppia(const unsigned char *inData, int inDataLength)
    if (!error.raw_ptr())
       try
       {
-         DBGLOG("Link...\n");
+         DBGLOG("Link..." HX_LF);
          cppia.link();
       }
       catch(const char *errorString)
@@ -490,7 +490,7 @@ CppiaLoadedModule LoadCppia(const unsigned char *inData, int inDataLength)
       if (!error.raw_ptr())
          try
          {
-            DBGLOG("Compile...\n");
+            DBGLOG("Compile..." HX_LF);
             cppia.compile();
          }
          catch(const char *errorString)

--- a/src/hx/cppia/CppiaStream.h
+++ b/src/hx/cppia/CppiaStream.h
@@ -119,7 +119,7 @@ struct CppiaStream
       if (!binary)
          return getAsciiToken();
       int id = getInt();
-      //printf("Token %s\n", tokenMap[id].c_str());
+      //printf("Token %s" HX_LF, tokenMap[id].c_str());
       return tokenMap[id];
    }
 

--- a/src/hx/cppia/CppiaVars.cpp
+++ b/src/hx/cppia/CppiaVars.cpp
@@ -167,7 +167,7 @@ CppiaExpr *CppiaVar::createAccess(CppiaExpr *inSrc)
 
 void CppiaVar::linkVarTypes(CppiaModule &cppia, int &ioOffset)
 {
-   DBGLOG("linkVarTypes %p\n",dynamicFunction);
+   DBGLOG("linkVarTypes %p" HX_LF,dynamicFunction);
    if (dynamicFunction)
    {
       //dynamicFunction->linkTypes(cppia);

--- a/src/hx/cppia/GlobalBuiltin.cpp
+++ b/src/hx/cppia/GlobalBuiltin.cpp
@@ -390,7 +390,7 @@ CppiaExpr *createGlobalBuiltin(CppiaExpr *src, String function, Expressions &ioE
    }
 
 
-   printf("Unknown function : %s(%d)\n", function.out_str(), (int)ioExpressions.size() );
+   printf("Unknown function : %s(%d)" HX_LF, function.out_str(), (int)ioExpressions.size() );
    throw (HX_CSTRING("Unknown global:") + function).utf8_str();
    return 0;
 }

--- a/src/hx/cppia/HaxeNative.cpp
+++ b/src/hx/cppia/HaxeNative.cpp
@@ -43,14 +43,14 @@ void HaxeNativeClass::addVtableEntries( std::vector<std::string> &outVtable)
 
 void HaxeNativeClass::dump()
 {
-   printf("HaxeNativeClass %s\n", name.c_str());
+   printf("HaxeNativeClass %s" HX_LF, name.c_str());
 
    if (functions)
       for(ScriptNamedFunction *f=functions;f->name;f++)
-         printf("  %s func %s\n", f->isStatic ? "static" : "virtual", f->name );
+         printf("  %s func %s" HX_LF, f->isStatic ? "static" : "virtual", f->name );
    if (haxeSuper)
    {
-      printf("super:\n");
+      printf("super:" HX_LF);
       haxeSuper->dump();
    }
 }
@@ -98,10 +98,10 @@ void HaxeNativeClass::link()
       if (!i->second)
          continue;
 
-      DBGLOG("== %s ==\n", i->first.c_str());
+      DBGLOG("== %s ==" HX_LF, i->first.c_str());
       if (i->second == hxObj)
       {
-         DBGLOG(" super =0\n");
+         DBGLOG(" super =0" HX_LF);
          continue;
       }
       hx::Class cls = hx::Class_obj::Resolve( String(i->first.c_str() ) );
@@ -113,16 +113,16 @@ void HaxeNativeClass::link()
             HaxeNativeClass *superRef = (*sScriptRegistered)[superClass.mPtr->mName.utf8_str()];
             if (superRef)
             {
-               DBGLOG("registered %s\n",superClass.mPtr->mName.utf8_str());
+               DBGLOG("registered %s" HX_LF,superClass.mPtr->mName.utf8_str());
                i->second->haxeSuper = superRef;
             }
          }
       }
 
-      DBGLOG("haxe super = %p\n", i->second->haxeSuper);
+      DBGLOG("haxe super = %p" HX_LF, i->second->haxeSuper);
       if (!i->second->haxeSuper)
       {
-         DBGLOG("using hx.Object\n");
+         DBGLOG("using hx.Object" HX_LF);
          i->second->haxeSuper = hxObj;
       }
    }
@@ -149,12 +149,12 @@ ScriptFunction HaxeNativeInterface::findFunction(const std::string &inName)
 
 void ScriptableRegisterClass( String inName, int inDataOffset, ScriptNamedFunction *inFunctions, hx::ScriptableClassFactory inFactory, hx::ScriptFunction inConstruct)
 {
-   DBGLOG("ScriptableRegisterClass %s\n", inName.out_str());
+   DBGLOG("ScriptableRegisterClass %s" HX_LF, inName.out_str());
    if (!sScriptRegistered)
       sScriptRegistered = new ScriptRegisteredMap();
    HaxeNativeClass *registered = new HaxeNativeClass(inName.utf8_str(),inDataOffset, inFunctions,inFactory, inConstruct);
    (*sScriptRegistered)[inName.utf8_str()] = registered;
-   //printf("Registering %s -> %p\n",inName.out_str(),(*sScriptRegistered)[inName.utf8_str()]);
+   //printf("Registering %s -> %p" HX_LF,inName.out_str(),(*sScriptRegistered)[inName.utf8_str()]);
 }
 
 
@@ -173,7 +173,7 @@ void ScriptableRegisterInterface( String inName,
                                   ScriptNamedFunction *inFunctions,
                                   void *inScriptTable)
 {
-   DBGLOG("ScriptableInterfaceFactory %s\n",inName.out_str());
+   DBGLOG("ScriptableInterfaceFactory %s" HX_LF,inName.out_str());
    if (!sScriptRegisteredInterface)
       sScriptRegisteredInterface = new HaxeNativeIntefaceMap();
 
@@ -200,7 +200,7 @@ void ScriptableRegisterInterface( String inName,
                                   const hx::type_info *inType,
                                   hx::ScriptableInterfaceFactory inFactory )
 {
-   DBGLOG("ScriptableInterfaceFactory %s\n",inName.out_str());
+   DBGLOG("ScriptableInterfaceFactory %s" HX_LF,inName.out_str());
    if (!sScriptRegisteredInterface)
       sScriptRegisteredInterface = new HaxeNativeIntefaceMap();
 

--- a/src/hx/cppia/StringBuiltin.cpp
+++ b/src/hx/cppia/StringBuiltin.cpp
@@ -186,7 +186,7 @@ struct CharAtExpr : public StringExpr
    }
    int runInt(CppiaCtx *ctx)
    {
-      //printf("Char code at %d INT\n", CODE);
+      //printf("Char code at %d INT" HX_LF, CODE);
       String val = strVal->runString(ctx);
       BCR_CHECK;
       int idx = a0->runInt(ctx);

--- a/src/hx/gc/Immix.cpp
+++ b/src/hx/gc/Immix.cpp
@@ -264,14 +264,14 @@ struct ProfileCollectSummary
    {
       #ifdef HXCPP_GC_SUMMARY
       double time = __hxcpp_time_stamp() - startTime;
-      GCLOG("Total time     : %.2fms\n", time*1000.0);
-      GCLOG("Collecting time: %.2fms\n", totalCollecting*1000.0);
-      GCLOG("Max Stall time : %.2fms\n", maxStall*1000.0);
+      GCLOG("Total time     : %.2fms" HX_LF, time*1000.0);
+      GCLOG("Collecting time: %.2fms" HX_LF, totalCollecting*1000.0);
+      GCLOG("Max Stall time : %.2fms" HX_LF, maxStall*1000.0);
       if (time==0) time = 1;
-      GCLOG(" Fraction      : %.2f%%\n",totalCollecting*100.0/time);
+      GCLOG(" Fraction      : %.2f%%" HX_LF,totalCollecting*100.0/time);
 
       #ifdef HXCPP_GC_DYNAMIC_SIZE
-      GCLOG("Space factor   : %.2fx\n",spaceFactor);
+      GCLOG("Space factor   : %.2fx" HX_LF,spaceFactor);
       #endif
       #endif
    }
@@ -514,9 +514,9 @@ void CriticalGCError(const char *inMessage)
    #ifdef ANDROID
    __android_log_print(ANDROID_LOG_ERROR, "HXCPP", "Critical Error: %s", inMessage);
    #elif defined(HX_WINRT)
-      WINRT_LOG("HXCPP Critical Error: %s\n", inMessage);
+      WINRT_LOG("HXCPP Critical Error: %s" HX_LF, inMessage);
    #else
-   printf("Critical Error: %s\n", inMessage);
+   printf("Critical Error: %s" HX_LF, inMessage);
    #endif
 
    DebuggerTrap();
@@ -738,7 +738,7 @@ struct BlockDataInfo
       mPtr     = inData;
       inData->mId = mId;
       #ifdef SHOW_MEM_EVENTS
-      GCLOG("  create block %d : %p -> %p\n",  mId, this, mPtr );
+      GCLOG("  create block %d : %p -> %p" HX_LF,  mId, this, mPtr );
       #endif
       clear();
    }
@@ -826,7 +826,7 @@ struct BlockDataInfo
    void destroy()
    {
       #ifdef SHOW_MEM_EVENTS
-      GCLOG("  release block %d : %p\n",  mId, this );
+      GCLOG("  release block %d : %p" HX_LF,  mId, this );
       #endif
       (*gBlockInfo)[mId] = 0;
       gBlockInfoEmptySlots++;
@@ -1350,13 +1350,13 @@ struct BlockDataInfo
                   int rows = header & IMMIX_ALLOC_ROW_COUNT;
                   if (rows==0)
                   {
-                     printf("BAD ROW0 %s\n", inWhere);
+                     printf("BAD ROW0 %s" HX_LF, inWhere);
                      DebuggerTrap();
                   }
                   for(int r=0;r<rows;r++)
                      if (!mPtr->mRowMarked[r+i])
                      {
-                        printf("Unmarked row %dx %d/%d %s, t=%d!\n", i, r, rows, inWhere,sgTimeToNextTableUpdate);
+                        printf("Unmarked row %dx %d/%d %s, t=%d!" HX_LF, i, r, rows, inWhere,sgTimeToNextTableUpdate);
                         DebuggerTrap();
                      }
                }
@@ -1426,7 +1426,7 @@ void GCCheckPointer(void *inPtr)
    #ifdef HXCPP_GC_DEBUG_ALWAYS_MOVE
    if (hx::sgPointerMoved.find(inPtr)!=hx::sgPointerMoved.end())
    {
-      GCLOG("Accessing moved pointer %p\n", inPtr);
+      GCLOG("Accessing moved pointer %p" HX_LF, inPtr);
       DebuggerTrap();
    }
    #endif
@@ -1437,7 +1437,7 @@ void GCCheckPointer(void *inPtr)
    #endif
    if ( !(mark & HX_GC_CONST_ALLOC_MARK_BIT) && mark!=gByteMarkID  )
    {
-      GCLOG("Old object access %p\n", inPtr);
+      GCLOG("Old object access %p" HX_LF, inPtr);
       NullReference("Object", false);
    }
 }
@@ -1645,7 +1645,7 @@ struct GlobalChunks
    {
       if (!(sRunningThreads & (1<<inThreadId)))
       {
-         printf("Complete non-running thread?\n");
+         printf("Complete non-running thread?" HX_LF);
          DebuggerTrap();
       }
       sRunningThreads &= ~(1<<inThreadId);
@@ -1730,7 +1730,7 @@ struct GlobalChunks
       {
          if (result->count==MarkChunk::OBJ_ARRAY_JOB)
          {
-            GCLOG("Popped array job?\n");
+            GCLOG("Popped array job?" HX_LF);
             pushJob(result,false);
          }
          else
@@ -1800,14 +1800,14 @@ public:
        #ifdef ANDROID
        __android_log_print(ANDROID_LOG_ERROR, "trace", "Class referenced from");
        #else
-       printf("Class referenced from:\n");
+       printf("Class referenced from:" HX_LF);
        #endif
 
        for(int i=0;i<n;i++)
           #ifdef ANDROID
           __android_log_print(ANDROID_LOG_INFO, "trace", "%s.%s",  mInfo[i].mClass, mInfo[i].mMember );
           #else
-          printf("%s.%s\n",  mInfo[i].mClass, mInfo[i].mMember );
+          printf("%s.%s" HX_LF,  mInfo[i].mClass, mInfo[i].mMember );
           #endif
 
        if (mPos>=StackSize)
@@ -1815,7 +1815,7 @@ public:
           #ifdef ANDROID
           __android_log_print(ANDROID_LOG_INFO, "trace", "... + deeper");
           #else
-          printf("... + deeper\n");
+          printf("... + deeper" HX_LF);
           #endif
        }
     }
@@ -1909,12 +1909,12 @@ public:
 /*
 void MarkerReleaseWorkerLocked( )
 {
-   //printf("Release...\n");
+   //printf("Release..." HX_LF);
    for(int i=0;i<sAllThreads;i++)
    {
       if ( ! (sRunningThreads & (1<<i) ) )
       {
-         //printf("Wake %d\n",i);
+         //printf("Wake %d" HX_LF,i);
          sRunningThreads |= (1<<i);
          sThreadWake[i]->Set();
          return;
@@ -1988,7 +1988,7 @@ void MarkAllocUnchecked(void *inPtr,hx::MarkContext *__inCtx)
       #if defined(HXCPP_GC_GENERATIONAL) && defined(HX_GC_VERIFY)
       if (sGcVerifyGenerational)
       {
-         printf("Nursery alloc escaped generational collection %p\n", inPtr);
+         printf("Nursery alloc escaped generational collection %p" HX_LF, inPtr);
          DebuggerTrap();
       }
       #endif
@@ -2028,7 +2028,7 @@ void MarkAllocUnchecked(void *inPtr,hx::MarkContext *__inCtx)
       #if defined(HXCPP_GC_GENERATIONAL) && defined(HX_GC_VERIFY)
       if (sGcVerifyGenerational && ((unsigned char *)inPtr)[HX_ENDIAN_MARK_ID_BYTE] != gPrevByteMarkID)
       {
-         printf("Alloc missed int generational collection %p\n", inPtr);
+         printf("Alloc missed int generational collection %p" HX_LF, inPtr);
          DebuggerTrap();
       }
       #endif
@@ -2074,7 +2074,7 @@ void MarkObjectAllocUnchecked(hx::Object *inPtr,hx::MarkContext *__inCtx)
       #if defined(HXCPP_GC_GENERATIONAL) && defined(HX_GC_VERIFY)
          if (sGcVerifyGenerational)
          {
-            printf("Nursery object escaped generational collection %p\n", inPtr);
+            printf("Nursery object escaped generational collection %p" HX_LF, inPtr);
             DebuggerTrap();
          }
       #endif
@@ -2792,7 +2792,7 @@ void RegisterWeakHash(HashBase<Dynamic> *inHash)
 
 void InternalEnableGC(bool inEnable)
 {
-   //printf("Enable %d\n", sgInternalEnable);
+   //printf("Enable %d" HX_LF, sgInternalEnable);
    sgInternalEnable = inEnable;
 }
 
@@ -2912,17 +2912,17 @@ struct MoveBlockJob
       {
          if (from>=to)
          {
-            //printf("Caught up!\n");
+            //printf("Caught up!" HX_LF);
             return 0;
          }
          #ifndef HXCPP_GC_DEBUG_ALWAYS_MOVE
          // Pinned / full
          if (blocks[from]->mMoveScore<2)
          {
-            //printf("All other blocks good!\n");
+            //printf("All other blocks good!" HX_LF);
             while(from<to)
             {
-               //printf("Ignore DEFRAG %p ... %p\n", blocks[from]->mPtr, blocks[from]->mPtr+1);
+               //printf("Ignore DEFRAG %p ... %p" HX_LF, blocks[from]->mPtr, blocks[from]->mPtr+1);
                from++;
             }
             return 0;
@@ -2930,27 +2930,27 @@ struct MoveBlockJob
          #endif
          if (blocks[from]->mPinned)
          {
-            //printf("PINNED DEFRAG %p ... %p\n", blocks[from]->mPtr, blocks[from]->mPtr+1);
+            //printf("PINNED DEFRAG %p ... %p" HX_LF, blocks[from]->mPtr, blocks[from]->mPtr+1);
             from++;
          }
          else // Found one...
             break;
       }
-      //printf("From block %d (id=%d)\n", from, blocks[from]->mId);
+      //printf("From block %d (id=%d)" HX_LF, from, blocks[from]->mId);
       BlockDataInfo *result = blocks[from++];
-      ////printf("FROM DEFRAG %p ... %p\n", result->mPtr, result->mPtr + 1 );
+      ////printf("FROM DEFRAG %p ... %p" HX_LF, result->mPtr, result->mPtr + 1 );
       return result;
    }
    BlockDataInfo *getTo()
    {
       if (from>=to)
       {
-         //printf("No more room!\n");
+         //printf("No more room!" HX_LF);
          return 0;
       }
-      //printf("To block %d (id=%d)\n", to, blocks[to]->mId);
+      //printf("To block %d (id=%d)" HX_LF, to, blocks[to]->mId);
       BlockDataInfo *result = blocks[to--];
-      //printf("TO DEFRAG %p ... %p\n", result->mPtr, result->mPtr + 1 );
+      //printf("TO DEFRAG %p ... %p" HX_LF, result->mPtr, result->mPtr + 1 );
       return result;
    }
 };
@@ -2967,7 +2967,7 @@ void *HxAllocGCBlock(size_t size)
    if (sBlockPool.size())
       return sBlockPool.pop();
    gcBlockAllocs++;
-   GCLOG("===========================================> New Chunk (%d)\n", gcBlockAllocs);
+   GCLOG("===========================================> New Chunk (%d)" HX_LF, gcBlockAllocs);
    return HxAlloc(size);
 }
 
@@ -3149,7 +3149,7 @@ public:
       if (!result)
       {
          #ifdef SHOW_MEM_EVENTS
-         GCLOG("Large alloc failed - forcing collect\n");
+         GCLOG("Large alloc failed - forcing collect" HX_LF);
          #endif
 
          if (isLocked)
@@ -3302,7 +3302,7 @@ public:
          {
             #ifdef SHOW_FRAGMENTATION
               #ifdef SHOW_MEM_EVENTS
-                GCLOG("  alloc -> enable full collect\n");
+                GCLOG("  alloc -> enable full collect" HX_LF);
               #endif
             #endif
             //sgTimeToNextTableUpdate = 1;
@@ -3356,7 +3356,7 @@ public:
       {
          DebuggerTrap();
          #ifdef SHOW_MEM_EVENTS
-         GCLOG("Alloc failed - try collect\n");
+         GCLOG("Alloc failed - try collect" HX_LF);
          #endif
          outForceCompact = true;
          return false;
@@ -3387,11 +3387,11 @@ public:
       #if defined(SHOW_MEM_EVENTS) || defined(SHOW_FRAGMENTATION_BLOCKS)
       if (inJustBorrowing)
       {
-         GCLOG("Borrow Blocks %d = %d k\n", mAllBlocks.size(), (mAllBlocks.size() << IMMIX_BLOCK_BITS)>>10);
+         GCLOG("Borrow Blocks %d = %d k" HX_LF, mAllBlocks.size(), (mAllBlocks.size() << IMMIX_BLOCK_BITS)>>10);
       }
       else
       {
-         GCLOG("Blocks %d = %d k\n", mAllBlocks.size(), (mAllBlocks.size() << IMMIX_BLOCK_BITS)>>10);
+         GCLOG("Blocks %d = %d k" HX_LF, mAllBlocks.size(), (mAllBlocks.size() << IMMIX_BLOCK_BITS)>>10);
       }
       #endif
 
@@ -3517,7 +3517,7 @@ public:
        // Maybe do something faster with weakmaps
 
 #ifdef HXCPP_TELEMETRY
-       //printf(" -- moving %018x to %018x, size %d\n", inFrom, inTo, size);
+       //printf(" -- moving %018x to %018x, size %d" HX_LF, inFrom, inTo, size);
        __hxt_gc_realloc(inFrom, inTo, size);
 #endif
 
@@ -3551,7 +3551,7 @@ public:
 
          unsigned int *allocStart = from->allocStart;
          #ifdef SHOW_MEM_EVENTS
-         //GCLOG("Move from %p (%d x %d)\n", from, from->mUsedRows, from->mHoles );
+         //GCLOG("Move from %p (%d x %d)" HX_LF, from, from->mUsedRows, from->mHoles );
          #endif
 
          const unsigned char *rowMarked = from->mPtr->mRowMarked;
@@ -3629,7 +3629,7 @@ public:
 
                         // Result has moved - store movement in original position...
                         memcpy(buffer, src, size);
-                        //GCLOG("   move %p -> %p %d (%08x %08x )\n", src, buffer, size, buffer[-1], buffer[1] );
+                        //GCLOG("   move %p -> %p %d (%08x %08x )" HX_LF, src, buffer, size, buffer[-1], buffer[1] );
 
                         *(unsigned int **)src = buffer;
                         header = IMMIX_OBJECT_HAS_MOVED;
@@ -3666,7 +3666,7 @@ public:
       }
 
       #ifdef SHOW_FRAGMENTATION
-      GCLOG("Moved %d objects (%d/%d blocks)\n", moveObjs, clearedBlocks, mAllBlocks.size());
+      GCLOG("Moved %d objects (%d/%d blocks)" HX_LF, moveObjs, clearedBlocks, mAllBlocks.size());
       #endif
 
       if (moveObjs)
@@ -3690,9 +3690,9 @@ public:
          {
             if ( ((*(unsigned int **)ioPtr)[-1]) == IMMIX_OBJECT_HAS_MOVED )
             {
-               //GCLOG("  patch object to  %p -> %p\n", *ioPtr,  (*(hx::Object ***)ioPtr)[0]);
+               //GCLOG("  patch object to  %p -> %p" HX_LF, *ioPtr,  (*(hx::Object ***)ioPtr)[0]);
                *ioPtr = (*(hx::Object ***)ioPtr)[0];
-               //GCLOG("    %08x %08x ...\n", ((int *)(*ioPtr))[0], ((int *)(*ioPtr))[1] ); 
+               //GCLOG("    %08x %08x ..." HX_LF, ((int *)(*ioPtr))[0], ((int *)(*ioPtr))[1] ); 
             }
          }
 
@@ -3700,9 +3700,9 @@ public:
          {
             if ( ((*(unsigned int **)ioPtr)[-1]) == IMMIX_OBJECT_HAS_MOVED )
             {
-               //GCLOG("  patch reference to  %p -> %p\n", *ioPtr,  (*(void ***)ioPtr)[0]);
+               //GCLOG("  patch reference to  %p -> %p" HX_LF, *ioPtr,  (*(void ***)ioPtr)[0]);
                *ioPtr = (*(void ***)ioPtr)[0];
-               //GCLOG("    %08x %08x ...\n", ((int *)(*ioPtr))[0], ((int *)(*ioPtr))[1] ); 
+               //GCLOG("    %08x %08x ..." HX_LF, ((int *)(*ioPtr))[0], ((int *)(*ioPtr))[1] ); 
             }
          }
       };
@@ -3832,7 +3832,7 @@ public:
 
                            // Result has moved - store movement in original position...
                            memcpy(buffer, src, size);
-                           //GCLOG("   move %p -> %p %d (%08x %08x )\n", src, buffer, size, buffer[-1], buffer[1] );
+                           //GCLOG("   move %p -> %p %d (%08x %08x )" HX_LF, src, buffer, size, buffer[-1], buffer[1] );
 
                            *(unsigned int **)src = buffer;
                            header = IMMIX_OBJECT_HAS_MOVED;
@@ -3866,7 +3866,7 @@ public:
       }
 
       #ifdef SHOW_FRAGMENTATION
-      //GCLOG("Compacted nursery %d objects (%d/%d blocks)\n", moveObjs, clearedBlocks, mAllBlocks.size());
+      //GCLOG("Compacted nursery %d objects (%d/%d blocks)" HX_LF, moveObjs, clearedBlocks, mAllBlocks.size());
       #endif
 
       if (moveObjs)
@@ -3902,7 +3902,7 @@ public:
             size_t groupBytes = g.blocks << (IMMIX_BLOCK_BITS);
 
             #ifdef SHOW_MEM_EVENTS
-            GCLOG("Release group %d: %p -> %p\n", i, g.alloc, g.alloc+groupBytes);
+            GCLOG("Release group %d: %p -> %p" HX_LF, i, g.alloc, g.alloc+groupBytes);
             #endif
             #ifdef HX_GC_VERIFY
             releasedRange.push_back( ReleasedRange(g.alloc, g.alloc+groupBytes) );
@@ -3937,7 +3937,7 @@ public:
             for(int g=0;g<releasedGids.size();g++)
                if (mAllBlocks[i]->mGroupId == releasedGids[g])
                {
-                  printf("Group %d should be released.\n", mAllBlocks[i]->mGroupId);
+                  printf("Group %d should be released." HX_LF, mAllBlocks[i]->mGroupId);
                   DebuggerTrap();
                }
             #endif
@@ -3953,7 +3953,7 @@ public:
          for(int r=0;r<releasedRange.size();r++)
          if ( ptr>=releasedRange[r].first && ptr<releasedRange[r].second )
          {
-            printf("Released block %p(%d:%p) still in list\n", info, info->mId, info->mPtr );
+            printf("Released block %p(%d:%p) still in list" HX_LF, info, info->mId, info->mPtr );
             DebuggerTrap();
          }
       }
@@ -3963,7 +3963,7 @@ public:
 
 
       #if defined(SHOW_MEM_EVENTS) || defined(SHOW_FRAGMENTATION)
-      GCLOG("Release %d blocks, %d groups,  %s\n", released, groups, formatBytes((size_t)released<<(IMMIX_BLOCK_BITS)).c_str());
+      GCLOG("Release %d blocks, %d groups,  %s" HX_LF, released, groups, formatBytes((size_t)released<<(IMMIX_BLOCK_BITS)).c_str());
       #endif
       return released;
    }
@@ -4248,7 +4248,7 @@ public:
       }
       else
       {
-         printf("Finishe non-runnning thread?\n");
+         printf("Finishe non-runnning thread?" HX_LF);
          DebuggerTrap();
       }
    }
@@ -4284,7 +4284,7 @@ public:
 
          #ifdef HX_GC_VERIFY
          if (! (sRunningThreads & (1<<inId)) )
-            printf("Bad running threads!\n");
+            printf("Bad running threads!" HX_LF);
          #endif
 
          if (sgThreadPoolJob==tpjMark)
@@ -4443,7 +4443,7 @@ public:
 
          if (sRunningThreads)
          {
-            printf("Bad thread stop %d\n", sRunningThreads);
+            printf("Bad thread stop %d" HX_LF, sRunningThreads);
             DebuggerTrap();
          }
       }
@@ -4602,7 +4602,7 @@ public:
       {
          if ( mAllBlocks[i-1]->mPtr >= mAllBlocks[i]->mPtr)
          {
-            printf("Bad block order block[%d]=%p >= block[%d]=%p / %d\n", i-1, mAllBlocks[i-1]->mPtr,
+            printf("Bad block order block[%d]=%p >= block[%d]=%p / %d" HX_LF, i-1, mAllBlocks[i-1]->mPtr,
                     i, mAllBlocks[i]->mPtr, mAllBlocks.size() );
             DebuggerTrap();
          }
@@ -4660,12 +4660,12 @@ public:
       HX_STACK_FRAME("GC", "collect", 0, "GC::collect", __FILE__, __LINE__,0)
       #ifdef SHOW_MEM_EVENTS
       int here = 0;
-      GCLOG("=== Collect === %p\n",&here);
+      GCLOG("=== Collect === %p" HX_LF,&here);
       #endif
 
 
       #ifdef PROFILE_THREAD_USAGE
-      GCLOG("Thread zero waits %d/%d/%d, misses=%d, hits=%d\n", sThreadZeroPokes, sThreadZeroWaits, mFreeBlocks.size(), sThreadZeroMisses, sThreadBlockZeroCount);
+      GCLOG("Thread zero waits %d/%d/%d, misses=%d, hits=%d" HX_LF, sThreadZeroPokes, sThreadZeroWaits, mFreeBlocks.size(), sThreadZeroMisses, sThreadBlockZeroCount);
       sThreadZeroWaits = 0;
       sThreadZeroPokes = 0;
       sThreadZeroMisses = 0;
@@ -4705,7 +4705,7 @@ public:
       {
          hx::sGlobalChunks.copyPointers(rememberedSet,!generational);
          #ifdef SHOW_MEM_EVENTS
-         GCLOG("Patch remembered set marks %d\n", rememberedSet.size());
+         GCLOG("Patch remembered set marks %d" HX_LF, rememberedSet.size());
          #endif
          for(int i=0;i<rememberedSet.size();i++)
             ((unsigned char *)rememberedSet[i])[HX_ENDIAN_MARK_ID_BYTE] = gByteMarkID;
@@ -4760,7 +4760,7 @@ public:
                space = retained;
             mGenerationalRetainEstimate = (double)retained/(double)space;
             #ifdef SHOW_MEM_EVENTS
-            GCLOG("Generational retention too high %f, do normal collect\n", mGenerationalRetainEstimate);
+            GCLOG("Generational retention too high %f, do normal collect" HX_LF, mGenerationalRetainEstimate);
             #endif
 
             generational = false;
@@ -4792,13 +4792,13 @@ public:
       {
          double useRatio = (double)(stats.rowsInUse<<IMMIX_LINE_BITS) / (sWorkingMemorySize);
          #if defined(SHOW_FRAGMENTATION) || defined(SHOW_MEM_EVENTS)
-            GCLOG("Row use ratio:%f\n", useRatio);
+            GCLOG("Row use ratio:%f" HX_LF, useRatio);
          #endif
          // Could be either expanding, or fragmented...
          if (useRatio>0.75)
          {
             #if defined(SHOW_FRAGMENTATION) || defined(SHOW_MEM_EVENTS)
-               GCLOG("Do full stats\n", useRatio);
+               GCLOG("Do full stats" HX_LF, useRatio);
             #endif
             full = true;
             stats.clear();
@@ -4817,17 +4817,17 @@ public:
       size_t bytesInUse = stats.bytesInUse;
 
       #if defined(SHOW_FRAGMENTATION) || defined(SHOW_MEM_EVENTS)
-      GCLOG("Total memory : %s\n", formatBytes(GetWorkingMemory()).c_str());
-      GCLOG("  reserved bytes : %s\n", formatBytes((size_t)mRowsInUse*IMMIX_LINE_LEN).c_str());
+      GCLOG("Total memory : %s" HX_LF, formatBytes(GetWorkingMemory()).c_str());
+      GCLOG("  reserved bytes : %s" HX_LF, formatBytes((size_t)mRowsInUse*IMMIX_LINE_LEN).c_str());
       if (full)
       {
-         GCLOG("  active bytes   : %s\n", formatBytes(bytesInUse).c_str());
-         GCLOG("  active ratio   : %f\n", (double)bytesInUse/( mRowsInUse*IMMIX_LINE_LEN));
-         GCLOG("  fragged blocks : %d (%.1f%%)\n", stats.fraggedBlocks, stats.fraggedBlocks*100.0/mAllBlocks.size() );
-         GCLOG("  fragged score  : %f\n", (double)stats.fragScore/mAllBlocks.size() );
+         GCLOG("  active bytes   : %s" HX_LF, formatBytes(bytesInUse).c_str());
+         GCLOG("  active ratio   : %f" HX_LF, (double)bytesInUse/( mRowsInUse*IMMIX_LINE_LEN));
+         GCLOG("  fragged blocks : %d (%.1f%%)" HX_LF, stats.fraggedBlocks, stats.fraggedBlocks*100.0/mAllBlocks.size() );
+         GCLOG("  fragged score  : %f" HX_LF, (double)stats.fragScore/mAllBlocks.size() );
       }
-      GCLOG("  large size   : %s\n", formatBytes(mLargeAllocated).c_str());
-      GCLOG("  empty blocks : %d (%.1f%%)\n", stats.emptyBlocks, stats.emptyBlocks*100.0/mAllBlocks.size());
+      GCLOG("  large size   : %s" HX_LF, formatBytes(mLargeAllocated).c_str());
+      GCLOG("  empty blocks : %d (%.1f%%)" HX_LF, stats.emptyBlocks, stats.emptyBlocks*100.0/mAllBlocks.size());
       #endif
 
 
@@ -4909,7 +4909,7 @@ public:
                #if defined(SHOW_FRAGMENTATION) || defined(SHOW_MEM_EVENTS)
                int releaseGroups = (int)((allMem - sWorkingMemorySize) / (IMMIX_BLOCK_SIZE<<IMMIX_BLOCK_GROUP_BITS));
                if (releaseGroups)
-                  GCLOG("Try to release %d groups\n", releaseGroups );
+                  GCLOG("Try to release %d groups" HX_LF, releaseGroups );
                #endif
                doRelease = true;
             }
@@ -4933,7 +4933,7 @@ public:
             }
             stats.emptyBlocks += borrowed;
             #if defined(SHOW_FRAGMENTATION)
-               GCLOG("Borrowed %d groups for %d target blocks\n", borrowed, workingBlocks);
+               GCLOG("Borrowed %d groups for %d target blocks" HX_LF, borrowed, workingBlocks);
             #endif
 
             MoveBlockJob job(mAllBlocks);
@@ -4955,25 +4955,25 @@ public:
                   {
                      size_t releaseSize = have - targetMem;
                      #ifdef SHOW_FRAGMENTATION
-                     GCLOG(" Release %s bytes to leave %s\n", formatBytes(releaseSize).c_str(), formatBytes(targetMem).c_str() );
+                     GCLOG(" Release %s bytes to leave %s" HX_LF, formatBytes(releaseSize).c_str(), formatBytes(targetMem).c_str() );
                      #endif
 
                      int releasedBlocks = releaseEmptyGroups(stats, releaseSize);
                      #ifdef SHOW_FRAGMENTATION
                      int releasedGroups = releasedBlocks >> IMMIX_BLOCK_GROUP_BITS;
-                     GCLOG(" Released %s, %d groups\n", formatBytes((size_t)releasedBlocks<<IMMIX_BLOCK_BITS).c_str(), releasedGroups );
+                     GCLOG(" Released %s, %d groups" HX_LF, formatBytes((size_t)releasedBlocks<<IMMIX_BLOCK_BITS).c_str(), releasedGroups );
                      #endif
                   }
                }
 
                // Reduce sWorkingMemorySize now we have defragged
                #if defined(SHOW_FRAGMENTATION) || defined(SHOW_MEM_EVENTS)
-               GCLOG("After compacting---\n");
-               GCLOG("  total memory : %s\n", formatBytes(GetWorkingMemory()).c_str() );
-               GCLOG("  total needed : %s\n", formatBytes((size_t)stats.rowsInUse*IMMIX_LINE_LEN).c_str() );
-               GCLOG("  for bytes    : %s\n", formatBytes(bytesInUse).c_str() );
-               GCLOG("  empty blocks : %d (%.1f%%)\n", stats.emptyBlocks, stats.emptyBlocks*100.0/mAllBlocks.size());
-               GCLOG("  fragged blocks : %d (%.1f%%)\n", stats.fraggedBlocks, stats.fraggedBlocks*100.0/mAllBlocks.size() );
+               GCLOG("After compacting---" HX_LF);
+               GCLOG("  total memory : %s" HX_LF, formatBytes(GetWorkingMemory()).c_str() );
+               GCLOG("  total needed : %s" HX_LF, formatBytes((size_t)stats.rowsInUse*IMMIX_LINE_LEN).c_str() );
+               GCLOG("  for bytes    : %s" HX_LF, formatBytes(bytesInUse).c_str() );
+               GCLOG("  empty blocks : %d (%.1f%%)" HX_LF, stats.emptyBlocks, stats.emptyBlocks*100.0/mAllBlocks.size());
+               GCLOG("  fragged blocks : %d (%.1f%%)" HX_LF, stats.fraggedBlocks, stats.fraggedBlocks*100.0/mAllBlocks.size() );
                #endif
             }
 
@@ -5002,7 +5002,7 @@ public:
          sWorkingMemorySize = std::max( mem + targetFree, (size_t)hx::sgMinimumWorkingMemory);
 
       #if defined(SHOW_FRAGMENTATION) || defined(SHOW_MEM_EVENTS)
-      GCLOG("Target memory %s, using %s\n",  formatBytes(sWorkingMemorySize).c_str(), formatBytes(mem).c_str() );
+      GCLOG("Target memory %s, using %s" HX_LF,  formatBytes(sWorkingMemorySize).c_str(), formatBytes(mem).c_str() );
       #endif
 
       // Large alloc target
@@ -5043,7 +5043,7 @@ public:
       }
 
       #ifdef SHOW_MEM_EVENTS
-      GCLOG("filled=%.2f%% + junk = %.2f%% = %.2f%% -> %s\n",
+      GCLOG("filled=%.2f%% + junk = %.2f%% = %.2f%% -> %s" HX_LF,
             filled_ratio*100, mGenerationalRetainEstimate*100, after_gen*100, sGcMode==gcmFull?"Full":"Generational");
       #endif
 
@@ -5059,14 +5059,14 @@ public:
       mCurrentRowsInUse = mRowsInUse;
 
       #ifdef SHOW_MEM_EVENTS
-      GCLOG("Collect Done\n");
+      GCLOG("Collect Done" HX_LF);
       #endif
 
       #ifdef PROFILE_COLLECT
       STAMP(t6)
       double period = t6-sLastCollect;
       sLastCollect=t6;
-      GCLOG("Collect time total=%.2fms =%.1f%%\n  setup=%.2f\n  %s=%.2f(init=%.2f/roots=%.2f %d+%d/loc=%.2f*%d %d+%d/mark=%.2f %d+%d/fin=%.2f*%d/ids=%.2f)\n  reclaim=%.2f\n  large(%d->%d, recyc %d)=%.2f\n  defrag=%.2f\n",
+      GCLOG("Collect time total=%.2fms =%.1f%%\n  setup=%.2f\n  %s=%.2f(init=%.2f/roots=%.2f %d+%d/loc=%.2f*%d %d+%d/mark=%.2f %d+%d/fin=%.2f*%d/ids=%.2f)\n  reclaim=%.2f\n  large(%d->%d, recyc %d)=%.2f\n  defrag=%.2f" HX_LF,
               (t6-t0)*1000, (t6-t0)*100.0/period, // total %
               (t1-t0)*1000, // sync/setup
               generational ? "mark gen" : "mark", (t2-t1)*1000,
@@ -5085,10 +5085,10 @@ public:
       #endif
 
       #ifdef PROFILE_THREAD_USAGE
-      GCLOG("Thread chunks:%d, wakes=%d\n", sThreadChunkPushCount, sThreadChunkWakes);
+      GCLOG("Thread chunks:%d, wakes=%d" HX_LF, sThreadChunkPushCount, sThreadChunkWakes);
       for(int i=-1;i<MAX_MARK_THREADS;i++)
-        GCLOG(" thread %d] %d + %d\n", i, sThreadMarkCount[i], sThreadArrayMarkCount[i]);
-      GCLOG("Locking spins  : %d\n", sSpinCount);
+        GCLOG(" thread %d] %d + %d" HX_LF, i, sThreadMarkCount[i], sThreadArrayMarkCount[i]);
+      GCLOG("Locking spins  : %d" HX_LF, sSpinCount);
       sSpinCount = 0;
       #endif
 
@@ -5357,7 +5357,7 @@ void MarkConservative(int *inBottom, int *inTop,hx::MarkContext *__inCtx)
    #endif
 
    #ifdef SHOW_MEM_EVENTS
-   GCLOG("Mark conservative %p...%p (%d)\n", inBottom, inTop, (int)(inTop-inBottom) );
+   GCLOG("Mark conservative %p...%p (%d)" HX_LF, inBottom, inTop, (int)(inTop-inBottom) );
    #endif
 
    #ifdef HXCPP_STACK_UP
@@ -5403,14 +5403,14 @@ void MarkConservative(int *inBottom, int *inTop,hx::MarkContext *__inCtx)
                      info->GetAllocType(pos-sizeof(int));
                if ( t==allocObject )
                {
-                  //GCLOG(" Mark object %p (%p)\n", vptr,ptr);
+                  //GCLOG(" Mark object %p (%p)" HX_LF, vptr,ptr);
                   HX_MARK_OBJECT( ((hx::Object *)vptr) );
                   lastPin = vptr;
                   info->pin();
                }
                else if (t==allocString)
                {
-                  // GCLOG(" Mark string %p (%p)\n", vptr,ptr);
+                  // GCLOG(" Mark string %p (%p)" HX_LF, vptr,ptr);
                   HX_MARK_STRING(vptr);
                   lastPin = vptr;
                   info->pin();
@@ -5422,7 +5422,7 @@ void MarkConservative(int *inBottom, int *inTop,hx::MarkContext *__inCtx)
                }
             }
          }
-         // GCLOG(" rejected %p %p %d %p %d=%d\n", ptr, vptr, !((size_t)vptr & 0x03), prev,
+         // GCLOG(" rejected %p %p %d %p %d=%d" HX_LF, ptr, vptr, !((size_t)vptr & 0x03), prev,
          // sGlobalAlloc->GetMemType(vptr) , memUnmanaged );
       }
    }
@@ -5480,7 +5480,7 @@ public:
       #ifdef HXCPP_GC_GENERATIONAL
       if (mOldReferrers)
       {
-         GCLOG("Uncleaned referrers\n");
+         GCLOG("Uncleaned referrers" HX_LF);
       }
 
       if (sGcMode==gcmGenerational)
@@ -5932,7 +5932,7 @@ public:
 
       #ifdef SHOW_MEM_EVENTS
       //int here = 0;
-      //GCLOG("=========== Mark Stack ==================== %p ... %p (%p)\n",mBottomOfStack,mTopOfStack,&here);
+      //GCLOG("=========== Mark Stack ==================== %p ... %p (%p)" HX_LF,mBottomOfStack,mTopOfStack,&here);
       #endif
 
       #ifdef HXCPP_DEBUG
@@ -6103,7 +6103,7 @@ void InitAlloc()
    void **stack = *(void ***)(&tmp);
    sgObject_root = stack[0];
 
-   //GCLOG("__root pointer %p\n", sgObject_root);
+   //GCLOG("__root pointer %p" HX_LF, sgObject_root);
    gMainThreadContext =  new LocalAllocator();
 
    tlsStackContext = gMainThreadContext;
@@ -6160,7 +6160,7 @@ void *InternalNew(int inSize,bool inIsObject)
    #ifdef HXCPP_DEBUG
    if (sgSpamCollects && sgAllocsSinceLastSpam>=sgSpamCollects)
    {
-      //GCLOG("InternalNew spam\n");
+      //GCLOG("InternalNew spam" HX_LF);
       CollectFromThisThread(false);
    }
    sgAllocsSinceLastSpam++;
@@ -6250,7 +6250,7 @@ void *InternalRealloc(void *inData,int inSize, bool inExpand)
    #ifdef HXCPP_DEBUG
    if (sgSpamCollects && sgAllocsSinceLastSpam>=sgSpamCollects)
    {
-      //GCLOG("InternalNew spam\n");
+      //GCLOG("InternalNew spam" HX_LF);
       CollectFromThisThread(false);
    }
    sgAllocsSinceLastSpam++;
@@ -6285,7 +6285,7 @@ void *InternalRealloc(void *inData,int inSize, bool inExpand)
 
 
 #ifdef HXCPP_TELEMETRY
-   //printf(" -- reallocating %018x to %018x, size from %d to %d\n", inData, new_data, s, inSize);
+   //printf(" -- reallocating %018x to %018x, size from %d to %d" HX_LF, inData, new_data, s, inSize);
    __hxt_gc_realloc(inData, new_data, inSize);
 #endif
 
@@ -6393,7 +6393,7 @@ public:
 
       unsigned int s = ObjectSize(obj);
       void *result = InternalCreateConstBuffer(obj,s,false);
-      //printf(" Freeze %d\n", s);
+      //printf(" Freeze %d" HX_LF, s);
       *ioPtr = (hx::Object *)result;
       (*ioPtr)->__Visit(this);
    }
@@ -6404,7 +6404,7 @@ public:
       if (!data || IsConstAlloc(data))
          return;
       unsigned int s = ObjectSize(data);
-      //printf(" Freeze %d\n", s);
+      //printf(" Freeze %d" HX_LF, s);
       void *result = InternalCreateConstBuffer(data,s,false);
       *ioPtr = result;
    }
@@ -6434,7 +6434,7 @@ void __hxcpp_spam_collects(int inEveryNCalls)
    #ifdef HXCPP_DEBUG
    sgSpamCollects = inEveryNCalls;
    #else
-   GCLOG("Spam collects only available on debug versions\n");
+   GCLOG("Spam collects only available on debug versions" HX_LF);
    #endif
 }
 
@@ -6446,7 +6446,7 @@ int __hxcpp_gc_trace(hx::Class inClass,bool inPrint)
        #elif defined(HX_WINRT)
        WINRT_LOG("GC trace not enabled in release build.");
        #else
-       printf("WARNING : GC trace not enabled in release build.\n");
+       printf("WARNING : GC trace not enabled in release build." HX_LF);
        #endif
        return 0;
     #else

--- a/src/hx/libs/std/Process.cpp
+++ b/src/hx/libs/std/Process.cpp
@@ -247,7 +247,7 @@ Dynamic _hx_std_process_run( String cmd, Array<String> vargs, int inShowParam )
       CloseHandle(oread);
       CloseHandle(eread);
       CloseHandle(iwrite);
-      //printf("Cmd %s\n",val_string(cmd));
+      //printf("Cmd %s" HX_LF,val_string(cmd));
       PROCESS_INFORMATION pinf;
       memset(&pinf,0,sizeof(pinf));
       if( !CreateProcessW(NULL,(wchar_t *)name,NULL,NULL,TRUE,0,NULL,NULL,&sinf,&pinf) )
@@ -310,7 +310,7 @@ Dynamic _hx_std_process_run( String cmd, Array<String> vargs, int inShowParam )
       dup2(output[1],1);
       dup2(error[1],2);
       execvp(argv[0],(char* const*)&argv[0]);
-      fprintf(stderr,"Command not found : %S\n",cmd.wchar_str());
+      fprintf(stderr,"Command not found : %S" HX_LF,cmd.wchar_str());
       exit(1);
    }
 


### PR DESCRIPTION
See HaxeFoundation/haxe#8379

 - sets `stdout` and `stderr` to binary mode (prevents `\n` from being output as `\r\n` automatically)
 - adds `HX_LF` macro, set to `\r\n` if `HX_WINDOWS` is defined, `\n` otherwise
 - replaces usages of `\n` with `HX_LF`