### PR TITLE
HXCPP_GC_GENERATIONAL fixes and improvements

### DIFF
--- a/include/Array.h
+++ b/include/Array.h
@@ -450,6 +450,8 @@ template<typename TYPE> inline bool ContainsPointers()
 
 inline const void *PointerOf(Dynamic &d) { return d.mPtr; }
 inline const void *PointerOf(String &s) { return s.raw_ptr(); }
+template<typename T>
+inline const void *PointerOf(::Array<T> &a) { return a.mPtr; }
 inline const void *PointerOf(...) { return 0; }
 
 

--- a/include/hx/CFFINekoLoader.h
+++ b/include/hx/CFFINekoLoader.h
@@ -230,25 +230,26 @@ int api_val_strlen(neko_value  arg1)
 	return 0;
 }
 void api_buffer_set_size(neko_buffer inBuffer,int inLen) { 
-   NEKO_NOT_IMPLEMENTED("api_buffer_set_size");
+  // NEKO_NOT_IMPLEMENTED("api_buffer_set_size");
 }
 
 
 void api_buffer_append_char(neko_buffer inBuffer,int inChar)
 {
-   NEKO_NOT_IMPLEMENTED("api_buffer_append_char");
+	char buf[2] = { (char)inChar, '\0' };
+	dyn_buffer_append_sub(inBuffer,buf,1);
 }
+
+
 
 
 
 // Byte arrays - use strings
-neko_buffer api_val_to_buffer(neko_value  arg1)
-{
-   return (neko_buffer)api_val_string(arg1);
-}
-bool api_val_is_buffer(neko_value  arg1) { return neko_val_is_string(arg1); } 
-int api_buffer_size(neko_buffer inBuffer) { return neko_val_strlen((neko_value)inBuffer); }
-char * api_buffer_data(neko_buffer inBuffer) { return (char *)api_val_string((neko_value)inBuffer); }
+// Byte arrays - not used on neko
+neko_buffer api_val_to_buffer(neko_value  arg1) { return 0; }
+bool api_val_is_buffer(neko_value  arg1) { return false; } 
+int api_buffer_size(neko_buffer inBuffer) { return 0; }
+char * api_buffer_data(neko_buffer inBuffer) { return 0; }
 
 char * api_val_dup_string(neko_value inVal)
 {
@@ -263,24 +264,19 @@ char * api_val_dup_string(neko_value inVal)
 neko_value api_alloc_string_len(const char *inStr,int inLen)
 {
 	if (gNeko2HaxeString)
-   {
-      if (!inStr)
-		   return dyn_val_call1(*gNeko2HaxeString,api_alloc_raw_string(inLen));
 		return dyn_val_call1(*gNeko2HaxeString,dyn_copy_string(inStr,inLen));
-   }
-   if (!inStr)
-		inStr = dyn_alloc_private(inLen);
    return dyn_copy_string(inStr,inLen);
 }
 
+
 neko_buffer api_alloc_buffer_len(int inLen)
 {
-	neko_value str=api_alloc_string_len(0,inLen+1);
-	char *s=(char *)api_val_string(str);
-	memset(s,0,inLen+1);
-	return (neko_buffer)str;
+	char *s=dyn_alloc_private(inLen+1);
+	memset(s,' ',inLen);
+	s[inLen] = 0;
+	neko_buffer b = dyn_alloc_buffer(s);
+	return b;
 }
-
 
 
 neko_value api_alloc_wstring_len(const wchar_t *inStr,int inLen)
@@ -545,7 +541,6 @@ void api_gc_change_managed_memory(int,const char *)
 }
 
 bool api_gc_try_blocking() { return false; }
-bool api_gc_try_unblocking() { return false; }
 
 #define IMPLEMENT_HERE(x) if (!strcmp(inName,#x)) return (void *)api_##x;
 #define IGNORE_API(x) if (!strcmp(inName,#x)) return (void *)api_empty;
@@ -570,7 +565,6 @@ void *DynamicNekoLoader(const char *inName)
    IMPLEMENT_HERE(alloc_root)
    IMPLEMENT_HERE(val_gc)
    IMPLEMENT_HERE(gc_try_blocking)
-   IMPLEMENT_HERE(gc_try_unblocking)
 
    IMPLEMENT_HERE(create_abstract)
    IMPLEMENT_HERE(free_abstract)

--- a/include/hx/Object.h
+++ b/include/hx/Object.h
@@ -166,11 +166,11 @@ public:
          if (!alloc)
             BadImmixAlloc();
          #endif
-
+         
          return ImmixAllocator::alloc(alloc, inSize, inContainer, inName);
 
       #else // Not HX_USE_INLINE_IMMIX_OPERATOR_NEW ...
-
+            
          void *result = hx::InternalNew(inSize,inContainer);
 
          #ifdef HXCPP_TELEMETRY

