### PR TITLE
GENERATIONAL: Fixes invalid pointers in MarkConservative

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ hxcpp.n
 *.ilk
 
 .vscode
+*.bak

--- a/include/hx/CFFILoader.h
+++ b/include/hx/CFFILoader.h
@@ -74,6 +74,7 @@ using namespace std;
 typedef void *(*ResolveProc)(const char *inName);
 static ResolveProc sResolveProc = 0;
 
+#ifndef STATIC_LINK
 extern "C" {
 EXPORT void hx_set_loader(ResolveProc inProc)
 {
@@ -83,7 +84,7 @@ EXPORT void hx_set_loader(ResolveProc inProc)
    sResolveProc = inProc;
 }
 }
-
+#endif
 
 
 #ifdef HXCPP_JS_PRIME // { js prime

--- a/include/hx/CFFINekoLoader.h
+++ b/include/hx/CFFINekoLoader.h
@@ -230,13 +230,13 @@ int api_val_strlen(neko_value  arg1)
 	return 0;
 }
 void api_buffer_set_size(neko_buffer inBuffer,int inLen) { 
-   NEKO_NOT_IMPLEMENTED("api_buffer_set_size");
+   //NEKO_NOT_IMPLEMENTED("api_buffer_set_size");
 }
 
 
 void api_buffer_append_char(neko_buffer inBuffer,int inChar)
 {
-   NEKO_NOT_IMPLEMENTED("api_buffer_append_char");
+   //NEKO_NOT_IMPLEMENTED("api_buffer_append_char");
 }
 
 

