### PR TITLE
CI fix

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,7 +25,7 @@ stages:
       - template: tools/azure-pipelines/build.yml
         parameters:
           name: Mac
-          vmImage: macOS-10.13
+          vmImage: macOS-10.14
           platform: mac
           arch: 64
       - template: tools/azure-pipelines/build.yml

--- a/tools/azure-pipelines/build.yml
+++ b/tools/azure-pipelines/build.yml
@@ -28,7 +28,7 @@ jobs:
             sudo apt-get install -qqy gcc-multilib g++-multilib mariadb-server
           displayName: Install dependencies
         - script: |
-            sudo systemctl start mariadb
+            sudo systemctl start mysql
             sudo mysql -u root -e "create database hxcpp; grant all privileges on hxcpp.* to hxcpp@localhost identified by 'hxcpp'; flush privileges;"
           displayName: Configure MariaDB
       - template: install-neko-snapshot.yaml

--- a/tools/azure-pipelines/build.yml
+++ b/tools/azure-pipelines/build.yml
@@ -28,6 +28,7 @@ jobs:
             sudo apt-get install -qqy gcc-multilib g++-multilib mariadb-server
           displayName: Install dependencies
         - script: |
+            sudo systemctl start mariadb
             sudo mysql -u root -e "create database hxcpp; grant all privileges on hxcpp.* to hxcpp@localhost identified by 'hxcpp'; flush privileges;"
           displayName: Configure MariaDB
       - template: install-neko-snapshot.yaml


### PR DESCRIPTION
 - bump Mac image to 10.14 (10.13 is no longer supported)
 - start MariaDB before accessing it, to maybe prevent the error:

```
ERROR 2002 (HY000): Can't connect to local MySQL server through socket '/var/run/mysqld/mysqld.sock' (2 "No such file or directory")
```