### PR TITLE
Add keyValueIterator to arrays

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -10,6 +10,7 @@
 4.0.19
 ------------------------------------------------------------
 
+* Add Array.keyValueIterator
 * General Utf16 string improvements
 * Limit the amount of recursion in toString function
 * Add float32 support to cppia

--- a/include/Array.h
+++ b/include/Array.h
@@ -93,6 +93,34 @@ public:
    Array<FROM> mArray;
 };
 
+// --- ArrayKeyValueIterator -------------------------------------------
+template<typename FROM,typename TO>
+class ArrayKeyValueIterator : public cpp::FastIterator_obj<Dynamic>
+{
+public:
+   HX_IS_INSTANCE_OF enum { _hx_ClassId = hx::clsIdArrayIterator };
+
+   ArrayKeyValueIterator(Array<FROM> inArray) : mArray(inArray), mIdx(0) { }
+
+   bool hasNext()  { return mIdx < mArray->length; }
+
+   inline TO toTo(const Dynamic &inD) { return inD.StaticCast<TO>(); }
+
+   template<typename T>
+   inline TO toTo(T inT) { return inT; }
+
+
+   Dynamic next();
+
+   void __Mark(hx::MarkContext *__inCtx) { HX_MARK_MEMBER_NAME(mArray,"mArray"); }
+   #ifdef HXCPP_VISIT_ALLOCS
+   void __Visit(hx::VisitContext *__inCtx) { HX_VISIT_MEMBER_NAME(mArray,"mArray"); }
+   #endif
+
+   int      mIdx;
+   Array<FROM> mArray;
+};
+
 }
 
 namespace hx
@@ -224,6 +252,7 @@ public:
    virtual Dynamic __copy() = 0;
    virtual Dynamic __insert(const Dynamic &a0,const Dynamic &a1) = 0;
    virtual Dynamic __iterator() = 0;
+   virtual Dynamic __keyValueIterator() = 0;
    virtual Dynamic __join(const Dynamic &a0) = 0;
    virtual Dynamic __pop() = 0;
    virtual Dynamic __push(const Dynamic &a0) = 0;
@@ -260,6 +289,7 @@ public:
    virtual hx::ArrayBase *__copy() = 0;
    virtual void __insert(int inIndex,const Dynamic &a1) = 0;
    virtual Dynamic __iterator() = 0;
+   virtual Dynamic __keyValueIterator() = 0;
    virtual ::String __join(::String a0) = 0;
    virtual Dynamic __pop() = 0;
    virtual int __push(const Dynamic &a0) = 0;
@@ -291,6 +321,7 @@ public:
    Dynamic copy_dyn();
    Dynamic insert_dyn();
    Dynamic iterator_dyn();
+   Dynamic keyValueIterator_dyn();
    Dynamic join_dyn();
    Dynamic pop_dyn();
    Dynamic push_dyn();
@@ -826,9 +857,13 @@ public:
    }
 
    Dynamic iterator() { return new hx::ArrayIterator<ELEM_,ELEM_>(this); }
+   Dynamic keyValueIterator() { return new hx::ArrayKeyValueIterator<ELEM_,ELEM_>(this); }
 
    template<typename TO>
    Dynamic iteratorFast() { return new hx::ArrayIterator<ELEM_,TO>(this); }