--- a/include/hx/GC.h.bak
+++ b/include/hx/GC.h.bak
@@ -1,0 +1,595 @@
+#ifndef HX_GC_H
+#define HX_GC_H
+
+#include <hx/Tls.h>
+#include <stdio.h>
+
+// Under the current scheme (as defined by HX_HCSTRING/HX_CSTRING in hxcpp.h)
+//  each constant string data is prepended with a 4-byte header that says the string
+//  is constant (ie, not part of GC) and whether there is(not) a pre-computed hash at
+//  the end of the data.
+// When HX_SMART_STRINGS is active, a bit says whether it is char16_t encoded.
+
+#define HX_GC_CONST_ALLOC_BIT  0x80000000
+#define HX_GC_CONST_ALLOC_MARK_BIT  0x80
+
+
+
+
+// Tell compiler the extra functions are supported
+#define HXCPP_GC_FUNCTIONS_1
+
+// Function called by the haxe code...
+
+#ifdef HXCPP_TELEMETRY
+extern void __hxt_gc_new(hx::StackContext *inStack, void* obj, int inSize, const char *inName);
+#endif
+
+
+// Helpers for debugging code
+HXCPP_EXTERN_CLASS_ATTRIBUTES void  __hxcpp_reachable(hx::Object *inKeep);
+HXCPP_EXTERN_CLASS_ATTRIBUTES void  __hxcpp_enable(bool inEnable);
+HXCPP_EXTERN_CLASS_ATTRIBUTES void  __hxcpp_collect(bool inMajor=true);
+HXCPP_EXTERN_CLASS_ATTRIBUTES void   __hxcpp_gc_compact();
+HXCPP_EXTERN_CLASS_ATTRIBUTES int   __hxcpp_gc_trace(hx::Class inClass, bool inPrint);
+HXCPP_EXTERN_CLASS_ATTRIBUTES int   __hxcpp_gc_used_bytes();
+HXCPP_EXTERN_CLASS_ATTRIBUTES double __hxcpp_gc_mem_info(int inWhat);
+HXCPP_EXTERN_CLASS_ATTRIBUTES void  __hxcpp_enter_gc_free_zone();
+HXCPP_EXTERN_CLASS_ATTRIBUTES void  __hxcpp_exit_gc_free_zone();
+HXCPP_EXTERN_CLASS_ATTRIBUTES void  __hxcpp_gc_safe_point();
+HXCPP_EXTERN_CLASS_ATTRIBUTES void  __hxcpp_spam_collects(int inEveryNCalls);
+HXCPP_EXTERN_CLASS_ATTRIBUTES void  __hxcpp_set_minimum_working_memory(int inBytes);
+HXCPP_EXTERN_CLASS_ATTRIBUTES void  __hxcpp_set_minimum_free_space(int inBytes);
+HXCPP_EXTERN_CLASS_ATTRIBUTES void  __hxcpp_set_target_free_space_percentage(int inPercentage);
+HXCPP_EXTERN_CLASS_ATTRIBUTES bool __hxcpp_is_const_string(const ::String &inString);
+HXCPP_EXTERN_CLASS_ATTRIBUTES Dynamic _hx_gc_freeze(Dynamic inObject);
+
+typedef void (hx::Object::*_hx_member_finalizer)(void);
+HXCPP_EXTERN_CLASS_ATTRIBUTES void __hxcpp_add_member_finalizer(hx::Object *inObject, _hx_member_finalizer, bool inPin);
+
+typedef void (*_hx_alloc_finalizer)(void *inPtr);
+HXCPP_EXTERN_CLASS_ATTRIBUTES void __hxcpp_add_alloc_finalizer(void *inAlloc, _hx_alloc_finalizer, bool inPin);
+
+template<typename T>
+inline void _hx_add_finalizable( hx::ObjectPtr<T> inObj, bool inPin)
+{
+  _hx_member_finalizer finalizer = (_hx_member_finalizer)&T::finalize;
+  __hxcpp_add_member_finalizer(inObj.mPtr, finalizer, inPin);
+}
+template<typename T>
+inline void _hx_add_finalizable( T *inObj, bool inPin)
+{
+  _hx_member_finalizer finalizer = (_hx_member_finalizer)&T::finalize;
+  __hxcpp_add_member_finalizer(inObj, finalizer, inPin);
+}
+
+
+
+template<typename T>
+T _hx_allocate_extended(int inExtra)
+{
+   typedef typename T::Obj Obj;
+   Obj *obj = new (inExtra) Obj();
+   return obj;
+}
+
+/*
+template<typename T>
+inline void _hx_allocate_extended( hx::ObjectPtr<T> inObj, bool inPin)
+*/
+
+
+// Finalizers from haxe code...
+void  __hxcpp_gc_do_not_kill(Dynamic inObj);
+
+// This is the correctly typed version - no change of getting function proto wrong
+void _hx_set_finalizer(Dynamic inObj, void (*inFunc)(Dynamic) );
+
+void  __hxcpp_set_finalizer(Dynamic inObj, void *inFunction);
+hx::Object *__hxcpp_get_next_zombie();
+
+#ifdef HXCPP_TELEMETRY
+void __hxcpp_set_hxt_finalizer(void* inObj, void *inFunc);
+#endif
+
+hx::Object *__hxcpp_weak_ref_create(Dynamic inObject);
+hx::Object *__hxcpp_weak_ref_get(Dynamic inRef);
+
+
+unsigned int __hxcpp_obj_hash(Dynamic inObj);
+int __hxcpp_obj_id(Dynamic inObj);
+hx::Object *__hxcpp_id_obj(int);
+
+
+
+
+
+
+namespace hx
+{
+// Generic allocation routine.
+// If inSize is small (<4k) it will be allocated from the immix pool.
+// Larger, and it will be allocated from a separate memory pool
+// inIsObject specifies whether "__Mark"  should be called on the resulting object
+void *InternalNew(int inSize,bool inIsObject);
+
+// Used internall - realloc array data
+void *InternalRealloc(int inFromSize, void *inData,int inSize,bool inAllowExpansion=false);
+
+void InternalReleaseMem(void *inMem);
+
+unsigned int ObjectSizeSafe(void *inData);
+
+// Const buffers are allocated outside the GC system, and do not require marking
+// String buffers can optionally have a pre-computed hash appended with this method
+void *InternalCreateConstBuffer(const void *inData,int inSize,bool inAddStringHash=false);
+
+// Called after collection by an unspecified thread
+typedef void (*finalizer)(hx::Object *v);
+
+// Used internally by the runtime.
+// The constructor will add this object to the internal list of finalizers.
+// If the parent object is not marked by the end of the collect, the finalizer will trigger.
+struct InternalFinalizer
+{
+   InternalFinalizer(hx::Object *inObj, finalizer inFinalizer=0);
+
+   #ifdef HXCPP_VISIT_ALLOCS
+   void Visit(VisitContext *__inCtx);
+   #endif
+   void Detach();
+
+   bool      mValid;
+   finalizer mFinalizer;
+   hx::Object  *mObject;
+};
+
+// Attach a finalizer to any object allocation.  This can be called from haxe code, but be aware that
+// you can't make any GC calls from the finalizer.
+void  GCSetFinalizer( hx::Object *, hx::finalizer f );
+
+// If another thread wants to do a collect, it will signal this variable.
+// This automatically gets checked when you call "new", but if you are in long-running
+//  loop with no new call, you might starve another thread if you to not check this.
+//  0xffffffff = pause requested
+extern int gPauseForCollect;
+
+
+// Minimum total memory - used + buffer for new objects
+extern int sgMinimumWorkingMemory;
+
+// Minimum free memory - not counting used memory
+extern int sgMinimumFreeSpace;
+
+// Also ensure that the free memory is larger than this amount of used memory
+extern int sgTargetFreeSpacePercentage;
+
+
+extern HXCPP_EXTERN_CLASS_ATTRIBUTES int gByteMarkID;
+
+// Call in response to a gPauseForCollect. Normally, this is done for you in "new"
+void PauseForCollect();
+
+
+// Used by WeakHash to work out if it needs to dispose its keys
+bool IsWeakRefValid(hx::Object *inPtr);
+bool IsWeakRefValid(const HX_CHAR *inPtr);
+
+// Used by CFFI to scan a block of memory for GC Pointers. May picks up random crap
+//  that points to real, active objects.
+void MarkConservative(int *inBottom, int *inTop,hx::MarkContext *__inCtx);
+
+
+// Create/Remove a root.
+// All statics are explicitly registered - this saves adding the whole data segment
+//  to the collection list.
+// It takes a pointer-pointer so it can move the contents, and the caller can change the contents
+void GCAddRoot(hx::Object **inRoot);
+void GCRemoveRoot(hx::Object **inRoot);
+
+
+// This is used internally in hxcpp
+// It calls InternalNew, and takes care of null-terminating the result
+char *NewString(int inLen);
+
+// The concept of 'private' is from the old conservative Gc method.
+// Now with explicit marking, these functions do the same thing, which is
+//  to allocate some GC memory and optionally copy the 'inData' into those bytes
+HXCPP_EXTERN_CLASS_ATTRIBUTES void *NewGCBytes(void *inData,int inSize);
+HXCPP_EXTERN_CLASS_ATTRIBUTES void *NewGCPrivate(void *inData,int inSize);
+
+// Force a collect from the calling thread
+// Only one thread should call this at a time
+int InternalCollect(bool inMajor,bool inCompact);
+
+
+// Disable the garbage collector.  It will try to increase its internal buffers to honour extra requests.
+//  If it runs out of memory, it will actually try to do a collect.
+void InternalEnableGC(bool inEnable);
+
+// Record that fact that external memory has been allocated and associated with a haxe object
+//  eg. BitmapData.  This will help the collector know when to collect
+void GCChangeManagedMemory(int inDelta, const char *inWhy=0);
+
+// Haxe threads can center GC free zones, where they can't make GC allocation calls, and should not mess with GC memory.
+// This means that they do not need to pause while the GC collections happen, and other threads will not
+//  wait for them to "check in" before collecting.  The standard runtime makes these calls around OS calls, such as "Sleep"
+void EnterGCFreeZone();
+void ExitGCFreeZone();
+// retuns true if ExitGCFreeZone should be called
+bool TryGCFreeZone();
+// retuns true if ExitGCFreeZone was called
+bool TryExitGCFreeZone();
+
+class HXCPP_EXTERN_CLASS_ATTRIBUTES AutoGCFreeZone
+{
+public:
+	AutoGCFreeZone() : locked(true) { EnterGCFreeZone(); }
+	~AutoGCFreeZone() { if (locked) ExitGCFreeZone(); }
+
+	void close() { if (locked) ExitGCFreeZone(); locked = false; }
+
+	bool locked;
+};
+
+
+// Defined in Class.cpp, these function is called from the Gc to start the marking/visiting
+void MarkClassStatics(hx::MarkContext *__inCtx);
+#ifdef HXCPP_VISIT_ALLOCS
+void VisitClassStatics(hx::VisitContext *__inCtx);
+#endif
+
+
+// Called by haxe/application code to mark allocations.
+//  "Object" allocs will recursively call __Mark
+inline void MarkAlloc(void *inPtr ,hx::MarkContext *__inCtx);
+inline void MarkObjectAlloc(hx::Object *inPtr ,hx::MarkContext *__inCtx);
+
+// Implemented differently for efficiency
+void MarkObjectArray(hx::Object **inPtr, int inLength, hx::MarkContext *__inCtx);
+void MarkStringArray(String *inPtr, int inLength, hx::MarkContext *__inCtx);
+
+// Provide extra debug info to the marking routines
+#ifdef HXCPP_DEBUG
+HXCPP_EXTERN_CLASS_ATTRIBUTES void MarkSetMember(const char *inName ,hx::MarkContext *__inCtx);
+HXCPP_EXTERN_CLASS_ATTRIBUTES void MarkPushClass(const char *inName ,hx::MarkContext *__inCtx);
+HXCPP_EXTERN_CLASS_ATTRIBUTES void MarkPopClass(hx::MarkContext *__inCtx);
+#endif
+
+
+// Used by runtime if it is being paranoid about pointers.  It checks that the pointer is real and alive at last collect.
+void GCCheckPointer(void *);
+void GCOnNewPointer(void *);
+
+
+// Called internally before and GC operations
+void CommonInitAlloc();
+
+
+// Threading ...
+void RegisterNewThread(void *inTopOfStack);
+void RegisterCurrentThread(void *inTopOfStack);
+void UnregisterCurrentThread();
+void GCPrepareMultiThreaded();
+
+
+
+
+} // end namespace hx
+
+
+// Inline code tied to the immix implementation
+
+namespace hx
+{
+
+#define HX_USE_INLINE_IMMIX_OPERATOR_NEW
+
+//#define HX_STACK_CTX ::hx::ImmixAllocator *_hx_stack_ctx =  hx::gMultiThreadMode ? hx::tlsImmixAllocator : hx::gMainThreadAlloc;
+
+
+// Each line ast 128 bytes (2^7)
+#if defined(HXCPP_GC_SHORT_ROWS)
+// Each line ast 64 bytes (2^6)
+#define IMMIX_LINE_BITS    6
+// This is necessary to allow IMMIX_LINE_BITS < 7
+#define IMMIX_LOOP_COUNT_ROWS  
+#else
+// Each line ast 128 bytes (2^7)
+#define IMMIX_LINE_BITS    7
+#endif
+
+#define HX_GC_REMEMBERED          0x40
+
+// The size info is stored in the header 8 bits to the right
+#define IMMIX_ALLOC_SIZE_SHIFT  6
+
+// Indicates that __Mark must be called recursively
+#define IMMIX_ALLOC_IS_CONTAINER   0x00800000
+// String is char16_t type
+#define HX_GC_STRING_CHAR16_T      0x00200000
+// String has hash data at end
+#define HX_GC_STRING_HASH          0x00100000
+
+#define HX_GC_STRING_HASH_BIT      0x10
+
+#ifdef HXCPP_BIG_ENDIAN
+   #define HX_GC_STRING_HASH_OFFSET        -3
+   #define HX_GC_CONST_ALLOC_MARK_OFFSET   -4
+   #define HX_ENDIAN_MARK_ID_BYTE        -4
+#else
+   #define HX_GC_STRING_HASH_OFFSET        -2
+   #define HX_GC_CONST_ALLOC_MARK_OFFSET   -1
+   #define HX_ENDIAN_MARK_ID_BYTE       -1
+#endif
+
+
+
+// The gPauseForCollect bits will turn spaceEnd negative, and so force the slow path
+#ifndef HXCPP_SINGLE_THREADED_APP
+   #define WITH_PAUSE_FOR_COLLECT_FLAG | hx::gPauseForCollect
+#else
+   #define WITH_PAUSE_FOR_COLLECT_FLAG
+#endif
+
+
+
+class StackContext;
+
+EXTERN_FAST_TLS_DATA(StackContext, tlsStackContext);
+
+extern StackContext *gMainThreadContext;
+
+extern unsigned int gImmixStartFlag[128];
+extern int gMarkID;
+extern int gMarkIDWithContainer;
+extern void BadImmixAlloc();
+
+
+class ImmixAllocator
+{
+public:
+   virtual ~ImmixAllocator() {}
+   virtual void *CallAlloc(int inSize,unsigned int inObjectFlags) = 0;
+   virtual void SetupStack() = 0;
+
+   #ifdef HXCPP_GC_NURSERY
+   unsigned char  *spaceFirst;
+   unsigned char  *spaceOversize;
+   #else
+   int            spaceStart;
+   int            spaceEnd;
+   #endif
+   unsigned int   *allocStartFlags;
+   unsigned char  *allocBase;
+
+
+
+   // These allocate the function using the garbage-colleced malloc
+   inline static void *alloc(ImmixAllocator *alloc, size_t inSize, bool inContainer, const char *inName )
+   {
+      #ifdef HXCPP_GC_NURSERY
+
+
+		     #if defined(HXCPP_VISIT_ALLOCS) && defined(HXCPP_M64)
+		     // Make sure we can fit a relocation pointer
+		     int allocSize = sizeof(int) + (inSize < 8 ? 8 : inSize);
+		     #else
+		     int allocSize = sizeof(int) + inSize;
+		     #endif
+
+         unsigned char *buffer = alloc->spaceFirst;
+         unsigned char *end = buffer + allocSize;
+
+         if ( end > alloc->spaceOversize )
+         {
+            // Fall back to external method
+            buffer = (unsigned char *)alloc->CallAlloc(inSize, inContainer ? IMMIX_ALLOC_IS_CONTAINER : 0);
+         }
+         else
+         {
+            alloc->spaceFirst = end;
+
+            if (inContainer)
+               ((unsigned int *)buffer)[-1] = (allocSize - 4)  | IMMIX_ALLOC_IS_CONTAINER;
+            else
+               ((unsigned int *)buffer)[-1] = (allocSize - 4) ;
+         }
+
+         #ifdef HXCPP_TELEMETRY
+         __hxt_gc_new((hx::StackContext *)alloc,buffer, inSize, inName);
+         #endif
+
+         return buffer;
+
+      #else
+         #ifndef HXCPP_ALIGN_ALLOC
+            // Inline the fast-path if we can
+            // We know the object can hold a pointer (vtable) and that the size is int-aligned
+            int start = alloc->spaceStart;
+            int end = start + sizeof(int) + inSize;
+
+            if ( end <= alloc->spaceEnd )
+            {
+               alloc->spaceStart = end;
+
+               unsigned int *buffer = (unsigned int *)(alloc->allocBase + start);
+
+               int startRow = start>>IMMIX_LINE_BITS;
+
+               alloc->allocStartFlags[ startRow ] |= gImmixStartFlag[start&127];
+
+               if (inContainer)
+                  *buffer++ =  (( (end+(IMMIX_LINE_LEN-1))>>IMMIX_LINE_BITS) -startRow) |
+                               (inSize<<IMMIX_ALLOC_SIZE_SHIFT) |
+                               hx::gMarkIDWithContainer;
+               else
+                  *buffer++ =  (( (end+(IMMIX_LINE_LEN-1))>>IMMIX_LINE_BITS) -startRow) |
+                               (inSize<<IMMIX_ALLOC_SIZE_SHIFT) |
+                               hx::gMarkID;
+
+               #if defined(HXCPP_GC_CHECK_POINTER) && defined(HXCPP_GC_DEBUG_ALWAYS_MOVE)
+               hx::GCOnNewPointer(buffer);
+               #endif
+
+               #ifdef HXCPP_TELEMETRY
+               __hxt_gc_new((hx::StackContext *)alloc,buffer, inSize, inName);
+               #endif
+               return buffer;
+            }
+         #endif // HXCPP_ALIGN_ALLOC
+
+         // Fall back to external method
+         void *result = alloc->CallAlloc(inSize, inContainer ? IMMIX_ALLOC_IS_CONTAINER : 0);
+
+         #ifdef HXCPP_TELEMETRY
+            __hxt_gc_new((hx::StackContext *)alloc,result, inSize, inName);
+         #endif
+
+         return result;
+      #endif // HXCPP_GC_NURSERY
+   }
+};
+
+typedef ImmixAllocator GcAllocator;
+typedef ImmixAllocator Ctx;
+
+
+#ifdef HXCPP_GC_GENERATIONAL
+  #define HX_OBJ_WB_CTX(obj,value,ctx) { \
+        unsigned char &mark =  ((unsigned char *)(obj))[ HX_ENDIAN_MARK_ID_BYTE]; \
+        if (mark == hx::gByteMarkID && value && !((unsigned char *)(value))[ HX_ENDIAN_MARK_ID_BYTE  ] ) { \
+            mark|=HX_GC_REMEMBERED; \
+            ctx->pushReferrer(obj); \
+     } }
+  #define HX_OBJ_WB_PESSIMISTIC_CTX(obj,ctx) { \
+     unsigned char &mark =  ((unsigned char *)(obj))[ HX_ENDIAN_MARK_ID_BYTE]; \
+     if (mark == hx::gByteMarkID)  { \
+        mark|=HX_GC_REMEMBERED; \
+        ctx->pushReferrer(obj); \
+     } }
+  // I'm not sure if this will ever trigger...
+  #define HX_OBJ_WB_NEW_MARKED_OBJECT(obj) { \
+     if (((unsigned char *)(obj))[ HX_ENDIAN_MARK_ID_BYTE]==hx::gByteMarkID) hx::NewMarkedObject(obj); \
+  }
+#else
+  #define HX_OBJ_WB_CTX(obj,value,ctx)
+  #define HX_OBJ_WB_PESSIMISTIC_CTX(obj,ctx)
+  #define HX_OBJ_WB_NEW_MARKED_OBJECT(obj)
+#endif
+
+#define HX_OBJ_WB(obj,value) HX_OBJ_WB_CTX(obj,value,_hx_ctx)
+#define HX_ARRAY_WB(array,index,value) HX_OBJ_WB(array,value)
+#define HX_OBJ_WB_PESSIMISTIC(obj) HX_OBJ_WB_PESSIMISTIC_CTX(obj,_hx_ctx)
+#define HX_OBJ_WB_GET(obj,value) HX_OBJ_WB_CTX(obj,value,HX_CTX_GET)
+#define HX_OBJ_WB_PESSIMISTIC_GET(obj) HX_OBJ_WB_PESSIMISTIC_CTX(obj,HX_CTX_GET)
+
+HXCPP_EXTERN_CLASS_ATTRIBUTES extern unsigned int gPrevMarkIdMask;
+
+// Called only once it is determined that a new mark is required
+HXCPP_EXTERN_CLASS_ATTRIBUTES void MarkAllocUnchecked(void *inPtr ,hx::MarkContext *__inCtx); 
+HXCPP_EXTERN_CLASS_ATTRIBUTES void MarkObjectAllocUnchecked(hx::Object *inPtr ,hx::MarkContext *__inCtx);
+HXCPP_EXTERN_CLASS_ATTRIBUTES void NewMarkedObject(hx::Object *inPtr);
+
+inline void MarkAlloc(void *inPtr ,hx::MarkContext *__inCtx)
+{
+   #ifdef EMSCRIPTEN
+   // Unaligned must be constants...
+   if ( !( ((size_t)inPtr) & 3) )
+   #endif
+   // This will also skip const regions
+   if ( !(((unsigned int *)inPtr)[-1] & gPrevMarkIdMask) )
+      MarkAllocUnchecked(inPtr,__inCtx);
+}
+inline void MarkObjectAlloc(hx::Object *inPtr ,hx::MarkContext *__inCtx)
+{
+   #ifdef EMSCRIPTEN
+   // Unaligned must be constants...
+   if ( !( ((size_t)inPtr) & 3) )
+   #endif
+   // This will also skip const regions
+   if ( !(((unsigned int *)inPtr)[-1] & gPrevMarkIdMask) )
+      MarkObjectAllocUnchecked(inPtr,__inCtx);
+}
+
+
+} // end namespace hx
+
+
+
+
+// It was theoretically possible to redefine the MarkContext arg type (or skip it)
+//  incase the particular GC scheme did not need it.  This may take a bit of extra
+//  work to get going again
+
+#define HX_MARK_ARG __inCtx
+//#define HX_MARK_ADD_ARG ,__inCtx
+#define HX_MARK_PARAMS hx::MarkContext *__inCtx
+//#define HX_MARK_ADD_PARAMS ,hx::MarkContext *__inCtx
+
+#ifdef HXCPP_VISIT_ALLOCS
+#define HX_VISIT_ARG __inCtx
+#define HX_VISIT_PARAMS hx::VisitContext *__inCtx
+#else
+#define HX_VISIT_ARG
+#define HX_VISIT_PARAMS
+#endif
+
+
+
+
+
+// These macros add debug to the mark/visit calls if required
+// They also perform some inline checking to avoid function calls if possible
+
+
+#ifdef HXCPP_DEBUG
+
+#define HX_MARK_MEMBER_NAME(x,name) { hx::MarkSetMember(name, __inCtx); hx::MarkMember(x, __inCtx ); }
+#define HX_MARK_BEGIN_CLASS(x) hx::MarkPushClass(#x, __inCtx );
+#define HX_MARK_END_CLASS() hx::MarkPopClass(__inCtx );
+#define HX_MARK_MEMBER(x) { hx::MarkSetMember(0, __inCtx); hx::MarkMember(x, __inCtx ); }
+#define HX_MARK_MEMBER_ARRAY(x,len) { hx::MarkSetMember(0, __inCtx); hx::MarkMemberArray(x, len, __inCtx ); }
+
+#else
+
+#define HX_MARK_MEMBER_NAME(x,name) hx::MarkMember(x, __inCtx )
+#define HX_MARK_BEGIN_CLASS(x)
+#define HX_MARK_END_CLASS()
+#define HX_MARK_MEMBER(x) hx::MarkMember(x, __inCtx )
+#define HX_MARK_MEMBER_ARRAY(x,len) hx::MarkMemberArray(x, len, __inCtx )
+
+#endif
+
+#define HX_MARK_OBJECT(ioPtr) if (ioPtr) hx::MarkObjectAlloc(ioPtr, __inCtx );
+
+
+
+
+#define HX_MARK_STRING(ioPtr) \
+   if (ioPtr) hx::MarkAlloc((void *)ioPtr, __inCtx );
+
+#define HX_MARK_ARRAY(ioPtr) { if (ioPtr) hx::MarkAlloc((void *)ioPtr, __inCtx ); }
+
+
+
+
+#define HX_VISIT_MEMBER_NAME(x,name) hx::VisitMember(x, __inCtx )
+#define HX_VISIT_MEMBER(x) hx::VisitMember(x, __inCtx )
+
+#define HX_VISIT_OBJECT(ioPtr) \
+  { if (ioPtr && !(((unsigned char *)ioPtr)[HX_GC_CONST_ALLOC_MARK_OFFSET] & HX_GC_CONST_ALLOC_MARK_BIT) ) __inCtx->visitObject( (hx::Object **)&ioPtr); }
+
+#define HX_VISIT_STRING(ioPtr) \
+   if (ioPtr && !(((unsigned char *)ioPtr)[HX_GC_CONST_ALLOC_MARK_OFFSET] & HX_GC_CONST_ALLOC_MARK_BIT) ) __inCtx->visitAlloc((void **)&ioPtr);
+
+#define HX_VISIT_ARRAY(ioPtr) { if (ioPtr) __inCtx->visitAlloc((void **)&ioPtr); }
+
+
+
+
+
+
+
+#endif
+

