### PR TITLE
Fix "cannot pass object of non-trivial type" errors in clang

### DIFF
--- a/include/Array.h
+++ b/include/Array.h
@@ -415,8 +415,11 @@ template<typename TYPE> inline bool ContainsPointers()
    return TypeContainsPointers( (TYPE *)0 );
 }
 
-inline const void *PointerOf(Dynamic &d) { return d.mPtr; }
+struct TNonGcStringSet;
+
+template<typename T> inline const void *PointerOf(hx::ObjectPtr<T> &o) { return o.mPtr; }
 inline const void *PointerOf(String &s) { return s.raw_ptr(); }
+inline const void *PointerOf(hx::TNonGcStringSet &set) { return 0; }
 inline const void *PointerOf(...) { return 0; }
 
 


### PR DESCRIPTION
clang doesn't like all of the PointerOf calls that might be happening.
There's one of those problems with Arrays at Kode/Kha#1168 and I changed PointerOf(Dynamic) to PointerOf(ObjectPtr) to catch it.
@nadako ran into the same problem with TNonGcStringSet as well so I added that too and just return 0. Not sure about that one though.