### PR TITLE
Add write-barrier on Array set to fix VirtualArray set. For #851

### DIFF
--- a/include/Array.h
+++ b/include/Array.h
@@ -888,7 +888,13 @@ public:
    virtual int __memcmp(const cpp::VirtualArray &a0) { return memcmp(a0); }
    virtual void __qsort(Dynamic inCompare) { this->qsort(inCompare); };
 
-   virtual void set(int inIndex, const cpp::Variant &inValue) { Item(inIndex) = ELEM_(inValue); }
+   virtual void set(int inIndex, const cpp::Variant &inValue) {
+      ELEM_ &elem = Item(inIndex);
+      elem = ELEM_(inValue);
+      if (hx::ContainsPointers<ELEM_>()) {
+         HX_OBJ_WB_GET(this, hx::PointerOf(elem));
+      }
+   }
    virtual void setUnsafe(int inIndex, const cpp::Variant &inValue) {
       ELEM_ &elem = *(ELEM_ *)(mBase + inIndex*sizeof(ELEM_));
       elem = ELEM_(inValue);


### PR DESCRIPTION
Please check those lines thoroughly because I have no idea what I'm doing.
There's set and __SetItem for reasons unknown to me. When setting a value in a VirtualArray that goes directly to set and also adding a write-barrier in there seems to keep objects from escaping a VirtualArray.