--- a/include/hx/LessThanEq.h
+++ b/include/hx/LessThanEq.h
@@ -248,7 +248,7 @@ struct CompareTraits< T * >
 
 
 template<typename T1>
-hx::Object *GetExistingObject(const T1 &v1)
+inline hx::Object *GetExistingObject(const T1 &v1)
 {
    typedef CompareTraits<T1> traits1;
    return traits1::toObject(v1);
@@ -256,14 +256,14 @@ hx::Object *GetExistingObject(const T1 &v1)
 
 
 template<typename T1>
-bool IsNull(const T1 &v1)
+inline bool IsNull(const T1 &v1)
 {
    typedef CompareTraits<T1> traits1;
    return traits1::isNull(v1);
 }
 
 template<typename T1>
-bool IsNotNull(const T1 &v1)
+inline bool IsNotNull(const T1 &v1)
 {
    typedef CompareTraits<T1> traits1;
    return !traits1::isNull(v1);
@@ -408,41 +408,41 @@ inline bool TestLessEq(const T1 &v1, const T2 &v2)
 
 
 template<typename T1, typename T2>
-bool IsEq(const T1 &v1, const T2 &v2) { return TestLessEq<false,true,T1,T2>(v1,v2); }
+inline bool IsEq(const T1 &v1, const T2 &v2) { return TestLessEq<false,true,T1,T2>(v1,v2); }
 
 template<typename T1, typename T2>
-bool IsNotEq(const T1 &v1, const T2 &v2) { return TestLessEq<false,false,T1,T2>(v1,v2); }
+inline bool IsNotEq(const T1 &v1, const T2 &v2) { return TestLessEq<false,false,T1,T2>(v1,v2); }
 
 template<typename T1, typename T2>
-bool IsLess(const T1 &v1, const T2 &v2) { return TestLessEq<true,false,T1,T2>(v1,v2); }
+inline bool IsLess(const T1 &v1, const T2 &v2) { return TestLessEq<true,false,T1,T2>(v1,v2); }
 
 template<typename T1, typename T2>
-bool IsLessEq(const T1 &v1, const T2 &v2) { return TestLessEq<true,true,T1,T2>(v1,v2); }
-
-
-template<typename T1, typename T2>
-bool IsGreater(const T1 &v1, const T2 &v2) { return TestLessEq<true,false,T2,T1>(v2,v1); }
-
-template<typename T1, typename T2>
-bool IsGreaterEq(const T1 &v1, const T2 &v2) { return TestLessEq<true,true,T2,T1>(v2,v1); }
-
+inline bool IsLessEq(const T1 &v1, const T2 &v2) { return TestLessEq<true,true,T1,T2>(v1,v2); }
 
 
 template<typename T1, typename T2>
-bool IsPointerEq(const T1 &v1, const T2 &v2)
+inline bool IsGreater(const T1 &v1, const T2 &v2) { return TestLessEq<true,false,T2,T1>(v2,v1); }
+
+template<typename T1, typename T2>
+inline bool IsGreaterEq(const T1 &v1, const T2 &v2) { return TestLessEq<true,true,T2,T1>(v2,v1); }
+
+
+
+template<typename T1, typename T2>
+inline bool IsPointerEq(const T1 &v1, const T2 &v2)
 {
    return GetExistingObject(v1) == GetExistingObject(v2);
 }
 
 template<typename T1, typename T2>
-bool IsPointerNotEq(const T1 &v1, const T2 &v2)
+inline bool IsPointerNotEq(const T1 &v1, const T2 &v2)
 {
    return GetExistingObject(v1) != GetExistingObject(v2);
 }
 
 
 template<typename T1, typename T2>
-bool IsInstanceEq(const T1 &v1, const T2 &v2)
+inline bool IsInstanceEq(const T1 &v1, const T2 &v2)
 {
    hx::Object *p1 = GetExistingObject(v1);
    hx::Object *p2 = GetExistingObject(v2);
@@ -454,7 +454,7 @@ bool IsInstanceEq(const T1 &v1, const T2 &v2)
 }
 
 template<typename T1, typename T2>
-bool IsInstanceNotEq(const T1 &v1, const T2 &v2)
+inline bool IsInstanceNotEq(const T1 &v1, const T2 &v2)
 {
    hx::Object *p1 = GetExistingObject(v1);
    hx::Object *p2 = GetExistingObject(v2);

--- a/include/hx/QuickSearchVec.h
+++ b/include/hx/QuickSearchVec.h
@@ -1,0 +1,131 @@
+#ifndef HX_QUICKSEARCHVEC_INCLUDED
+#define HX_QUICKSEARCHVEC_INCLUDED
+
+#include <stdlib.h>
+#include <algorithm>
+#include <hx/QuickVec.h>
+
+namespace hx
+{
+
+template<typename T>
+struct QuickSearchVec
+{
+	
+   int mHashCount;
+   int mHashShift;
+   
+   
+   QuickVec<T>** mPtr;
+   QuickVec<T> mElements;
+   T mMin;
+   T mMax;
+   
+   QuickSearchVec(int hashCount = 4096, int hashShift = 2, int reserveSize = 1024) : mHashCount(hashCount), mHashShift(hashShift)
+   { 
+   	
+   	 mMin = 0; mMax = 0;
+   	 mPtr = (QuickVec<T>**)malloc(sizeof(QuickVec<T>*) * hashCount);
+   	 
+   	 mElements.reserve(reserveSize);
+   	 for (int i = 0; i < hashCount; i++)
+   	 {
+   	 	mPtr[i] = new QuickVec<T>();
+   	  mPtr[i]->reserve(reserveSize >> 4);
+   	 }
+   	 
+   	 	 
+   }
+   
+   inline void setMinMax()
+   {
+   	  mMin = 0;
+   	  mMax = 0;
+   	  
+   	  for(int i=0;i<mElements.mSize;i++)
+      {
+      	if (mMin == 0 || mElements.mPtr[i] < mMin) mMin = mElements.mPtr[i];
+      	if (mMax == 0 || mElements.mPtr[i] > mMax) mMax = mElements.mPtr[i];
+      }
+   }
+    
+   ~QuickSearchVec()
+   {  
+   	  for (int i = 0; i < mHashCount; i++) 
+   	    delete mPtr[i];
+   	  
+      if (mPtr)
+        free(mPtr);
+   }
+   
+   inline bool has(T inVal)
+   {  
+   	  if (inVal >= mMin && inVal <= mMax)
+   	  {
+   	   unsigned int hash = ((size_t)inVal>>mHashShift)%mHashCount;
+   	   return mPtr[hash]->indexOf(inVal) != -1;
+   	  }
+   	  return false;
+   }
+   
+   inline void qerase(int inPos)
+   {  
+   	
+      T elem = mElements[inPos];
+      
+   	  unsigned int hash = ((size_t)elem>>mHashShift)%mHashCount;
+      mPtr[hash]->qerase_val(elem);
+   	  mElements.qerase(inPos);
+   	  
+   }
+   
+   inline bool qerase_val(T inVal)
+   {
+   	  unsigned int hash = ((size_t)inVal>>mHashShift)%mHashCount;
+      mPtr[hash]->qerase_val(inVal);
+   	  return mElements.qerase_val(inVal);
+   	  
+   	 
+   }   
+   
+   inline T pop()
+   {
+      
+      T elem = mElements.pop();
+      
+   	  unsigned int hash = ((size_t)elem>>mHashShift)%mHashCount;
+      mPtr[hash]->qerase_val(elem);
+      
+      
+      return elem;
+   }  
+
+   inline void push(const T &inV)
+   {
+   	 
+   	 unsigned int hash = ((size_t)inV>>mHashShift)%mHashCount;
+   	 
+   	 mPtr[hash]->push(inV);
+   	 mElements.push(inV);
+
+     if (mMin == 0 || inV < mMin) mMin = inV;
+     if (mMax == 0 || inV > mMax) mMax = inV;
+   	 
+   }
+   
+   inline int size() const { return mElements.size(); }
+   inline T &operator[](int inIndex) { return mElements[inIndex]; }
+   inline const T &operator[](int inIndex) const { return mElements[inIndex]; }
+
+private:
+   QuickSearchVec(const QuickSearchVec<T> &);
+   void operator =(const QuickSearchVec<T> &);
+
+   
+};
+
+
+
+} // end namespace hx
+
+#endif

--- a/include/hx/QuickVec.h
+++ b/include/hx/QuickVec.h
@@ -47,12 +47,39 @@ struct QuickVec
       mSize = inSize;
       return mPtr;
    }
+   
+   T * reserve(int inSize)
+   {
+      if (inSize>mAlloc)
+      {
+         mAlloc = inSize;
+         mPtr = (T *)realloc(mPtr,sizeof(T)*mAlloc);
+      }
+      return mPtr;
+   }
+   
    // Can push this many without realloc
    bool hasExtraCapacity(int inN)
    {
       return mSize+inN<=mAlloc;
    }
+   inline int indexOf(T inVal)
+   {   
+   	  	for(int i=0;i<mSize;i++)
+         	if (mPtr[i]==inVal)
+           	 return i;
 
+      return -1;
+   }  
+   inline bool has(T inVal)
+   {   
+   	  	for(int i=0;i<mSize;i++)
+         	if (mPtr[i]==inVal)
+           	 return true;
+
+      return false;
+   }
+   
    bool safeReserveExtra(int inN)
    {
       int want = mSize + inN;
@@ -76,9 +103,14 @@ struct QuickVec
    }
    inline void pop_back() { --mSize; }
    inline T &back() { return mPtr[mSize-1]; }
+   inline void back_of(int amount) { mSize -= amount; }
    inline T pop()
    {
       return mPtr[--mSize];
+   }
+   inline T get(int index)
+   {
+      return mPtr[index];
    }
    inline void qerase(int inPos)
    {

--- a/include/hx/Thread.h
+++ b/include/hx/Thread.h
@@ -62,6 +62,7 @@ inline int HxAtomicInc(volatile int *ioWhere)
 inline int HxAtomicDec(volatile int *ioWhere)
    { return __atomic_dec(ioWhere); }
 
+#define HX_HAS_ATOMIC 1
 #elif defined(HX_WINDOWS)
 
 inline bool HxAtomicExchangeIf(int inTest, int inNewVal,volatile int *ioWhere)

--- a/include/hx/Thread.h.bak
+++ b/include/hx/Thread.h.bak
@@ -1,0 +1,441 @@
+#ifdef HX_THREAD_H_OVERRIDE
+// Users can define their own header to use here, but there is no API
+// compatibility gaurantee for future changes.
+#include HX_THREAD_H_OVERRIDE
+#else
+
+#ifndef HX_THREAD_H
+#define HX_THREAD_H
+
+#ifndef HXCPP_HEADER_VERSION
+#include "hx/HeaderVersion.h"
+#endif
+
+#ifdef HX_WINRT
+
+#include <windows.h>
+#include <process.h>
+#include <mutex>
+
+#elif defined(_WIN32)
+
+#undef _WIN32_WINNT
+#define _WIN32_WINNT 0x0400
+
+#include <windows.h>
+#include <process.h>
+#else
+#include <errno.h>
+#include <pthread.h>
+#include <sys/time.h>
+#include <stdio.h>
+#define HXCPP_PTHREADS
+#endif
+
+#ifdef RegisterClass
+#undef RegisterClass
+#endif
+
+#if defined(ANDROID)
+
+#if (HXCPP_ANDROID_PLATFORM>=16)
+// Nice one, google, no one was using that.
+#define __ATOMIC_INLINE__ static __inline__ __attribute__((always_inline))
+// returns 0=exchange took place, 1=not
+__ATOMIC_INLINE__ int __atomic_cmpxchg(int old, int _new, volatile int *ptr)
+   { return __sync_val_compare_and_swap(ptr, old, _new) != old; }
+__ATOMIC_INLINE__ int __atomic_dec(volatile int *ptr) { return __sync_fetch_and_sub (ptr, 1); }
+__ATOMIC_INLINE__ int __atomic_inc(volatile int *ptr) { return __sync_fetch_and_add (ptr, 1); }
+#else
+#include <sys/atomics.h>
+#endif
+
+// returns 1 if exchange took place
+inline bool HxAtomicExchangeIf(int inTest, int inNewVal,volatile int *ioWhere)
+   { return !__atomic_cmpxchg(inTest, inNewVal, ioWhere); }
+inline bool HxAtomicExchangeIfPtr(void *inTest, void *inNewVal,void * volatile *ioWhere)
+   { return __sync_val_compare_and_swap(ioWhere, inTest, inNewVal)==inTest; }
+
+// Returns old value naturally
+inline int HxAtomicInc(volatile int *ioWhere)
+   { return __atomic_inc(ioWhere); }
+inline int HxAtomicDec(volatile int *ioWhere)
+   { return __atomic_dec(ioWhere); }
+
+#elif defined(HX_WINDOWS)
+
+inline bool HxAtomicExchangeIf(int inTest, int inNewVal,volatile int *ioWhere)
+   { return InterlockedCompareExchange((volatile LONG *)ioWhere, inNewVal, inTest)==inTest; }
+
+inline bool HxAtomicExchangeIfPtr(void *inTest, void *inNewVal,void *volatile *ioWhere)
+   { return InterlockedCompareExchangePointer(ioWhere, inNewVal, inTest)==inTest; }
+
+// Make it return old value
+inline int HxAtomicInc(volatile int *ioWhere)
+   { return InterlockedIncrement((volatile LONG *)ioWhere)-1; }
+inline int HxAtomicDec(volatile int *ioWhere)
+   { return InterlockedDecrement((volatile LONG *)ioWhere)+1; }
+
+#define HX_HAS_ATOMIC 1
+
+#elif defined(HX_MACOS) || defined(IPHONE) || defined(APPLETV)
+#include <libkern/OSAtomic.h>
+
+#define HX_HAS_ATOMIC 1
+
+inline bool HxAtomicExchangeIf(int inTest, int inNewVal,volatile int *ioWhere)
+   { return OSAtomicCompareAndSwap32Barrier(inTest, inNewVal, ioWhere); }
+inline bool HxAtomicExchangeIfPtr(void *inTest, void *inNewVal,void * volatile *ioWhere)
+   { return OSAtomicCompareAndSwapPtrBarrier(inTest, inNewVal, ioWhere); }
+inline int HxAtomicInc(volatile int *ioWhere)
+   { return OSAtomicIncrement32Barrier(ioWhere)-1; }
+inline int HxAtomicDec(volatile int *ioWhere)
+   { return OSAtomicDecrement32Barrier(ioWhere)+1; }
+
+
+#elif defined(HX_LINUX)
+
+#define HX_HAS_ATOMIC 1
+
+inline bool HxAtomicExchangeIf(int inTest, int inNewVal,volatile int *ioWhere)
+   { return __sync_bool_compare_and_swap(ioWhere, inTest, inNewVal); }
+inline bool HxAtomicExchangeIfPtr(void *inTest, void *inNewVal,void *volatile *ioWhere)
+   { return __sync_bool_compare_and_swap(ioWhere, inTest, inNewVal); }
+// Returns old value naturally
+inline int HxAtomicInc(volatile int *ioWhere)
+   { return __sync_fetch_and_add(ioWhere,1); }
+inline int HxAtomicDec(volatile int *ioWhere)
+   { return __sync_fetch_and_sub(ioWhere,1); }
+
+#else
+
+#define HX_HAS_ATOMIC 0
+
+inline bool HxAtomicExchangeIfPtr(void *inTest, void *inNewVal,void *volatile *ioWhere)
+{
+   if (*ioWhere == inTest)
+   {
+      *ioWhere = inNewVal;
+      return true;
+   }
+   return false;
+}
+
+
+inline int HxAtomicExchangeIf(int inTest, int inNewVal,volatile int *ioWhere)
+{
+   if (*ioWhere == inTest)
+   {
+      *ioWhere = inNewVal;
+      return true;
+   }
+   return false;
+}
+inline int HxAtomicInc(volatile int *ioWhere)
+   { return (*ioWhere)++; }
+inline int HxAtomicDec(volatile int *ioWhere)
+   { return (*ioWhere)--; }
+
+
+#endif
+
+inline bool HxAtomicExchangeIfCastPtr(void *inTest, void *inNewVal,void *ioWhere)
+{
+   return HxAtomicExchangeIfPtr(inTest, inNewVal, (void *volatile *)ioWhere);
+}
+
+
+#if defined(HX_WINDOWS)
+
+
+struct HxMutex
+{
+   HxMutex()
+   {
+      mValid = true;
+      #ifdef HX_WINRT
+      InitializeCriticalSectionEx(&mCritSec,4000,0);
+      #else
+      InitializeCriticalSection(&mCritSec);
+      #endif
+   }
+   ~HxMutex() { if (mValid) DeleteCriticalSection(&mCritSec); }
+   void Lock() { EnterCriticalSection(&mCritSec); }
+   void Unlock() { LeaveCriticalSection(&mCritSec); }
+   bool TryLock() { return TryEnterCriticalSection(&mCritSec); }
+   bool IsValid() { return mValid; }
+   void Clean()
+   {
+      if (mValid)
+      {
+         DeleteCriticalSection(&mCritSec);
+         mValid = false;
+      }
+   }
+
+   bool             mValid;
+   CRITICAL_SECTION mCritSec;
+};
+
+
+#define THREAD_FUNC_TYPE DWORD WINAPI
+#define THREAD_FUNC_RET return 0;
+
+inline bool HxCreateDetachedThread(DWORD (WINAPI *func)(void *), void *param)
+{
+	return (CreateThread(NULL, 0, func, param, 0, 0) != 0);
+}
+
+#else
+
+struct HxMutex
+{
+   HxMutex()
+   {
+      pthread_mutexattr_t mta;
+      pthread_mutexattr_init(&mta);
+      pthread_mutexattr_settype(&mta, PTHREAD_MUTEX_RECURSIVE);
+      mValid = pthread_mutex_init(&mMutex,&mta) ==0;
+   }
+   ~HxMutex() { if (mValid) pthread_mutex_destroy(&mMutex); }
+   void Lock() { pthread_mutex_lock(&mMutex); }
+   void Unlock() { pthread_mutex_unlock(&mMutex); }
+   bool TryLock() { return !pthread_mutex_trylock(&mMutex); }
+   bool IsValid() { return mValid; }
+   void Clean()
+   {
+      if (mValid)
+         pthread_mutex_destroy(&mMutex);
+      mValid = 0;
+   }
+
+   bool mValid;
+   pthread_mutex_t mMutex;
+};
+
+#define THREAD_FUNC_TYPE void *
+#define THREAD_FUNC_RET return 0;
+
+inline bool HxCreateDetachedThread(void *(*func)(void *), void *param)
+{
+	pthread_t t;
+	pthread_attr_t attr;
+	if (pthread_attr_init(&attr) != 0)
+		return false;
+#ifdef PTHREAD_CREATE_DETACHED
+	if (pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED) != 0)
+		return false;
+#endif
+	if (pthread_create(&t, &attr, func, param) != 0 )
+		return false;
+	if (pthread_attr_destroy(&attr) != 0)
+		return false;
+	return true;
+}
+
+#endif
+
+
+
+
+template<typename LOCKABLE>
+struct TAutoLock
+{
+   TAutoLock(LOCKABLE &inMutex) : mMutex(inMutex) { mMutex.Lock(); }
+   ~TAutoLock() { mMutex.Unlock(); }
+   void Lock() { mMutex.Lock(); }
+   void Unlock() { mMutex.Unlock(); }
+
+   LOCKABLE &mMutex;
+};
+
+typedef TAutoLock<HxMutex> AutoLock;
+
+
+#if defined(HX_WINDOWS)
+
+struct HxSemaphore
+{
+   HxSemaphore()
+   {
+      #ifdef HX_WINRT
+      mSemaphore = CreateEventEx(nullptr,nullptr,0,EVENT_ALL_ACCESS);
+      #else
+      mSemaphore = CreateEvent(0,0,0,0);
+      #endif
+   }
+   ~HxSemaphore() { if (mSemaphore) CloseHandle(mSemaphore); }
+   void Set() { SetEvent(mSemaphore); }
+   void Wait()
+   {
+      #ifdef HX_WINRT
+      WaitForSingleObjectEx(mSemaphore,INFINITE,false);
+      #else
+      WaitForSingleObject(mSemaphore,INFINITE);
+      #endif
+   }
+    // Returns true on success, false on timeout
+   bool WaitSeconds(double inSeconds)
+   {
+      #ifdef HX_WINRT
+      return WaitForSingleObjectEx(mSemaphore,inSeconds*1000.0,false) != WAIT_TIMEOUT;
+      #else
+      return WaitForSingleObject(mSemaphore,inSeconds*1000.0) != WAIT_TIMEOUT;
+      #endif
+   }
+   void Reset() { ResetEvent(mSemaphore); }
+   void Clean() { if (mSemaphore) CloseHandle(mSemaphore); mSemaphore = 0; }
+
+   HANDLE mSemaphore;
+};
+
+#else
+
+
+#define HX_THREAD_SEMAPHORE_LOCKABLE
+
+struct HxSemaphore
+{
+   HxSemaphore()
+   {
+      mSet = false;
+      mValid = true;
+      pthread_cond_init(&mCondition,0);
+   }
+   ~HxSemaphore()
+   {
+      if (mValid)
+      {
+         pthread_cond_destroy(&mCondition);
+      }
+   }
+   // For autolock
+   inline operator HxMutex &() { return mMutex; }
+   void Set()
+   {
+      AutoLock lock(mMutex);
+      if (!mSet)
+      {
+         mSet = true;
+         pthread_cond_signal( &mCondition );
+      }
+   }
+   void QSet()
+   {
+      mSet = true;
+      pthread_cond_signal( &mCondition );
+   }
+   void Reset()
+   {
+      AutoLock lock(mMutex);
+      mSet = false;
+   }
+   void QReset() { mSet = false; }
+   void Wait()
+   {
+      AutoLock lock(mMutex);
+      while( !mSet )
+         pthread_cond_wait( &mCondition, &mMutex.mMutex );
+      mSet = false;
+   }
+   // when we already hold the mMutex lock ...
+   void QWait()
+   {
+      while( !mSet )
+         pthread_cond_wait( &mCondition, &mMutex.mMutex );
+      mSet = false;
+   }
+   // Returns true if the wait was success, false on timeout.
+   bool WaitSeconds(double inSeconds)
+   {
+      struct timeval tv;
+      gettimeofday(&tv, 0);
+
+      int isec = (int)inSeconds;
+      int usec = (int)((inSeconds-isec)*1000000.0);
+      timespec spec;
+      spec.tv_nsec = (tv.tv_usec + usec) * 1000;
+      if (spec.tv_nsec>1000000000)
+      {
+         spec.tv_nsec-=1000000000;
+         isec++;
+      }
+      spec.tv_sec = tv.tv_sec + isec;
+
+      AutoLock lock(mMutex);
+
+      int result = 0;
+      // Wait for set to be true...
+      while( !mSet &&  (result=pthread_cond_timedwait( &mCondition, &mMutex.mMutex, &spec )) != ETIMEDOUT)
+      {
+         if (result!=0)
+         {
+            // Error - something's gone wrong...
+            /*
+            if (result==EINVAL) 
+               printf("ERROR: Condition EINVAL\n");
+            else if (result==EPERM)
+               printf("ERROR: Condition EPERM\n");
+            else
+               printf("ERROR: Condition unknown error\n");
+            */
+            break;
+         }
+         // Condition signalled - but try mSet again ...
+      }
+
+      bool wasSet = mSet;
+      mSet = false;
+      return wasSet;
+   }
+   void Clean()
+   {
+      mMutex.Clean();
+      if (mValid)
+      {
+         mValid = false;
+         pthread_cond_destroy(&mCondition);
+      }
+   }
+
+
+   HxMutex         mMutex;
+   pthread_cond_t  mCondition;
+   bool            mSet;
+   bool            mValid;
+};
+
+
+#endif
+
+
+#if defined HX_WINRT
+
+inline void HxSleep(unsigned int ms)
+{
+	::Sleep(ms);
+}
+
+#elif defined HX_WINDOWS
+
+inline void HxSleep(unsigned int ms)
+{
+	::Sleep(ms);
+}
+
+#else
+
+inline void HxSleep(unsigned int ms)
+{
+   struct timespec t;
+   struct timespec tmp;
+   t.tv_sec = 0;
+   t.tv_nsec = ms * 1000000;
+   nanosleep(&t, &tmp);
+}
+
+#endif
+
+
+#endif
+#endif

--- a/src/hx/gc/GcCommon.cpp.bak
+++ b/src/hx/gc/GcCommon.cpp.bak
@@ -34,7 +34,7 @@ int sgMinimumWorkingMemory       = 8*1024*1024;
 int sgMinimumFreeSpace           = 4*1024*1024;
 #endif
 // Once you use more than the minimum, this kicks in...
-int sgTargetFreeSpacePercentage  = 50;
+int sgTargetFreeSpacePercentage  = 100;
 
 
 

--- a/src/hx/gc/GcRegCapture.cpp
+++ b/src/hx/gc/GcRegCapture.cpp
@@ -16,20 +16,28 @@ void CaptureX86(RegisterCaptureBuffer &outBuffer)
    void *regEsi;
    void *regEdi;
    void *regEbx;
+   void *regEax;
+   void *regEcx;
    #ifdef __GNUC__
    asm ("mov %%esi, %0\n\t" : "=r" (regEsi) );
    asm ("mov %%edi, %0\n\t" : "=r" (regEdi) );
    asm ("mov %%ebx, %0\n\t" : "=r" (regEbx) );
+   asm ("mov %%eax, %0\n\t" : "=r" (regEax) );
+   asm ("mov %%ecx, %0\n\t" : "=r" (regEcx) );
    #else
    __asm {
       mov regEsi, esi
       mov regEdi, edi
       mov regEbx, ebx
+      mov regEax, eax
+      mov regEcx, ecx
    }
    #endif
    outBuffer.esi = regEsi;
    outBuffer.edi = regEdi;
    outBuffer.ebx = regEbx;
+   outBuffer.eax = regEax;
+   outBuffer.ecx = regEcx;
 }
 
 } // end namespace hx