+
+   template<typename TO>
+   Dynamic keyValueIteratorFast() { return new hx::ArrayKeyValueIterator<ELEM_,TO>(this); }
    
    virtual hx::ArrayStore getStoreType() const
    {
@@ -849,6 +884,7 @@ public:
    virtual Dynamic __copy() { return copy(); }
    virtual Dynamic __insert(const Dynamic &a0,const Dynamic &a1) { insert(a0,a1); return null(); }
    virtual Dynamic __iterator() { return iterator(); }
+   virtual Dynamic __keyValueIterator() { return keyValueIterator(); }
    virtual Dynamic __join(const Dynamic &a0) { return join(a0); }
    virtual Dynamic __pop() { return pop(); }
    virtual Dynamic __push(const Dynamic &a0) { return push(a0);}
@@ -875,6 +911,7 @@ public:
    virtual hx::ArrayBase *__copy() { return copy().mPtr; }
    virtual void __insert(int inIndex,const Dynamic &a1) { insert(inIndex,a1);}
    virtual Dynamic __iterator() { return iterator(); }
+   virtual Dynamic __keyValueIterator() { return keyValueIterator(); }
    virtual ::String __join(::String a0) { return join(a0); }
    virtual Dynamic __pop() { return pop(); }
    virtual int __push(const Dynamic &a0) { return push(a0);}

--- a/include/cpp/VirtualArray.h
+++ b/include/cpp/VirtualArray.h
@@ -510,6 +510,8 @@ public:
    Dynamic iterator() { checkBase(); return  !base ? getEmptyIterator() :  base->__iterator(); }
    static Dynamic getEmptyIterator();
 
+   Dynamic keyValueIterator() { checkBase(); return  !base ? getEmptyIterator() :  base->__keyValueIterator(); }
+
    bool IsByteArray() const { checkBase(); return store!=hx::arrayEmpty && base->IsByteArray(); }
 
    void zero(Dynamic inFirst, Dynamic inCount) { checkBase(); if (store!=hx::arrayEmpty) base->zero(inFirst,inCount); }
@@ -538,6 +540,7 @@ public:
    Dynamic copy_dyn();
    Dynamic insert_dyn();
    Dynamic iterator_dyn();
+   Dynamic keyValueIterator_dyn();
    Dynamic join_dyn();
    Dynamic pop_dyn();
    Dynamic push_dyn();

--- a/include/hx/Operators.h
+++ b/include/hx/Operators.h
@@ -431,7 +431,16 @@ Dynamic String::keyValueIterator()
    return new hx::StringKeyValueIterator(*this);
 }
 
-
+namespace hx
+{
+template<typename FROM, typename TO> Dynamic hx::ArrayKeyValueIterator<FROM, TO>::next()
+{
+   int p = mIdx++;
+   return
+     hx::AnonStruct2_obj< int,TO >::Create(HX_("key",9f,89,51,00),p,
+                                           HX_("value",71,7f,b8,31), toTo(mArray->__get(p)) );
+}
+}
 
 
 

--- a/src/Array.cpp
+++ b/src/Array.cpp
@@ -615,6 +615,7 @@ DEFINE_ARRAY_FUNC1(return,resize);
 
 DEFINE_ARRAY_FUNC1(return,concat);
 DEFINE_ARRAY_FUNC0(return,iterator);
+DEFINE_ARRAY_FUNC0(return,keyValueIterator);
 DEFINE_ARRAY_FUNC1(return,join);
 DEFINE_ARRAY_FUNC0(return,pop);
 DEFINE_ARRAY_FUNC0(return,copy);
