### PR TITLE
Set T* call to 0 when initialized from null

### DIFF
--- a/include/cpp/Pointer.h
+++ b/include/cpp/Pointer.h
@@ -426,7 +426,7 @@ public:
    inline Function( ) { }
    inline Function( const Function &inRHS ) : call(inRHS.call) {  }
    inline Function( const Dynamic &inRHS) { call = inRHS==null()?0: (T*)inRHS->__GetHandle(); }
-   inline Function( const null &inRHS ) { }
+   inline Function( const null &inRHS ) { call = 0; }
    inline Function( T *inValue ) : call((T*)(inValue)) { }
    //inline Function( T *inValue ) : call(inValue) { }
    inline Function( AutoCast inValue ) : call( (T*)inValue.value) { }


### PR DESCRIPTION
Fixes #941

Adds missing `call = 0` when initializing from null (otherwise call is uninitialized and contains junk data)

Before:
```haxe
var callable: Callable<() -> Void> = null;
trace('callable should be null: $callable');
// traces "callable should be null: Pointer(0x10d9f6800)" :[

if (callable != null) callable(); // crash
```

After:
```haxe
var callable: Callable<() -> Void> = null;
trace('callable should be null: $callable');
// traces "callable should be null: null" 👍 
```

This was causing a crash where we were trying to check a Callable was not null before calling