--- a/src/hx/gc/GcRegCapture.cpp.bak
+++ b/src/hx/gc/GcRegCapture.cpp.bak
@@ -1,0 +1,131 @@
+#include "GcRegCapture.h"
+
+#ifdef HXCPP_CAPTURE_SETJMP // {
+
+// Nothing
+
+#elif defined(HXCPP_CAPTURE_x86) // }  {
+
+#pragma optimize( "", off )
+
+
+namespace hx {
+
+void CaptureX86(RegisterCaptureBuffer &outBuffer)
+{
+   void *regEsi;
+   void *regEdi;
+   void *regEbx;
+   void *regEax;
+   void *regEcx;
+   void *regEbp;
+   #ifdef __GNUC__
+   asm ("mov %%esi, %0\n\t" : "=r" (regEsi) );
+   asm ("mov %%edi, %0\n\t" : "=r" (regEdi) );
+   asm ("mov %%ebx, %0\n\t" : "=r" (regEbx) );
+   asm ("mov %%eax, %0\n\t" : "=r" (regEax) );
+   asm ("mov %%ecx, %0\n\t" : "=r" (regEcx) );
+   asm ("mov %%ebp, %0\n\t" : "=r" (regEbp) );
+   #else
+   __asm {
+      mov regEsi, esi
+      mov regEdi, edi
+      mov regEbx, ebx
+      mov regEax, eax
+      mov regEcx, ecx
+      mov regEbp, ebp
+   }
+   #endif
+   outBuffer.esi = regEsi;
+   outBuffer.edi = regEdi;
+   outBuffer.ebx = regEbx;
+   outBuffer.eax = regEax;
+   outBuffer.ecx = regEcx;
+   outBuffer.ebp = regEbp;
+}
+
+} // end namespace hx
+
+#elif defined(HXCPP_CAPTURE_x64) // } {
+
+#if !defined(__GNUC__)
+#include <windows.h>
+#endif
+
+namespace hx {
+
+void CaptureX64(RegisterCaptureBuffer &outBuffer)
+{
+   #if !defined(__GNUC__)
+      CONTEXT context;
+
+      context.ContextFlags = CONTEXT_INTEGER;
+      RtlCaptureContext(&context);
+
+      outBuffer.rbx = (void *)context.Rbx;
+      outBuffer.rbp = (void *)context.Rbp;
+      outBuffer.rdi = (void *)context.Rdi;
+      outBuffer.r12 = (void *)context.R12;
+      outBuffer.r13 = (void *)context.R13;
+      outBuffer.r14 = (void *)context.R14;
+      outBuffer.r15 = (void *)context.R15;
+      memcpy(outBuffer.xmm, &context.Xmm0, sizeof(outBuffer.xmm));
+   #else
+      void *regBx;
+      void *regBp;
+      void *regDi;
+      void *reg12;
+      void *reg13;
+      void *reg14;
+      void *reg15;
+      asm ("movq %%rbx, %0\n\t" : "=r" (regBx) );
+      asm ("movq %%rbp, %0\n\t" : "=r" (regBp) );
+      asm ("movq %%rdi, %0\n\t" : "=r" (regDi) );
+      asm ("movq %%r12, %0\n\t" : "=r" (reg12) );
+      asm ("movq %%r13, %0\n\t" : "=r" (reg13) );
+      asm ("movq %%r14, %0\n\t" : "=r" (reg14) );
+      asm ("movq %%r15, %0\n\t" : "=r" (reg15) );
+      outBuffer.rbx = regBx;
+      outBuffer.rbp = regBp;
+      outBuffer.r12 = reg12;
+      outBuffer.r13 = reg13;
+      outBuffer.r14 = reg14;
+      outBuffer.r15 = reg15;
+   #endif
+}
+
+} // end namespace hx
+
+
+#else // }  {
+
+#include <string.h>
+
+namespace hx {
+
+// Put this function here so we can be reasonablly sure that "this" register and
+// the 4 registers that may be used to pass args are on the stack.
+int RegisterCapture::Capture(int *inTopOfStack,int **inBuf,int &outSize,int inMaxSize, int *inBottom)
+{
+	int size = ( (char *)inTopOfStack - (char *)inBottom )/sizeof(void *);
+	if (size>inMaxSize)
+		size = inMaxSize;
+	outSize = size;
+	if (size>0)
+	   memcpy(inBuf,inBottom,size*sizeof(void*));
+	return 1;
+}
+
+
+RegisterCapture *gRegisterCaptureInstance = 0;
+RegisterCapture *RegisterCapture::Instance()
+{
+	if (!gRegisterCaptureInstance)
+		gRegisterCaptureInstance = new RegisterCapture();
+	return gRegisterCaptureInstance;
+}
+
+} // end namespace hx
+
+#endif // }
+

