### PR TITLE
Handle .length and .nfields on empty result sets

### DIFF
--- a/src/hx/libs/mysql/Mysql.cpp
+++ b/src/hx/libs/mysql/Mysql.cpp
@@ -196,6 +196,9 @@ int  _hx_mysql_result_get_length(Dynamic handle)
 **/
 int  _hx_mysql_result_get_nfields(Dynamic handle)
 {
+   if( handle->__GetType() == vtInt )
+     return 0;
+
    return getResult(handle)->nfields;
 }
 

--- a/src/hx/libs/sqlite/Sqlite.cpp
+++ b/src/hx/libs/sqlite/Sqlite.cpp
@@ -281,7 +281,7 @@ int  _hx_sqlite_result_get_length(Dynamic handle)
 **/
 int     _hx_sqlite_result_get_nfields(Dynamic handle)
 {
-   return getResult(handle,true)->ncols;
+   return getResult(handle,false)->ncols;
 }
 
 /**

--- a/test/std/Test.hx
+++ b/test/std/Test.hx
@@ -120,6 +120,11 @@ class Test
               PRIMARY KEY(id)
           )");
       }
+      var dels = cnx.request("DELETE FROM User");
+      if (dels.nfields != 0)
+         return error("Bad DELETE'd result");
+      v("deleted " + dels.length + " existing rows");
+
       cnx.request("INSERT INTO User (name,age,money) VALUES ('John',32,100.45)");
       cnx.request("INSERT INTO User (name,age,money) VALUES ('Bob',14,4.50)");
 
@@ -227,9 +232,7 @@ class Test
    public static function testSqlite()
    {
       log("Test sqlite");
-      var dbFile = "mybase.db";
-      if (FileSystem.exists(dbFile))
-         FileSystem.deleteFile(dbFile);
+      var dbFile = "hxcpp.db";
       var cnx = Sqlite.open(dbFile);
       if (testDb(cnx)!=0)
          return error("db error");


### PR DESCRIPTION
Forward the number of changed rows for statements other than SELECT.
This prevents an exception to be thrown with SQLite,[1] and also matches
the corresponding Neko documentation[2].

Both hx_sqlite_result_get_length and _hx_mysql_result_get_nfields are
changed to work in these scenarios.  The latter change fixes a different
yet related error with MySQL, where .nfields would raise a similar
exception.

Finally, this also fixes an issue with running the MySQL tests locally,
as the 'hxcpp' test database will be reused and has to be cleared.

[1] Sqlite cnx.request return error! (hxcpp#859)
[2] Neko SQLite API (https://nekovm.org/doc/view/sqlite/)

Fixes: #859