### PR TITLE
Make socket poll select function error informative

### DIFF
--- a/src/hx/libs/std/Socket.cpp
+++ b/src/hx/libs/std/Socket.cpp
@@ -1210,7 +1210,8 @@ void _hx_std_socket_poll_events( Dynamic pdata, double timeout )
    if( select(0/* Ignored */, p->fdr->fd_count ? p->outr : 0, p->fdw->fd_count ?p->outw : 0,NULL,tt) == SOCKET_ERROR )
    {
       hx::ExitGCFreeZone();
-      return;
+      hx::Throw( HX_CSTRING("Select error ") + String((int)WSAGetLastError()) );
+      //return;
    }
    hx::ExitGCFreeZone();
 


### PR DESCRIPTION
On windows 64 bit I have random issue when some sockets become not valid. Error 10038. I didn't see this on Win 32 or other platforms yet. It's good to have at least error message when it happens.

For haxe server it can be used as work around fix:

```haxe
	function loopThread( t : ThreadInfos ) {
		if( t.socks.length > 0 ) {
            var available: Array<Socket> = null;
            try {
                available = t.p.poll( t.socks, connectLag );
            }catch(e: Dynamic){
                trace(e); //process error 10038 here
                while(t.socks.length>0) {//stop all thread sockets
                    var s: Socket = t.socks.pop();
                    var infos : ClientInfos<Client> = s.custom;
                    try s.shutdown(true,true) catch( e : Dynamic ) {};
                    doClientDisconnected( s , infos.client );
                }
                return;
            }
```

Error info: (https://docs.microsoft.com/en-us/windows/win32/winsock/windows-sockets-error-codes-2)
WSAENOTSOCK
10038
Socket operation on nonsocket.
    An operation was attempted on something that is not a socket. Either the socket handle parameter did not reference a valid socket, or for select, a member of an fd_set was not valid.