--- a/src/hx/gc/GcRegCapture.h
+++ b/src/hx/gc/GcRegCapture.h
@@ -44,7 +44,6 @@ struct RegisterCaptureBuffer
    void *ecx;
    void *edi;
    void *esi;
-   void *ebp;
 };
 
 void CaptureX86(RegisterCaptureBuffer &outBuffer);

--- a/src/hx/gc/GcRegCapture.h
+++ b/src/hx/gc/GcRegCapture.h
@@ -39,9 +39,12 @@ typedef jmp_buf RegisterCaptureBuffer;
 
 struct RegisterCaptureBuffer
 {
+   void *eax;
    void *ebx;
+   void *ecx;
    void *edi;
    void *esi;
+   void *ebp;
 };
 
 void CaptureX86(RegisterCaptureBuffer &outBuffer);

--- a/src/hx/gc/GcRegCapture.h.bak
+++ b/src/hx/gc/GcRegCapture.h.bak
@@ -1,0 +1,108 @@
+#ifndef HX_GC_HELPERS_INCLUDED
+#define HX_GC_HELPERS_INCLUDED
+
+#if defined(HX_WINDOWS) && defined(HXCPP_ARM64)
+#define HXCPP_CAPTURE_SETJMP
+#endif
+
+#ifdef HXCPP_CAPTURE_SETJMP
+   #include <setjmp.h>
+#else
+
+   #if (defined(HX_WINDOWS) || defined(HX_MACOS)) && !defined(HXCPP_M64)
+      #define HXCPP_CAPTURE_x86
+   #endif
+
+   #if (defined(HX_MACOS) || (defined(HX_WINDOWS) && !defined(HX_WINRT)) || defined(_XBOX_ONE)) && defined(HXCPP_M64)
+      #define HXCPP_CAPTURE_x64
+   #endif
+
+#endif
+
+
+namespace hx
+{
+
+// Capture Registers
+//
+#ifdef HXCPP_CAPTURE_SETJMP // {
+
+typedef jmp_buf RegisterCaptureBuffer;
+
+#define CAPTURE_REGS \
+   setjmp(mRegisterBuf);
+
+#define CAPTURE_REG_START (int *)(&mRegisterBuf)
+#define CAPTURE_REG_END (int *)(&mRegisterBuf+1)
+
+#elif defined(HXCPP_CAPTURE_x86) // } {
+
+struct RegisterCaptureBuffer
+{
+   void *eax;
+   void *ebx;
+   void *ecx;
+   void *edi;
+   void *esi;
+   void *ebp;
+};
+
+void CaptureX86(RegisterCaptureBuffer &outBuffer);
+
+#define CAPTURE_REGS \
+   hx::CaptureX86(mRegisterBuf);
+
+#define CAPTURE_REG_START (int *)(&mRegisterBuf)
+#define CAPTURE_REG_END (int *)(&mRegisterBuf+1)
+
+#elif defined(HXCPP_CAPTURE_x64) // }  {
+
+
+struct RegisterCaptureBuffer
+{
+   void *rbx;
+   void *rbp;
+   void *rdi;
+   void *r12;
+   void *r13;
+   void *r14;
+   void *r15;
+
+   void *xmm[16*2];
+};
+
+void CaptureX64(RegisterCaptureBuffer &outBuffer);
+
+#define CAPTURE_REGS \
+   hx::CaptureX64(mRegisterBuf);
+
+#define CAPTURE_REG_START (int *)(&mRegisterBuf)
+#define CAPTURE_REG_END (int *)(&mRegisterBuf+1)
+
+#else 
+
+
+class RegisterCapture
+{
+public:
+	virtual int Capture(int *inTopOfStack,int **inBuf,int &outSize,int inMaxSize,int *inDummy);
+   static RegisterCapture *Instance();
+};
+
+typedef int *RegisterCaptureBuffer[20];
+
+#define CAPTURE_REGS \
+   hx::RegisterCapture::Instance()->Capture(mTopOfStack, \
+                mRegisterBuf,mRegisterBufSize,20,mBottomOfStack); \
+
+#define CAPTURE_REG_START (int *)mRegisterBuf
+#define CAPTURE_REG_END (int *)(mRegisterBuf+mRegisterBufSize)
+
+#endif // }
+
+
+
+}
+
+
+#endif

