### PR TITLE
Fix lost field name when allocating MySQL results

### DIFF
--- a/src/hx/libs/mysql/Mysql.cpp
+++ b/src/hx/libs/mysql/Mysql.cpp
@@ -434,7 +434,7 @@ static Result *alloc_result( Connection *c, MYSQL_RES *r )
       if( strchr(fields[i].name,'(') )
          name = String::createPermanent("???",3); // looks like an inner request : prevent hashing + cashing it
       else
-         name.makePermanent();
+         name = String::createPermanent(fields[i].name, -1);
 
       res->field_names[i] = name;
       res->fields_convs[i] = convert_type(fields[i].type,fields[i].flags,fields[i].length);

--- a/test/std/Test.hx
+++ b/test/std/Test.hx
@@ -102,14 +102,24 @@ class Test
    public static function testDb(cnx:Connection) : Int
    {
       v("connected :" + cnx);
-      cnx.request("
-        CREATE TABLE IF NOT EXISTS User (
-            id INTEGER PRIMARY KEY AUTOINCREMENT, 
-            name TEXT, 
-            age INTEGER, 
-            money DOUBLE
-        )
-");
+      if (cnx.dbName() == "SQLite") {
+        cnx.request("
+          CREATE TABLE IF NOT EXISTS User (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              name TEXT,
+              age INTEGER,
+              money DOUBLE
+          )");
+      } else {
+        cnx.request("
+          CREATE TABLE IF NOT EXISTS User (
+              id INTEGER NOT NULL AUTO_INCREMENT,
+              name TEXT,
+              age INTEGER,
+              money DOUBLE,
+              PRIMARY KEY(id)
+          )");
+      }
       cnx.request("INSERT INTO User (name,age,money) VALUES ('John',32,100.45)");
       cnx.request("INSERT INTO User (name,age,money) VALUES ('Bob',14,4.50)");
 
@@ -238,10 +248,10 @@ class Test
          cnx = Mysql.connect({ 
             host : "localhost",
             port : 3306,
-            user : "root",
-            pass : "",
+            user : "hxcpp",
+            pass : "hxcpp",
             socket : null,
-            database : "MyBase"
+            database : "hxcpp"
         });
       }
       catch(e:Dynamic)
@@ -872,7 +882,7 @@ class Test
          exitCode |= testCompress();
          exitCode |= testRegexp();
          exitCode |= testSqlite();
-         //exitCode |= testMysql();
+         exitCode |= testMysql();
          exitCode |= testRandom();
          exitCode |= testFile();
          exitCode |= testFileSystem();

--- a/tools/azure-pipelines/build.yml
+++ b/tools/azure-pipelines/build.yml
@@ -25,8 +25,11 @@ jobs:
         - script: |
             set -ex
             sudo apt-get update -qqy
-            sudo apt-get install -qqy gcc-multilib g++-multilib
+            sudo apt-get install -qqy gcc-multilib g++-multilib mariadb-server
           displayName: Install dependencies
+        - script: |
+            sudo mysql -u root -e "create database hxcpp; grant all privileges on hxcpp.* to hxcpp@localhost identified by 'hxcpp'; flush privileges;"
+          displayName: Configure MariaDB
       - template: install-neko-snapshot.yaml
         parameters:
           platform: ${{ parameters.platform }}


### PR DESCRIPTION
Fixes: e11b94aae518 ("More utf16 fixes")
Fixes: HaxeFoundation/record-macros#43