### PR TITLE
Get size of map and regex captures

### DIFF
--- a/include/hx/StdLibs.h
+++ b/include/hx/StdLibs.h
@@ -533,6 +533,7 @@ HXCPP_EXTERN_CLASS_ATTRIBUTES Dynamic _hx_regexp_new_options(String s, String op
 HXCPP_EXTERN_CLASS_ATTRIBUTES bool    _hx_regexp_match(Dynamic handle, String string, int pos, int len);
 HXCPP_EXTERN_CLASS_ATTRIBUTES String  _hx_regexp_matched(Dynamic handle, int pos);
 HXCPP_EXTERN_CLASS_ATTRIBUTES Dynamic _hx_regexp_matched_pos(Dynamic handle, int match);
+HXCPP_EXTERN_CLASS_ATTRIBUTES int     _hx_regexp_matched_num(Dynamic handle);
 
 
 // haxe.zip.(Un)Compress.hx -> src/hx/libs/zlib/ZLib.cpp

--- a/include/hx/StdLibs.h
+++ b/include/hx/StdLibs.h
@@ -159,6 +159,10 @@ HXCPP_EXTERN_CLASS_ATTRIBUTES String __hxcpp_utf8_string_to_char_bytes(String &i
    #define HX_MAP_THIS_ARG Dynamic &ioHash
 #endif
 
+// --- HashRoot ---------------------------------------------------------------------
+
+HXCPP_EXTERN_CLASS_ATTRIBUTES int           __root_hash_size(Dynamic *rtHash);
+
 // --- IntHash ----------------------------------------------------------------------
 
 HXCPP_EXTERN_CLASS_ATTRIBUTES inline hx::Object   *__int_hash_create() { return 0; }

--- a/include/hx/StdLibs.h
+++ b/include/hx/StdLibs.h
@@ -173,6 +173,7 @@ HXCPP_EXTERN_CLASS_ATTRIBUTES void          __int_hash_set_string(HX_MAP_THIS_AR
 HXCPP_EXTERN_CLASS_ATTRIBUTES void          __int_hash_set_float(HX_MAP_THIS_ARG,int inKey,Float inValue);
 HXCPP_EXTERN_CLASS_ATTRIBUTES ::String      __int_hash_to_string(Dynamic &hash);
 HXCPP_EXTERN_CLASS_ATTRIBUTES void          __int_hash_clear(Dynamic &hash);
+HXCPP_EXTERN_CLASS_ATTRIBUTES int           __int_hash_size(Dynamic &hash);
 
 HXCPP_EXTERN_CLASS_ATTRIBUTES Dynamic       __int_hash_get(Dynamic inHash,int inKey);
 HXCPP_EXTERN_CLASS_ATTRIBUTES int           __int_hash_get_int(Dynamic inHash,int inKey);
@@ -196,6 +197,7 @@ HXCPP_EXTERN_CLASS_ATTRIBUTES ::String      __string_hash_map_substr(HX_MAP_THIS
 HXCPP_EXTERN_CLASS_ATTRIBUTES ::String      __string_hash_to_string(Dynamic &hash);
 HXCPP_EXTERN_CLASS_ATTRIBUTES ::String      __string_hash_to_string_raw(Dynamic &hash);
 HXCPP_EXTERN_CLASS_ATTRIBUTES void          __string_hash_clear(Dynamic &hash);
+HXCPP_EXTERN_CLASS_ATTRIBUTES int           __string_hash_size(Dynamic &hash);
 
 HXCPP_EXTERN_CLASS_ATTRIBUTES Dynamic       __string_hash_get(Dynamic inHash,String inKey);
 HXCPP_EXTERN_CLASS_ATTRIBUTES int           __string_hash_get_int(Dynamic inHash,String inKey);
@@ -216,6 +218,7 @@ HXCPP_EXTERN_CLASS_ATTRIBUTES void          __object_hash_set_string(HX_MAP_THIS
 HXCPP_EXTERN_CLASS_ATTRIBUTES void          __object_hash_set_float(HX_MAP_THIS_ARG,Dynamic inKey,Float inValue,bool inWeakKey=false);
 HXCPP_EXTERN_CLASS_ATTRIBUTES ::String      __object_hash_to_string(Dynamic &hash);
 HXCPP_EXTERN_CLASS_ATTRIBUTES void          __object_hash_clear(Dynamic &hash);
+HXCPP_EXTERN_CLASS_ATTRIBUTES int           __object_hash_size(Dynamic &hash);
 
 
 HXCPP_EXTERN_CLASS_ATTRIBUTES Dynamic       __object_hash_get(Dynamic inHash,Dynamic inKey);

--- a/include/hx/StdLibs.h
+++ b/include/hx/StdLibs.h
@@ -177,7 +177,6 @@ HXCPP_EXTERN_CLASS_ATTRIBUTES void          __int_hash_set_string(HX_MAP_THIS_AR
 HXCPP_EXTERN_CLASS_ATTRIBUTES void          __int_hash_set_float(HX_MAP_THIS_ARG,int inKey,Float inValue);
 HXCPP_EXTERN_CLASS_ATTRIBUTES ::String      __int_hash_to_string(Dynamic &hash);
 HXCPP_EXTERN_CLASS_ATTRIBUTES void          __int_hash_clear(Dynamic &hash);
-HXCPP_EXTERN_CLASS_ATTRIBUTES int           __int_hash_size(Dynamic &hash);
 
 HXCPP_EXTERN_CLASS_ATTRIBUTES Dynamic       __int_hash_get(Dynamic inHash,int inKey);
 HXCPP_EXTERN_CLASS_ATTRIBUTES int           __int_hash_get_int(Dynamic inHash,int inKey);
@@ -201,7 +200,6 @@ HXCPP_EXTERN_CLASS_ATTRIBUTES ::String      __string_hash_map_substr(HX_MAP_THIS
 HXCPP_EXTERN_CLASS_ATTRIBUTES ::String      __string_hash_to_string(Dynamic &hash);
 HXCPP_EXTERN_CLASS_ATTRIBUTES ::String      __string_hash_to_string_raw(Dynamic &hash);
 HXCPP_EXTERN_CLASS_ATTRIBUTES void          __string_hash_clear(Dynamic &hash);
-HXCPP_EXTERN_CLASS_ATTRIBUTES int           __string_hash_size(Dynamic &hash);
 
 HXCPP_EXTERN_CLASS_ATTRIBUTES Dynamic       __string_hash_get(Dynamic inHash,String inKey);
 HXCPP_EXTERN_CLASS_ATTRIBUTES int           __string_hash_get_int(Dynamic inHash,String inKey);
@@ -222,7 +220,6 @@ HXCPP_EXTERN_CLASS_ATTRIBUTES void          __object_hash_set_string(HX_MAP_THIS
 HXCPP_EXTERN_CLASS_ATTRIBUTES void          __object_hash_set_float(HX_MAP_THIS_ARG,Dynamic inKey,Float inValue,bool inWeakKey=false);
 HXCPP_EXTERN_CLASS_ATTRIBUTES ::String      __object_hash_to_string(Dynamic &hash);
 HXCPP_EXTERN_CLASS_ATTRIBUTES void          __object_hash_clear(Dynamic &hash);
-HXCPP_EXTERN_CLASS_ATTRIBUTES int           __object_hash_size(Dynamic &hash);
 
 
 HXCPP_EXTERN_CLASS_ATTRIBUTES Dynamic       __object_hash_get(Dynamic inHash,Dynamic inKey);

--- a/src/hx/Hash.cpp
+++ b/src/hx/Hash.cpp
@@ -238,6 +238,15 @@ void __int_hash_clear(Dynamic &ioHash)
       hash->clear();
 }
 
+int __int_hash_size(Dynamic &ioHash)
+{
+   IntHashBase *hash = static_cast<IntHashBase *>(ioHash.GetPtr());
+   if(!hash)
+      return 0;
+   return ((IntHashObject *) hash)->getSize();
+}
+
+
 
 
 // --- StringHash ----------------------------------------------------
@@ -547,6 +556,14 @@ void __string_hash_clear(Dynamic &ioHash)
       hash->clear();
 }
 
+int __string_hash_size(Dynamic &ioHash)
+{
+   StringHashBase *hash = static_cast<StringHashBase *>(ioHash.GetPtr());
+   if(!hash)
+      return 0;
+   return ((StringHashObject *) hash)->getSize();
+}
+
 
 
 
@@ -821,5 +838,13 @@ void __object_hash_clear(Dynamic &ioHash)
    DynamicHashBase *hash = static_cast<DynamicHashBase *>(ioHash.GetPtr());
    if (hash)
       hash->clear();
+}
+
+int __object_hash_size(Dynamic &ioHash)
+{
+   DynamicHashBase *hash = static_cast<DynamicHashBase *>(ioHash.GetPtr());
+   if(!hash)
+      return 0;
+   return ((DynamicHashObject *) hash)->getSize();
 }
 

--- a/src/hx/Hash.cpp
+++ b/src/hx/Hash.cpp
@@ -5,6 +5,17 @@
 using namespace hx;
 
 
+// --- HashRoot ---------------------------------------------------
+
+int __root_hash_size(Dynamic &rtHash)
+{
+   HashRoot *hash = static_cast<HashRoot *>(rtHash.GetPtr());
+   if(!hash)
+      return 0;
+   return hash->getSize();
+}
+
+
 // --- IntHash ----------------------------------------------------
 
 namespace
@@ -237,15 +248,6 @@ void __int_hash_clear(Dynamic &ioHash)
    if (hash)
       hash->clear();
 }
-
-int __int_hash_size(Dynamic &ioHash)
-{
-   IntHashBase *hash = static_cast<IntHashBase *>(ioHash.GetPtr());
-   if(!hash)
-      return 0;
-   return ((IntHashObject *) hash)->getSize();
-}
-
 
 
 
@@ -556,15 +558,6 @@ void __string_hash_clear(Dynamic &ioHash)
       hash->clear();
 }
 
-int __string_hash_size(Dynamic &ioHash)
-{
-   StringHashBase *hash = static_cast<StringHashBase *>(ioHash.GetPtr());
-   if(!hash)
-      return 0;
-   return ((StringHashObject *) hash)->getSize();
-}
-
-
 
 
 // --- ObjectHash ----------------------------------------------------
@@ -838,13 +831,5 @@ void __object_hash_clear(Dynamic &ioHash)
    DynamicHashBase *hash = static_cast<DynamicHashBase *>(ioHash.GetPtr());
    if (hash)
       hash->clear();
-}
-
-int __object_hash_size(Dynamic &ioHash)
-{
-   DynamicHashBase *hash = static_cast<DynamicHashBase *>(ioHash.GetPtr());
-   if(!hash)
-      return 0;
-   return ((DynamicHashObject *) hash)->getSize();
 }
 

--- a/src/hx/Hash.h
+++ b/src/hx/Hash.h
@@ -218,10 +218,15 @@ template<typename T> inline void CopyValue(null &, const T &) {  }
 struct HashRoot : public Object
 {
    HashStore store;
+   int       size;
+   int       mask;
+   int       bucketCount;
 
     HX_IS_INSTANCE_OF enum { _hx_ClassId = hx::clsIdHash };
 
    virtual void updateAfterGc() = 0;
+   
+   inline int getSize() { return size; }
 };
 
 template<typename KEY>
@@ -230,6 +235,9 @@ struct HashBase : public HashRoot
    HashBase(int inStore)
    {
       store = (HashStore)inStore;
+      size = 0;
+      mask = 0;
+      bucketCount = 0;
    }
 
 
@@ -276,22 +284,15 @@ struct Hash : public HashBase< typename ELEMENT::Key >
    enum { IgnoreHash = Element::IgnoreHash };
 
 
-   int       size;
-   int       mask;
-   int       bucketCount;
-   ELEMENT   **bucket;
+   ELEMENT **bucket;
 
 
    Hash() : HashBase<Key>( StoreOf<Value>::store )
    {
       bucket = 0;
-      size = 0;
-      mask = 0;
-      bucketCount = 0;
       if (ELEMENT::WeakKeys && Element::ManageKeys)
          RegisterWeakHash(this);
    }
-   inline int getSize() { return size; }
 
    template<typename T>
    bool TIsWeakRefValid(T &) { return true; }

--- a/src/hx/Hash.h
+++ b/src/hx/Hash.h
@@ -279,6 +279,7 @@ struct Hash : public HashBase< typename ELEMENT::Key >
    using HashRoot::size;
    using HashRoot::mask;
    using HashRoot::bucketCount;
+   using HashRoot::getSize;
    
    typedef typename ELEMENT::Key   Key;
    typedef typename ELEMENT::Value Value;

--- a/src/hx/libs/regexp/RegExp.cpp
+++ b/src/hx/libs/regexp/RegExp.cpp
@@ -244,4 +244,19 @@ Dynamic _hx_regexp_matched_pos(Dynamic handle, int m)
             ->setFixed(1,HX_("pos",94,5d,55,00),start);
 }
 
+/**
+   regexp_matched_num : 'regexp -> int
+   <doc>Return the total number of matched groups, or -1 if the regexp has not
+   been matched yet</doc>
+**/
+int _hx_regexp_matched_num(Dynamic handle)
+{
+   pcredata *d = PCRE(handle);
+   
+   if( !d->string.raw_ptr() )
+      return -1;
+   else
+      return d->nmatchs;
+}
+
 


### PR DESCRIPTION
Part 2 of an effort to add methods to get the size of a map, and the number of captures from a regex.

There are other ways I could implement the size method for Hashes, so I can do it another way if you don't like my current implementation.

### Option 1
The current solution, which is to cast the `XXXHashBase *` value to `XXXHashObject *` and access `getSize` that way.
```cpp
int __XXX_hash_size(Dynamic &ioHash) {
    XXXHashBase *hash = static_cast<XXXHashBase *>(ioHash.GetPtr());
    if(!hash)
       return 0;
    return ((XXXHashObject *) hash)->getSize();
}
```

### Option 2
Add `HashBase#getSize()` as a virtual method, and remove the `inline` qualifier from the `Hash#getSize()` method.
```cpp
class HashBase ... {
    ...
    virtual int getSize() = 0;
};

class Hash ... {
    ...
    int getSize() { return size; }
};
```

### Option 3
Instead of making `getSize` a virtual method, add a variant of it that *is* virtual instead (that way it doesn't affectexisting code).
```cpp
class HashBase ... {
    ...
    virtual int getDynSize() = 0;
};

class Hash ... {
    ...
    int getDynSize() { return size; }
};
```

### Option 4
Move the `size` property from `Hash` to `HashBase`, and then move `getSize` from `Hash` to `HashBase` so that it can remain inline.
```cpp
class HashBase ... {
    int size;
    ...
    inline int getSize() { return size; }
};

class Hash ... {
    ...
};
```

Part 1: https://github.com/HaxeFoundation/hashlink/pull/437