--- a/src/hx/gc/Immix.cpp
+++ b/src/hx/gc/Immix.cpp
@@ -145,7 +145,7 @@ static size_t sgMaximumFreeSpace  = 50*1024*1024;
 //#define HX_GC_VERIFY
 //#define SHOW_MEM_EVENTS
 //#define SHOW_MEM_EVENTS_VERBOSE
-//#define SHOW_FRAGMENTATION
+// #define SHOW_FRAGMENTATION
 
 //#define HX_GC_FIXED_BLOCKS
 //#define HX_WATCH
@@ -394,7 +394,6 @@ static void MarkLocalAlloc(LocalAllocator *inAlloc,hx::MarkContext *__inCtx);
 static void VisitLocalAlloc(LocalAllocator *inAlloc,hx::VisitContext *__inCtx);
 #endif
 static void WaitForSafe(LocalAllocator *inAlloc);
-static void ReleaseFromSafe(LocalAllocator *inAlloc);
 static void ClearPooledAlloc(LocalAllocator *inAlloc);
 static void CollectFromThisThread(bool inMajor,bool inForceCompact);
 static void ResetLocalAllocatorInitializing(LocalAllocator *inAlloc);
@@ -1088,9 +1087,7 @@ struct BlockDataInfo
             else
             {
             	 
-            	 // there is an hole here, so allocStart[r] must be reset
-            	 allocStart[r] = 0;
-            	
+            	 // there is an hole here, so allocStart[r] must be reset            	
                int start = r;
                ranges[hole].start = start;
               
@@ -1270,41 +1267,13 @@ struct BlockDataInfo
       AllocType t = GetEnclosingNurseryType(inOffset,&ptr);
       if (t != allocNone)
       	 return t;
-
       #endif
 
       if (( allocStart[r] & hx::gImmixStartFlag[inOffset &IMMIX_START_MASK]) )
-      {
-      
-      // the ptr can be GetAllocTypeChecked only if not in an hole
-       #ifdef HXCPP_GC_NURSERY      
-        if (this->IsInHole(inOffset))
-       	 return allocNone;
-       #endif      	 
-      	
        return GetAllocTypeChecked(inOffset,inAllowPrevious);
-      }
       else
        return allocNone;
       
-   }
-   
-   inline bool IsInHole(int inOffset)
-   {
-     
-      for(int h=0;h<mHoles;h++)
-      {
-         int scan = mRanges[h].start;
-         if (scan > inOffset)
-         	 break;
-         	 
-         int last = mRanges[h].start + mRanges[h].length;
-         if (inOffset >= scan && inOffset < last) 
-         	 return true;
-
-      }  	
-      
-      return false;
    }
 
    void pin() { mPinned = true; }
