### PR TITLE
Fix issue with nullpointer when debugging 

### DIFF
--- a/src/hx/Debugger.cpp
+++ b/src/hx/Debugger.cpp
@@ -875,9 +875,11 @@ private:
    // when evaluating breakpoints
    static const char *LookupFileName(String fileName)
    {
+      if (fileName.length == 0) return 0;
+       
       for (const char **ptr = hx::__hxcpp_all_files; *ptr; ptr++)
       {
-         if (fileName.length>0  && !strcmp(*ptr, fileName))
+         if (!strcmp(*ptr, fileName))
             return *ptr;
       }
 

--- a/src/hx/Debugger.cpp
+++ b/src/hx/Debugger.cpp
@@ -877,7 +877,7 @@ private:
    {
       for (const char **ptr = hx::__hxcpp_all_files; *ptr; ptr++)
       {
-         if (!strcmp(*ptr, fileName))
+         if (fileName.length>0  && !strcmp(*ptr, fileName))
             return *ptr;
       }
 


### PR DESCRIPTION
This change solves an issue i have when using VS code debugger, i am not sure why an empty string is passed to lookupFileName , but checking if the string is empty before trying to do a compare solves my nullpointer crash/problem.
