### PR TITLE
Pass the byte length into sqlite requests instead of char length (Fixes #900)

### DIFF
--- a/include/hxString.h
+++ b/include/hxString.h
@@ -154,8 +154,7 @@ public:
 
    inline const char *&raw_ref() { return __s; }
    inline const char *raw_ptr() const { return __s; }
-   const char *utf8_str(hx::IStringAlloc *inBuffer = 0,bool throwInvalid=true) const;
-   const char *utf8_str_len(hx::IStringAlloc *inBuffer = 0,int *byteLength = 0,bool throwInvalid=true) const;
+   const char *utf8_str(hx::IStringAlloc *inBuffer = 0,bool throwInvalid=true, int *byteLength = 0) const;
    const char *ascii_substr(hx::IStringAlloc *inBuffer,int start, int length) const;
    inline const char *c_str() const { return utf8_str(); }
    inline const char *out_str(hx::IStringAlloc *inBuffer = 0) const { return utf8_str(inBuffer,false); }

--- a/include/hxString.h
+++ b/include/hxString.h
@@ -155,6 +155,7 @@ public:
    inline const char *&raw_ref() { return __s; }
    inline const char *raw_ptr() const { return __s; }
    const char *utf8_str(hx::IStringAlloc *inBuffer = 0,bool throwInvalid=true) const;
+   const char *utf8_str_len(hx::IStringAlloc *inBuffer = 0,int *byteLength = 0,bool throwInvalid=true) const;
    const char *ascii_substr(hx::IStringAlloc *inBuffer,int start, int length) const;
    inline const char *c_str() const { return utf8_str(); }
    inline const char *out_str(hx::IStringAlloc *inBuffer = 0) const { return utf8_str(inBuffer,false); }

--- a/src/String.cpp
+++ b/src/String.cpp
@@ -1575,20 +1575,19 @@ const char * String::utf8_str(hx::IStringAlloc *inBuffer,bool throwInvalid) cons
 
 const char * String::utf8_str_len(hx::IStringAlloc *inBuffer,int *byteLength,bool throwInvalid) const
 {
-#ifdef HX_SMART_STRINGS
+   #ifdef HX_SMART_STRINGS
    if (isUTF16Encoded())
    {
       return TConvertToUTF8(__w, byteLength, inBuffer, throwInvalid);
    }
-   else
+   #endif
    {
-      *byteLength = length;
+      if (byteLength != 0)
+      {
+         *byteLength = length;
+      }
       return __s;
    }
-#else
-   *byteLength = length;
-   return __s;
-#endif
 }
 
 const char *String::ascii_substr(hx::IStringAlloc *inBuffer,int start, int length) const

--- a/src/String.cpp
+++ b/src/String.cpp
@@ -1573,6 +1573,24 @@ const char * String::utf8_str(hx::IStringAlloc *inBuffer,bool throwInvalid) cons
    return __s;
 }
 
+const char * String::utf8_str_len(hx::IStringAlloc *inBuffer,int *byteLength,bool throwInvalid) const
+{
+#ifdef HX_SMART_STRINGS
+   if (isUTF16Encoded())
+   {
+      return TConvertToUTF8(__w, byteLength, inBuffer, throwInvalid);
+   }
+   else
+   {
+      *byteLength = length;
+      return __s;
+   }
+#else
+   *byteLength = length;
+   return __s;
+#endif
+}
+
 const char *String::ascii_substr(hx::IStringAlloc *inBuffer,int start, int length) const
 {
    #ifdef HX_SMART_STRINGS

--- a/src/String.cpp
+++ b/src/String.cpp
@@ -1564,30 +1564,17 @@ void __hxcpp_string_of_bytes(Array<unsigned char> &inBytes,String &outString,int
 
 
 
-const char * String::utf8_str(hx::IStringAlloc *inBuffer,bool throwInvalid) const
+const char * String::utf8_str(hx::IStringAlloc *inBuffer,bool throwInvalid, int *byteLength) const
 {
    #ifdef HX_SMART_STRINGS
    if (isUTF16Encoded())
-      return TConvertToUTF8(__w,0,inBuffer,throwInvalid);
+      return TConvertToUTF8(__w,byteLength,inBuffer,throwInvalid);
    #endif
+   if (byteLength != 0)
+   {
+      *byteLength = length;
+   }
    return __s;
-}
-
-const char * String::utf8_str_len(hx::IStringAlloc *inBuffer,int *byteLength,bool throwInvalid) const
-{
-   #ifdef HX_SMART_STRINGS
-   if (isUTF16Encoded())
-   {
-      return TConvertToUTF8(__w, byteLength, inBuffer, throwInvalid);
-   }
-   #endif
-   {
-      if (byteLength != 0)
-      {
-         *byteLength = length;
-      }
-      return __s;
-   }
 }
 
 const char *String::ascii_substr(hx::IStringAlloc *inBuffer,int start, int length) const

--- a/src/hx/libs/sqlite/Sqlite.cpp
+++ b/src/hx/libs/sqlite/Sqlite.cpp
@@ -234,7 +234,7 @@ Dynamic _hx_sqlite_request(Dynamic handle,String sql)
    database *db = getDatabase(handle);
 
    int byteLength = 0;
-   const char * sqlStr = sql.utf8_str_len(0, &byteLength);
+   const char * sqlStr = sql.utf8_str(0, true, &byteLength);
    sqlite3_stmt *statement = 0;
    const char *tl = 0;
    if( sqlite3_prepare(db->db,sqlStr,byteLength,&statement,&tl) != SQLITE_OK )

--- a/src/hx/libs/sqlite/Sqlite.cpp
+++ b/src/hx/libs/sqlite/Sqlite.cpp
@@ -233,10 +233,11 @@ Dynamic _hx_sqlite_request(Dynamic handle,String sql)
 {
    database *db = getDatabase(handle);
 
-
+   int byteLength = 0;
+   const char * sqlStr = sql.utf8_str_len(0, &byteLength);
    sqlite3_stmt *statement = 0;
    const char *tl = 0;
-   if( sqlite3_prepare(db->db,sql.utf8_str(),sql.length,&statement,&tl) != SQLITE_OK )
+   if( sqlite3_prepare(db->db,sqlStr,byteLength,&statement,&tl) != SQLITE_OK )
    {
       hx::Throw( HX_CSTRING("Sqlite error in ") + sql + HX_CSTRING(" : ") +
                   String(sqlite3_errmsg(db->db) ) );

--- a/test/std/Test.hx
+++ b/test/std/Test.hx
@@ -111,6 +111,7 @@ class Test
               money DOUBLE,
               password BLOB
           )");
+         cnx.request("SELECT '豪鬼' test");
       } else {
         cnx.request("
           CREATE TABLE IF NOT EXISTS UserPwd (


### PR DESCRIPTION
Didn't seem to be an existing way to do it so I added a new utf8 string conversion function which allows retrieving the byte length from `TConvertToUTF8`.

20 will now be passed into the `sqlit3_prepare` function for `SELECT '豪鬼' test` instead of 16. The reduced example from #900 now outputs `{ test => è±ªé¬¼ }` instead of an error being thrown.

Was going to add some tests but there don't seem to be any existing sqlite tests in the main haxe repo or hxcpp.