### PR TITLE
Override toString on hxThreadInfo to returns a string with the thread number

### DIFF
--- a/src/hx/Thread.cpp
+++ b/src/hx/Thread.cpp
@@ -194,6 +194,10 @@ public:
 	{
 		return mDeque->PopFront(inBlocked);
 	}
+	String toString()
+	{
+		return String(GetThreadNumber());
+	}
 	void SetTLS(int inID,Dynamic inVal) {
       mTLS->__SetItem(inID,inVal);
    }


### PR DESCRIPTION
Previously getting the string of a thread would return "Object" but now it returns a string with the thread number.