### PR TITLE
Revert cppflag -> flag, fixes #833

### DIFF
--- a/toolchain/iphoneos-toolchain.xml
+++ b/toolchain/iphoneos-toolchain.xml
@@ -30,8 +30,8 @@
   <!-- <cppflag value="-fvisibility-inlines-hidden"/> -->
   <pchflag value="-x" />
   <pchflag value="c++-header" />
-  <cppflag value="-stdlib=libstdc++" if="FORCE_LIBGCC" />
-  <cppflag value="-stdlib=libc++" if="HXCPP_CPP11" />
+  <flag value="-stdlib=libstdc++" if="FORCE_LIBGCC" />
+  <flag value="-stdlib=libc++" if="HXCPP_CPP11" />
   <flag value="-g" if="HXCPP_DEBUG_LINK"/>
   <flag value="-O2" unless="debug"/>
   <flag value="-arch"/>

--- a/toolchain/iphonesim-toolchain.xml
+++ b/toolchain/iphonesim-toolchain.xml
@@ -24,8 +24,8 @@
   <!-- <cppflag value="-fvisibility-inlines-hidden"/> -->
   <pchflag value="-x" />
   <pchflag value="c++-header" />
-  <cppflag value="-stdlib=libstdc++" if="FORCE_LIBGCC" />
-  <cppflag value="-stdlib=libc++" if="HXCPP_CPP11" />
+  <flag value="-stdlib=libstdc++" if="FORCE_LIBGCC" />
+  <flag value="-stdlib=libc++" if="HXCPP_CPP11" />
   <flag value="-g" if="HXCPP_DEBUG_LINK"/>
   <flag value="-O2" unless="debug"/>
   <flag value="-fmessage-length=0"/>


### PR DESCRIPTION
See #833, recent change to `cppflag` seems to prevent these flags from being included when compiling, this PR restores them to `flag` which seems to fix compiling on iOS with `-D HXCPP_CPP11`

It's possible the reason cppflag isn't working is because `-D objc` is also set (so .mm files are generated)