### PR TITLE
add -std=c++11 to fix watchos and watchsimulator

### DIFF
--- a/toolchain/watchos-toolchain.xml
+++ b/toolchain/watchos-toolchain.xml
@@ -14,15 +14,15 @@
   <exe name="xcrun --toolchain WatchOS clang++" />
   <flag value="-c"/>
   <flag value="-arch"/>
-  <flag value="armv7k"/>
-
+  <flag value="armv7k" unless="HXCPP_ARM64_32"/>
+  <flag value="arm64_32" if="HXCPP_ARM64_32"/>
 
   <pchflag value="-x" />
   <pchflag value="c++-header" />
 
   <flag value="-stdlib=libc++" if="HXCPP_CPP11" />
   <flag value="-std=c++11" if="HXCPP_CPP11" />
-  
+
   <flag value="-g" />
 
   <flag value="-isysroot"/>

--- a/toolchain/watchos-toolchain.xml
+++ b/toolchain/watchos-toolchain.xml
@@ -44,7 +44,7 @@
   <mmflag value="-fobjc-abi-version=2"/>
   <mmflag value="-fobjc-legacy-dispatch"/>
 
-  <flag value="-mwatchos-version-min=2.2"/>
+  <flag value="-mwatchos-version-min=3.0"/>
   <flag value="-DHX_APPLEWATCH"/>
   <flag value="-DHX_WATCHOS"/>
   <flag value="-fobjc-arc"  />

--- a/toolchain/watchos-toolchain.xml
+++ b/toolchain/watchos-toolchain.xml
@@ -13,9 +13,14 @@
 <compiler id="WatchOS" exe="clang" >
   <exe name="xcrun --toolchain WatchOS clang++" />
   <flag value="-c"/>
+
   <flag value="-arch"/>
-  <flag value="armv7k" unless="HXCPP_ARM64_32"/>
-  <flag value="arm64_32" if="HXCPP_ARM64_32"/>
+  <flag value="${HXCPP_ARCH}" if="HXCPP_ARCH"/>
+  <section unless="HXCPP_ARCH">
+    <flag value="armv7k" unless="HXCPP_ARM64_32"/>
+    <flag value="arm64_32" if="HXCPP_ARM64_32"/>
+  </section>
+  
 
   <pchflag value="-x" />
   <pchflag value="c++-header" />

--- a/toolchain/watchos-toolchain.xml
+++ b/toolchain/watchos-toolchain.xml
@@ -21,6 +21,8 @@
   <pchflag value="c++-header" />
 
   <flag value="-stdlib=libc++" if="HXCPP_CPP11" />
+  <flag value="-std=c++11" if="HXCPP_CPP11" />
+  
   <flag value="-g" />
 
   <flag value="-isysroot"/>

--- a/toolchain/watchsimulator-toolchain.xml
+++ b/toolchain/watchsimulator-toolchain.xml
@@ -14,15 +14,14 @@
   <exe name="xcrun --toolchain WatchSimulator clang++" />
   <flag value="-c"/>
   <flag value="-arch"/>
-  <flag value="i386"/>
-
+  <flag value="i386" unless="HXCPP_M64"/>
+  <flag value="x86_64" if="HXCPP_M64"/>
 
   <pchflag value="-x" />
   <pchflag value="c++-header" />
 
   <flag value="-stdlib=libc++" if="HXCPP_CPP11" />
   <flag value="-std=c++11" if="HXCPP_CPP11" />
-
   <flag value="-g" />
 
   <flag value="-isysroot"/>
@@ -44,7 +43,7 @@
   <mmflag value="-fobjc-abi-version=2"/>
   <mmflag value="-fobjc-legacy-dispatch"/>
 
-  <flag value="-mwatchos-simulator-version-min=2.2"/>
+  <flag value="-mwatchos-simulator-version-min=3.0"/>
   <flag value="-DHX_APPLEWATCH"/>
   <flag value="-DHX_WATCHSIM"/>
   <flag value="-fobjc-arc"  />

--- a/toolchain/watchsimulator-toolchain.xml
+++ b/toolchain/watchsimulator-toolchain.xml
@@ -17,8 +17,8 @@
   <flag value="-arch"/>
   <flag value="${HXCPP_ARCH}" if="HXCPP_ARCH"/>
   <section unless="HXCPP_ARCH">
-    <flag value="i386" unless="HXCPP_M64"/>
-    <flag value="x86_64" if="HXCPP_M64" unless="HXCPP_ARM64"/>
+    <flag value="i386" unless="HXCPP_M64 || HXCPP_ARM64 || HXCPP_X86_64"/>
+    <flag value="x86_64" if="HXCPP_M64 || HXCPP_X86_64"/>
     <flag value="arm64" if="HXCPP_ARM64"/>
   </section>
 

--- a/toolchain/watchsimulator-toolchain.xml
+++ b/toolchain/watchsimulator-toolchain.xml
@@ -13,9 +13,14 @@
 <compiler id="WatchSimulator" exe="clang" >
   <exe name="xcrun --toolchain WatchSimulator clang++" />
   <flag value="-c"/>
+
   <flag value="-arch"/>
-  <flag value="i386" unless="HXCPP_M64"/>
-  <flag value="x86_64" if="HXCPP_M64"/>
+  <flag value="${HXCPP_ARCH}" if="HXCPP_ARCH"/>
+  <section unless="HXCPP_ARCH">
+    <flag value="i386" unless="HXCPP_M64"/>
+    <flag value="x86_64" if="HXCPP_M64" unless="HXCPP_ARM64"/>
+    <flag value="arm64" if="HXCPP_ARM64"/>
+  </section>
 
   <pchflag value="-x" />
   <pchflag value="c++-header" />

--- a/toolchain/watchsimulator-toolchain.xml
+++ b/toolchain/watchsimulator-toolchain.xml
@@ -21,6 +21,8 @@
   <pchflag value="c++-header" />
 
   <flag value="-stdlib=libc++" if="HXCPP_CPP11" />
+  <flag value="-std=c++11" if="HXCPP_CPP11" />
+
   <flag value="-g" />
 
   <flag value="-isysroot"/>


### PR DESCRIPTION
Hxcpp fails to compile on watchos, adding -std=c++11 resolves (this change mirrors the iphoneos toolchain which also uses std=c++11)

`watchsimulator` build fails with errors about no thread local data support on this target, bumping min watch sdk target to 3.0 resolves


Also adds some missing architecture flags

Users need `-lc++` when linking against static binaries compiled with haxe, see this post for an example
https://community.haxe.org/t/missing-hxcpp-h-in-cpp-compilation/2975/19

closes #952 