### PR TITLE
Fix for thread issue 910

### DIFF
--- a/src/hx/Thread.cpp
+++ b/src/hx/Thread.cpp
@@ -237,7 +237,6 @@ THREAD_FUNC_TYPE hxThreadFunc( void *inInfo )
    info[0] = (hxThreadInfo *)inInfo;
    info[1] = 0;
 
-	hxThreadInfo *oldinfo = tlsCurrentThread;
 	tlsCurrentThread = info[0];
 
 	hx::SetTopOfStack((int *)&info[1], true);
@@ -259,8 +258,7 @@ THREAD_FUNC_TYPE hxThreadFunc( void *inInfo )
 
 	hx::UnregisterCurrentThread();
 
-	//tlsCurrentThread = 0;
-	tlsCurrentThread = oldinfo;
+	tlsCurrentThread = 0;
 
 	THREAD_FUNC_RET
 }

--- a/src/hx/Thread.cpp
+++ b/src/hx/Thread.cpp
@@ -237,6 +237,7 @@ THREAD_FUNC_TYPE hxThreadFunc( void *inInfo )
    info[0] = (hxThreadInfo *)inInfo;
    info[1] = 0;
 
+	hxThreadInfo *oldinfo = tlsCurrentThread;
 	tlsCurrentThread = info[0];
 
 	hx::SetTopOfStack((int *)&info[1], true);
@@ -258,7 +259,8 @@ THREAD_FUNC_TYPE hxThreadFunc( void *inInfo )
 
 	hx::UnregisterCurrentThread();
 
-	tlsCurrentThread = 0;
+	//tlsCurrentThread = 0;
+	tlsCurrentThread = oldinfo;
 
 	THREAD_FUNC_RET
 }
@@ -302,10 +304,13 @@ static hxThreadInfo *GetCurrentInfo(bool createNew = true)
 	if (!info && createNew)
 	{
 		// Hmm, must be the "main" thead...
-		info = new hxThreadInfo(null(), 0);
-		sMainThreadInfo = info;
-		hx::GCAddRoot(&sMainThreadInfo);
-		tlsCurrentThread = info;
+		if(!sMainThreadInfo) {
+		  info = new hxThreadInfo(null(), 0);
+		  sMainThreadInfo = info;
+		  hx::GCAddRoot(&sMainThreadInfo);
+		  tlsCurrentThread = info;
+                }else
+		  info = (hxThreadInfo *)sMainThreadInfo; 			
 	}
 	return info;
 }

--- a/src/hx/Thread.cpp
+++ b/src/hx/Thread.cpp
@@ -302,13 +302,14 @@ static hxThreadInfo *GetCurrentInfo(bool createNew = true)
 	if (!info && createNew)
 	{
 		// Hmm, must be the "main" thead...
-		if(!sMainThreadInfo) {
-		  info = new hxThreadInfo(null(), 0);
-		  sMainThreadInfo = info;
-		  hx::GCAddRoot(&sMainThreadInfo);
-		  tlsCurrentThread = info;
-                }else
-		  info = (hxThreadInfo *)sMainThreadInfo; 			
+		if (!sMainThreadInfo) {
+			info = new hxThreadInfo(null(), 0);
+			sMainThreadInfo = info;
+			hx::GCAddRoot(&sMainThreadInfo);
+			tlsCurrentThread = info;
+		} else {
+			info = (hxThreadInfo *)sMainThreadInfo; 			
+		}
 	}
 	return info;
 }
@@ -567,5 +568,4 @@ int _hx_atomic_dec(::cpp::Pointer<cpp::AtomicInt> inPtr )
 {
    return HxAtomicDec(inPtr);
 }
-
 


### PR DESCRIPTION
Because I have this issue on haxe 3 too, needed to look what went wrong here https://github.com/HaxeFoundation/hxcpp/issues/910
I think Thread current can return wrong thread. I found fix that helping in my case. Not sure if this actually fixing in all cases. For example when thread run from thread, etc.
Problem can be related to declaring tlsCurrentThread as global var.