### PR TITLE
Fix typeinfo.h for MS Visual Studio

### DIFF
--- a/include/hxcpp.h
+++ b/include/hxcpp.h
@@ -13,7 +13,11 @@
 #include "hx/HeaderVersion.h"
 
 #ifdef _MSC_VER
-   #include <typeinfo.h>
+   #if _MSC_VER >= 1423
+      #include <typeinfo>
+   #else
+      #include <typeinfo.h>
+   #end
    namespace hx { typedef ::type_info type_info; }
 #else
    #include <typeinfo>

--- a/include/hxcpp.h
+++ b/include/hxcpp.h
@@ -17,7 +17,7 @@
       #include <typeinfo>
    #else
       #include <typeinfo.h>
-   #end
+   #endif
    namespace hx { typedef ::type_info type_info; }
 #else
    #include <typeinfo>


### PR DESCRIPTION
Closes #852 
This is a blindfix because I don't have up-to-date windows environment. I hope CI will tell if this is correct.