--- a/include/hx/QuickVecMinMax.h
+++ b/include/hx/QuickVecMinMax.h
@@ -1,0 +1,164 @@
+#ifndef HX_QUICKVECMINMAX_INCLUDED
+#define HX_QUICKVECMINMAX_INCLUDED
+
+#include <stdlib.h>
+#include <algorithm>
+
+namespace hx
+{
+
+template<typename T>
+struct QuickVecMinMax
+{
+   int mAlloc;
+   int mSize;
+   T *mPtr;
+   T mMin;
+   T mMax;
+
+   QuickVecMinMax() : mPtr(0), mAlloc(0), mSize(0), mMin(0), mMax(0) { } 
+   ~QuickVecMinMax()
+   {
+      if (mPtr)
+         free(mPtr);
+   }
+
+   inline void push(const T &inV)
+   {
+      if (mSize+1>mAlloc)
+      {
+         mAlloc = 10 + (mSize*3/2);
+         mPtr = (T *)realloc(mPtr,sizeof(T)*mAlloc);
+      }
+      mPtr[mSize]=inV;
+      if (mMin == 0 || inV < mMin) mMin = inV;
+      if (mMax == 0 || inV > mMax) mMax = inV;
+      mSize++;
+   }
+   
+   void swap(QuickVecMinMax<T> &inOther)
+   {
+      std::swap(mAlloc, inOther.mAlloc);
+      std::swap(mSize, inOther.mSize);
+      std::swap(mPtr, inOther.mPtr);
+   }
+   T *setSize(int inSize)
+   {
+      if (inSize>mAlloc)
+      {
+         mAlloc = inSize;
+         mPtr = (T *)realloc(mPtr,sizeof(T)*mAlloc);
+      }
+      mSize = inSize;
+      return mPtr;
+   }
+   // Can push this many without realloc
+   bool hasExtraCapacity(int inN)
+   {
+      return mSize+inN<=mAlloc;
+   }
+
+   bool safeReserveExtra(int inN)
+   {
+      int want = mSize + inN;
+      if (want>mAlloc)
+      {
+         int wantAlloc = 10 + (mSize*3/2);
+         if (wantAlloc<want)
+            wantAlloc = want;
+         T *newBuffer = (T *)malloc( sizeof(T)*wantAlloc );
+         if (!newBuffer)
+            return false;
+         mAlloc = wantAlloc;
+         if (mPtr)
+         {
+            memcpy(newBuffer, mPtr, mSize*sizeof(T));
+            free(mPtr);
+         }
+         mPtr = newBuffer;
+      }
+      return true;
+   }
+   inline void pop_back() { --mSize; }
+   inline T &back() { return mPtr[mSize-1]; }
+   inline T pop()
+   {
+      return mPtr[--mSize];
+   }
+   inline void qerase(int inPos)
+   {
+      --mSize;
+      if (mPtr[inPos] == mMin) mMin++;
+      if (mPtr[inPos] == mMax) mMax--;
+      mPtr[inPos] = mPtr[mSize];
+      
+   }
+   
+   inline void set_min_max()
+   {   
+   	  mMin = 0;
+   	  mMax = 0;
+   	  
+   	  for(int i=0;i<mSize;i++)
+      {
+      	if (mMin == 0 || mPtr[i] < mMin) mMin = mPtr[i];
+      	if (mMax == 0 || mPtr[i] > mMax) mMax = mPtr[i];
+      }
+
+   }
+      
+   inline bool has(T inVal)
+   {   
+   	  if (inVal >= mMin && inVal <= mMax)
+   	  	for(int i=0;i<mSize;i++)
+         	if (mPtr[i]==inVal)
+           	 return true;
+
+      return false;
+   }
+   
+   inline void erase(int inPos)
+   {
+      --mSize;
+      if (mSize>inPos)
+         memmove(mPtr+inPos, mPtr+inPos+1, (mSize-inPos)*sizeof(T));
+   }
+   void zero() { memset(mPtr,0,mSize*sizeof(T) ); }
+
+   inline bool qerase_val(T inVal)
+   {
+      for(int i=0;i<mSize;i++)
+         if (mPtr[i]==inVal)
+         {
+            --mSize;
+            mPtr[i] = mPtr[mSize];
+            return true;
+         }
+      return false;
+   }
+
+   inline bool some_left() { return mSize; }
+   inline bool empty() const { return !mSize; }
+   inline void clear() { mSize = 0; }
+   inline int next()
+   {
+      if (mSize+1>=mAlloc)
+      {
+         mAlloc = 10 + (mSize*3/2);
+         mPtr = (T *)realloc(mPtr,sizeof(T)*mAlloc);
+      }
+      return mSize++;
+   }
+   inline int size() const { return mSize; }
+   inline T &operator[](int inIndex) { return mPtr[inIndex]; }
+   inline const T &operator[](int inIndex) const { return mPtr[inIndex]; }
+
+private:
+   QuickVecMinMax(const QuickVecMinMax<T> &);
+   void operator =(const QuickVecMinMax<T> &);
+};
+
+
+} // end namespace hx
+
+#endif


### PR DESCRIPTION
As requested, i've created a pull request with my changes. 

I've noticed that 0 bytes allocations were going into the nursery, I have mainly fixed this issue that was causing random crashes. Plus, i've implemented the possibility to decrease the line length (i've set to 6 bits per default). I've disabled the large recycle pool and created a pool of 5 large list to mainly collect only the less used ones.

**If you are using lime, you have to rebuild it to match the new inline functions**