@@ -3168,8 +3137,8 @@ public:
       //  value, so we can't doa realloc without potentially crashing it.
 #ifdef RECYCLE_LARGE
       if (largeObjectRecycle.hasExtraCapacity(1))
-#endif
       {
+#endif
          unsigned int *blob = ((unsigned int *)inLarge) - 2;
          unsigned int size = *blob;
          mLargeListLock.Lock();
@@ -3179,15 +3148,17 @@ public:
          // We could maybe free anyhow?
          #ifdef RECYCLE_LARGE
          if (!largeObjectRecycle.hasExtraCapacity(1))
-         #endif
          {
+         	  #endif
             mLargeListLock.Unlock();
             HxFree(blob);
             return;
+#ifdef RECYCLE_LARGE            
          }
          largeObjectRecycle.push(blob);
          mLargeListLock.Unlock();
       }
+#endif
    }
 
    void *AllocLarge(int inSize, bool inClear)
@@ -5347,8 +5318,6 @@ public:
             #ifdef HXCPP_SCRIPTABLE
             ((hx::StackContext *)mLocalAllocs[i])->byteMarkId = hx::gByteMarkID;
             #endif
-            if (mLocalAllocs[i]!=this_local)
-               ReleaseFromSafe(mLocalAllocs[i]);
          }
 
          if (!inLocked)
