### PR TITLE
Adding proper implementation for api_buffer_val for Neko

### DIFF
--- a/include/hx/CFFINekoLoader.h
+++ b/include/hx/CFFINekoLoader.h
@@ -445,6 +445,17 @@ void api_free_abstract(neko_value inAbstract)
 
 neko_value api_buffer_val(neko_buffer arg1)
 {
+        if (neko_val_is_string(arg1))
+            return (neko_value)arg1;
+
+        if (neko_val_is_object(arg1))
+        {
+            neko_value s = dyn_val_field((neko_value)arg1,__s_id);
+            if (neko_val_is_string(s))
+                return (neko_value)(s);
+        }
+
+
    return api_alloc_null();
 }
 


### PR DESCRIPTION
Lime & openFL has code that detects if the platform its compiled for support buffers.
After https://github.com/HaxeFoundation/hxcpp/commit/e707d2e0eb040f8e464b00e317ad6a42f560097d  this code would detect that Neko had support for Buffers and attempt to use these APIs, however it would fail as not all the API was implemented or were incomplete.

This commit fixes the implementation of `api_buffer_val` so that til will return the actual buffer (from string or object) instead of a null vaule. There are still other buffer APIs that are missing (`api_buffer_set_size` &`api_buffer_append_char` ) but lime/openFl  does not rely on these so i have not looked into how these should be implemented.

The only thing i am a bit unsertain about is if it should `return api_alloc_null();` or  `return 0;` in the case where the buffer is neither a string nor an object. i see `api_empty` returns 0, while the original implementation  returned `api_alloc_null();` @hughsando do you know what is the correct value to return here ?