@@ -644,6 +645,7 @@ hx::Val ArrayBase::__Field(const String &inString, hx::PropertyAccess inCallProp
    if (inString==HX_CSTRING("insert")) return insert_dyn();
    if (inString==HX_CSTRING("copy")) return copy_dyn();
    if (inString==HX_CSTRING("iterator")) return iterator_dyn();
+   if (inString==HX_CSTRING("keyValueIterator")) return keyValueIterator_dyn();
    if (inString==HX_CSTRING("join")) return join_dyn();
    if (inString==HX_CSTRING("pop")) return pop_dyn();
    if (inString==HX_CSTRING("push")) return push_dyn();
@@ -681,6 +683,7 @@ static String sArrayFields[] = {
    HX_CSTRING("concat"),
    HX_CSTRING("insert"),
    HX_CSTRING("iterator"),
+   HX_CSTRING("keyValueIterator"),
    HX_CSTRING("join"),
    HX_CSTRING("copy"),
    HX_CSTRING("pop"),
@@ -757,6 +760,17 @@ hx::Val IteratorBase::__Field(const String &inString, hx::PropertyAccess inCallP
 }
 }
 
+namespace hx
+{
+template<typename FROM, typename TO> Dynamic hx::ArrayKeyValueIterator<FROM, TO>::next()
+{
+   int p = mIdx++;
+   return
+     hx::AnonStruct2_obj< int,TO >::Create(HX_("key",9f,89,51,00),p,
+                                           HX_("value",71,7f,b8,31), toTo(mArray->__get(p)) );
+}
+}
+
 
 #ifdef HX_VARRAY_DEFINED
 // -------- VirtualArray -------------------------------------
@@ -804,6 +818,7 @@ Dynamic VirtualArray_obj::func##_dyn()  { return new VirtualArray_##func(this); 
 DEFINE_VARRAY_FUNC1(return,concat);
 DEFINE_VARRAY_FUNC2(,insert);
 DEFINE_VARRAY_FUNC0(return,iterator);
+DEFINE_VARRAY_FUNC0(return,keyValueIterator);
 DEFINE_VARRAY_FUNC1(return,join);
 DEFINE_VARRAY_FUNC0(return,pop);
 DEFINE_VARRAY_FUNC0(return,copy);
@@ -877,6 +892,7 @@ hx::Val VirtualArray_obj::__Field(const String &inString, hx::PropertyAccess inC
    if (inString==HX_CSTRING("insert")) return insert_dyn();
    if (inString==HX_CSTRING("copy")) return copy_dyn();
    if (inString==HX_CSTRING("iterator")) return iterator_dyn();
+   if (inString==HX_CSTRING("keyValueIterator")) return keyValueIterator_dyn();
    if (inString==HX_CSTRING("join")) return join_dyn();
    if (inString==HX_CSTRING("pop")) return pop_dyn();
    if (inString==HX_CSTRING("push")) return push_dyn();

--- a/src/Array.cpp
+++ b/src/Array.cpp
@@ -760,17 +760,6 @@ hx::Val IteratorBase::__Field(const String &inString, hx::PropertyAccess inCallP
 }
 }
 
-namespace hx
-{
-template<typename FROM, typename TO> Dynamic hx::ArrayKeyValueIterator<FROM, TO>::next()
-{
-   int p = mIdx++;
-   return
-     hx::AnonStruct2_obj< int,TO >::Create(HX_("key",9f,89,51,00),p,
-                                           HX_("value",71,7f,b8,31), toTo(mArray->__get(p)) );
-}
-}
-
 
 #ifdef HX_VARRAY_DEFINED
 // -------- VirtualArray -------------------------------------

--- a/src/hx/cppia/ArrayBuiltin.cpp
+++ b/src/hx/cppia/ArrayBuiltin.cpp
@@ -11,6 +11,7 @@ const char *gArrayFuncNames[] =
    "afCopy",
    "afInsert",
    "afIterator",
+   "afKeyValueIterator",
    "afJoin",
    "afPop",
    "afPush",
@@ -41,6 +42,7 @@ int gArrayArgCount[] =
    0, //afCopy,
    2, //afInsert,
    0, //afIterator,
+   0, //afKeyValueIterator,
    1, //afJoin,
    0, //afPop,
    1, //afPush,
@@ -804,6 +806,12 @@ struct ArrayBuiltin : public ArrayBuiltinBase
          BCR_CHECK;
          return thisVal->iterator().mPtr;
       }
+      if (FUNC==afKeyValueIterator)
+      {
+         Array_obj<ELEM> *thisVal = (Array_obj<ELEM>*)thisExpr->runObject(ctx);
+         BCR_CHECK;
+         return thisVal->keyValueIterator().mPtr;
+      }
 
       if (FUNC==afPush || FUNC==afContains || FUNC==afRemove || FUNC==afIndexOf || FUNC==afLastIndexOf)
          return Dynamic(runInt(ctx)).mPtr;
@@ -1146,6 +1154,11 @@ struct ArrayBuiltin : public ArrayBuiltinBase
    static hx::Object *SLJIT_CALL runGetIteratator( Array_obj<ELEM> *inArray )
    {
       return inArray->iterator().mPtr;
+   }
+
+   static hx::Object *SLJIT_CALL runGetKeyValueIteratator( Array_obj<ELEM> *inArray )
+   {
+      return inArray->keyValueIterator().mPtr;
    }
 
    static void SLJIT_CALL runSetSizeExact( Array_obj<ELEM> *inArray, int size )
@@ -1702,10 +1715,17 @@ struct ArrayBuiltin : public ArrayBuiltinBase
 
    
          // Array<ELEM>