@@ -5978,16 +5947,13 @@ public:
    {
       if (sgIsCollecting)
          CriticalGCError("Bad Allocation while collecting - from finalizer?");
-      #ifndef HXCPP_SINGLE_THREADED_APP
-      volatile int dummy = 1;
-      mBottomOfStack = (int *)&dummy;
-      CAPTURE_REGS;
-      #ifdef VerifyStackRead
-      VerifyStackRead(mBottomOfStack, mTopOfStack)
-      #endif
-
-      mReadyForCollect.Set();
-      mCollectDone.Wait();
+         
+			#ifndef HXCPP_SINGLE_THREADED_APP         
+	    EnterGCFreeZone();
+	    gThreadStateChangeLock->Lock();
+	    ExitGCFreeZoneLocked();
+	    
+	    gThreadStateChangeLock->Unlock();
       #endif
    }
 
@@ -6070,14 +6036,6 @@ public:
          #endif
          mReadyForCollect.Wait();
       }
-      #endif
-   }
-
-   void ReleaseFromSafe()
-   {
-      #ifndef HXCPP_SINGLE_THREADED_APP
-      if (!mGCFreeZone)
-         mCollectDone.Set();
       #endif
    }
 
@@ -6319,7 +6277,6 @@ public:
    #ifndef HXCPP_SINGLE_THREADED_APP
    bool            mGCFreeZone;
    HxSemaphore     mReadyForCollect;
-   HxSemaphore     mCollectDone;
    #endif
 
    int             mStackLocks;
@@ -6352,11 +6309,6 @@ void ResetLocalAllocatorInitializing(LocalAllocator *inAlloc)
 void WaitForSafe(LocalAllocator *inAlloc)
 {
    inAlloc->WaitForSafe();
-}
-
-void ReleaseFromSafe(LocalAllocator *inAlloc)
-{
-   inAlloc->ReleaseFromSafe();
 }
 
 void MarkLocalAlloc(LocalAllocator *inAlloc,hx::MarkContext *__inCtx)

--- a/src/hx/gc/Immix.cpp.bak
+++ b/src/hx/gc/Immix.cpp.bak
@@ -140,12 +140,12 @@ static size_t sgMaximumFreeSpace  = 50*1024*1024;
 // HXCPP_GC_DYNAMIC_SIZE
 
 //#define HXCPP_GC_SUMMARY
-#define PROFILE_COLLECT
+//#define PROFILE_COLLECT
 //#define PROFILE_THREAD_USAGE
 //#define HX_GC_VERIFY
 //#define SHOW_MEM_EVENTS
 //#define SHOW_MEM_EVENTS_VERBOSE
-//#define SHOW_FRAGMENTATION
+#define SHOW_FRAGMENTATION
 
 //#define HX_GC_FIXED_BLOCKS
 //#define HX_WATCH
@@ -394,7 +394,6 @@ static void MarkLocalAlloc(LocalAllocator *inAlloc,hx::MarkContext *__inCtx);
 static void VisitLocalAlloc(LocalAllocator *inAlloc,hx::VisitContext *__inCtx);
 #endif
 static void WaitForSafe(LocalAllocator *inAlloc);
-static void ReleaseFromSafe(LocalAllocator *inAlloc);
 static void ClearPooledAlloc(LocalAllocator *inAlloc);
 static void CollectFromThisThread(bool inMajor,bool inForceCompact);
 static void ResetLocalAllocatorInitializing(LocalAllocator *inAlloc);
@@ -1088,9 +1087,7 @@ struct BlockDataInfo
             else
             {
             	 
-            	 // there is an hole here, so allocStart[r] must be reset
-            	 allocStart[r] = 0;
-            	
+            	 // there is an hole here, so allocStart[r] must be reset            	
                int start = r;
                ranges[hole].start = start;
               
@@ -1270,41 +1267,13 @@ struct BlockDataInfo
       AllocType t = GetEnclosingNurseryType(inOffset,&ptr);
       if (t != allocNone)
       	 return t;
-
       #endif
 
       if (( allocStart[r] & hx::gImmixStartFlag[inOffset &IMMIX_START_MASK]) )
-      {
-      
-      // the ptr can be GetAllocTypeChecked only if not in an hole
-       #ifdef HXCPP_GC_NURSERY      
-        if (this->IsInHole(inOffset))
-       	 return allocNone;
-       #endif      	 
-      	
        return GetAllocTypeChecked(inOffset,inAllowPrevious);
-      }
       else
        return allocNone;
       
-   }
-   
-   inline bool IsInHole(int inOffset)
-   {
-     
-      for(int h=0;h<mHoles;h++)
-      {
-         int scan = mRanges[h].start;
-         if (scan > inOffset)
-         	 break;
-         	 
-         int last = mRanges[h].start + mRanges[h].length;
-         if (inOffset >= scan && inOffset < last) 
-         	 return true;
-
-      }  	
-      
-      return false;
    }
 
    void pin() { mPinned = true; }
@@ -3168,8 +3137,8 @@ public:
       //  value, so we can't doa realloc without potentially crashing it.
 #ifdef RECYCLE_LARGE
       if (largeObjectRecycle.hasExtraCapacity(1))
-#endif
       {
+#endif
          unsigned int *blob = ((unsigned int *)inLarge) - 2;
          unsigned int size = *blob;
          mLargeListLock.Lock();
@@ -3179,15 +3148,17 @@ public:
          // We could maybe free anyhow?
          #ifdef RECYCLE_LARGE
          if (!largeObjectRecycle.hasExtraCapacity(1))
-         #endif
          {
+         	  #endif
             mLargeListLock.Unlock();
             HxFree(blob);
             return;
+#ifdef RECYCLE_LARGE            
          }
          largeObjectRecycle.push(blob);
          mLargeListLock.Unlock();
       }
+#endif
    }
 
    void *AllocLarge(int inSize, bool inClear)
@@ -5347,8 +5318,6 @@ public:
             #ifdef HXCPP_SCRIPTABLE
             ((hx::StackContext *)mLocalAllocs[i])->byteMarkId = hx::gByteMarkID;
             #endif
-            if (mLocalAllocs[i]!=this_local)
-               ReleaseFromSafe(mLocalAllocs[i]);
          }
 
          if (!inLocked)
@@ -5978,16 +5947,13 @@ public:
    {
       if (sgIsCollecting)
          CriticalGCError("Bad Allocation while collecting - from finalizer?");
-      #ifndef HXCPP_SINGLE_THREADED_APP
-      volatile int dummy = 1;
-      mBottomOfStack = (int *)&dummy;
-      CAPTURE_REGS;
-      #ifdef VerifyStackRead
-      VerifyStackRead(mBottomOfStack, mTopOfStack)
-      #endif
-
-      mReadyForCollect.Set();
-      mCollectDone.Wait();
+         
+			#ifndef HXCPP_SINGLE_THREADED_APP         
+	    EnterGCFreeZone();
+	    gThreadStateChangeLock->Lock();
+	    ExitGCFreeZoneLocked();
+	    
+	    gThreadStateChangeLock->Unlock();
       #endif
    }
 
@@ -6070,14 +6036,6 @@ public:
          #endif
          mReadyForCollect.Wait();
       }
-      #endif
-   }
-
-   void ReleaseFromSafe()
-   {
-      #ifndef HXCPP_SINGLE_THREADED_APP
-      if (!mGCFreeZone)
-         mCollectDone.Set();
       #endif
    }
 
@@ -6319,7 +6277,6 @@ public:
    #ifndef HXCPP_SINGLE_THREADED_APP
    bool            mGCFreeZone;
    HxSemaphore     mReadyForCollect;
-   HxSemaphore     mCollectDone;
    #endif
 
    int             mStackLocks;
@@ -6352,11 +6309,6 @@ void ResetLocalAllocatorInitializing(LocalAllocator *inAlloc)
 void WaitForSafe(LocalAllocator *inAlloc)
 {
    inAlloc->WaitForSafe();
-}
-
-void ReleaseFromSafe(LocalAllocator *inAlloc)
-{
-   inAlloc->ReleaseFromSafe();
 }
 
 void MarkLocalAlloc(LocalAllocator *inAlloc,hx::MarkContext *__inCtx)

--- a/src/hx/gc/Immix.cpp.bak
+++ b/src/hx/gc/Immix.cpp.bak
@@ -140,7 +140,7 @@ static size_t sgMaximumFreeSpace  = 50*1024*1024;
 // HXCPP_GC_DYNAMIC_SIZE
 
 //#define HXCPP_GC_SUMMARY
-//#define PROFILE_COLLECT
+#define PROFILE_COLLECT
 //#define PROFILE_THREAD_USAGE
 //#define HX_GC_VERIFY
 //#define SHOW_MEM_EVENTS


### PR DESCRIPTION
MarkConservative may cause the GC to fail and crash due to invalid pointers threated as valid pointers inside registers or stack.

The root cause is GetAllocType that is using the non-safe allocStart bitmap to detect allocations. allocStart is only updated in FULL collect passes. A nursery allocation can have the allocStart flag set due to old allocations. In the same time a non-valid allocation can have its allocStart on 1. For this reason GetEnclosingNurseryType must be called without the conditional allocStart check, and
GetAllocTypeChecked must be called after checking if the inOffset is inside an hole.