### PR TITLE
Fixing issue with sockets on windows 

### DIFF
--- a/src/hx/libs/std/Socket.cpp
+++ b/src/hx/libs/std/Socket.cpp
@@ -109,11 +109,16 @@ SOCKET val_sock(Dynamic inValue)
 
 static void block_error()
 {
-   hx::ExitGCFreeZone();
+
 #ifdef NEKO_WINDOWS
    int err = WSAGetLastError();
+   // call ExitGCFreeZone after WSAGetLastError, WSAGetLastError is just an alias for GetLastError and
+   // calling ExitGCFreeZone will on some cases clear the lastError code.
+   hx::ExitGCFreeZone();
    if( err == WSAEWOULDBLOCK || err == WSAEALREADY )
+
 #else
+   hx::ExitGCFreeZone();
    if( errno == EAGAIN || errno == EWOULDBLOCK || errno == EINPROGRESS || errno == EALREADY )
 #endif
       hx::Throw(HX_CSTRING("Blocking"));
@@ -562,7 +567,7 @@ void _hx_std_socket_connect( Dynamic o, int host, int port )
    *(int*)&addr.sin_addr.s_addr = host;
 
    hx::EnterGCFreeZone();
-   if( connect(val_sock(o),(struct sockaddr*)&addr,sizeof(addr)) != 0 )
+   if( connect(val_sock(o),(struct sockaddr*)&addr,sizeof(addr)) == SOCKET_ERROR )
    {
       // This will throw a "Blocking" exception if the "error" was because
       // it's a non-blocking socket with connection in progress, otherwise


### PR DESCRIPTION
This pull-request will fix an issue with sockets on windows where sockets would not work properly when making debug builds.
The windows compiler for some reason  "fixes" this issue when making release builds  but  the code is still "wrong" in the sense that  logic is executed between the socket error occurs and when the call to get the error code happens.


Debug builds `WSAGetLastError` would always return 0 
https://stackoverflow.com/questions/25438935/winsock-recv-call-returns-1-but-wsagetlasterror-is-set-to-0