-            case afIterator:
+         case afIterator:
             {
                thisExpr->genCode(compiler, sJitTemp0, etObject);
                compiler->callNative( (void *)runGetIteratator, sJitTemp0.as(jtPointer) );
+               compiler->convertReturnReg(etObject, inDest, destType);
+               break;
+            }
+         case afKeyValueIterator:
+            {
+               thisExpr->genCode(compiler, sJitTemp0, etObject);
+               compiler->callNative( (void *)runGetKeyValueIteratator, sJitTemp0.as(jtPointer) );
                compiler->convertReturnReg(etObject, inDest, destType);
                break;
             }
@@ -2108,6 +2128,8 @@ CppiaExpr *createArrayBuiltin(CppiaExpr *src, ArrayType inType, CppiaExpr *inThi
       return TCreateArrayBuiltin<afInsert,NoCrement>(src, inType, inThisExpr, ioExpressions);
    if (field==HX_CSTRING("iterator"))
       return TCreateArrayBuiltin<afIterator,NoCrement>(src, inType, inThisExpr, ioExpressions);
+   if (field==HX_CSTRING("keyValueIterator"))
+      return TCreateArrayBuiltin<afKeyValueIterator,NoCrement>(src, inType, inThisExpr, ioExpressions);
    if (field==HX_CSTRING("join"))
       return TCreateArrayBuiltin<afJoin,NoCrement>(src, inType, inThisExpr, ioExpressions);
    if (field==HX_CSTRING("pop"))

--- a/src/hx/cppia/ArrayVirtual.cpp
+++ b/src/hx/cppia/ArrayVirtual.cpp
@@ -404,6 +404,10 @@ struct ArrayBuiltinAny : public ArrayBuiltinBase
       {
          return thisVal->CALL(iterator)().mPtr;
       }
+      if (FUNC==afKeyValueIterator)
+      {
+         return thisVal->CALL(keyValueIterator)().mPtr;
+      }
 
       return 0;
    }
@@ -914,6 +918,8 @@ CppiaExpr *createArrayAnyBuiltin(CppiaExpr *src, CppiaExpr *inThisExpr, String f
       return TCreateArrayAnyBuiltin<afInsert>(src, inThisExpr, ioExpressions);
    if (field==HX_CSTRING("iterator"))
       return TCreateArrayAnyBuiltin<afIterator>(src, inThisExpr, ioExpressions);
+   if (field==HX_CSTRING("keyValueIterator"))
+      return TCreateArrayAnyBuiltin<afKeyValueIterator>(src, inThisExpr, ioExpressions);
    if (field==HX_CSTRING("join"))
       return TCreateArrayAnyBuiltin<afJoin>(src, inThisExpr, ioExpressions);
    if (field==HX_CSTRING("pop"))

--- a/src/hx/cppia/Cppia.h
+++ b/src/hx/cppia/Cppia.h
@@ -113,6 +113,7 @@ enum ArrayFunc
    afCopy,
    afInsert,
    afIterator,
+   afKeyValueIterator,
    afJoin,
    afPop,
    afPush,


### PR DESCRIPTION
Closes #871 (and unblocks https://github.com/HaxeFoundation/haxe/pull/7422).

I mostly followed the implementation of `iterator` for Arrays. Some things that I am not sure about:

 - `include/hx/Object.h` has a `clsIdArrayIterator` - should there ba a `clsIdArrayKeyValueIterator`? I couldn't figure out what these `clsId` things actually do. For now the KV iterator is also marked as `clsIdArrayIterator`.
 - `src/cppia/Cppia.h`, line 116 - I added `afKeyValueIterator` to the array functions right after the existing `afIterator`. Is there an external dependency on the exact order of these values?
 - `src/cppia/ArrayBuiltin.cpp`, line 1697 - is the conversion to `destType` there just "convert to object"?
 - `include/Array.h` and `src/Array.cpp` - I added a `hx::ArrayKeyValueIterator` class to mirror the `hx::ArrayIterator` one. I could not define the `Dynamic next()` method in the header file because I cannot include `Anon.h` in `Array.h` (cyclic dependency). The implementation of is in `src/Array.cpp`.

The CI failure seems to be related to the last point. I guess `src/Array.cpp` (or its object file) is not being linked wherever things from `src/Array.h` are used?