### PR TITLE
Implement non-blocking process exit code fetching

### DIFF
--- a/include/hx/StdLibs.h
+++ b/include/hx/StdLibs.h
@@ -610,7 +610,11 @@ HXCPP_EXTERN_CLASS_ATTRIBUTES int _hx_std_process_stdout_read( Dynamic handle, A
 HXCPP_EXTERN_CLASS_ATTRIBUTES int _hx_std_process_stderr_read( Dynamic handle, Array<unsigned char> buf, int pos, int len );
 HXCPP_EXTERN_CLASS_ATTRIBUTES int _hx_std_process_stdin_write( Dynamic handle, Array<unsigned char> buf, int pos, int len );
 HXCPP_EXTERN_CLASS_ATTRIBUTES void _hx_std_process_stdin_close( Dynamic handle );
+#if (HXCPP_API_LEVEL > 420)
 HXCPP_EXTERN_CLASS_ATTRIBUTES Dynamic _hx_std_process_exit( Dynamic handle, bool block );
+#else
+HXCPP_EXTERN_CLASS_ATTRIBUTES int _hx_std_process_exit( Dynamic handle );
+#endif
 HXCPP_EXTERN_CLASS_ATTRIBUTES int _hx_std_process_pid( Dynamic handle );
 HXCPP_EXTERN_CLASS_ATTRIBUTES void _hx_std_process_kill( Dynamic handle );
 HXCPP_EXTERN_CLASS_ATTRIBUTES void _hx_std_process_close( Dynamic handle );

--- a/include/hx/StdLibs.h
+++ b/include/hx/StdLibs.h
@@ -610,7 +610,7 @@ HXCPP_EXTERN_CLASS_ATTRIBUTES int _hx_std_process_stdout_read( Dynamic handle, A
 HXCPP_EXTERN_CLASS_ATTRIBUTES int _hx_std_process_stderr_read( Dynamic handle, Array<unsigned char> buf, int pos, int len );
 HXCPP_EXTERN_CLASS_ATTRIBUTES int _hx_std_process_stdin_write( Dynamic handle, Array<unsigned char> buf, int pos, int len );
 HXCPP_EXTERN_CLASS_ATTRIBUTES void _hx_std_process_stdin_close( Dynamic handle );
-HXCPP_EXTERN_CLASS_ATTRIBUTES int _hx_std_process_exit( Dynamic handle );
+HXCPP_EXTERN_CLASS_ATTRIBUTES Dynamic _hx_std_process_exit( Dynamic handle, bool block );
 HXCPP_EXTERN_CLASS_ATTRIBUTES int _hx_std_process_pid( Dynamic handle );
 HXCPP_EXTERN_CLASS_ATTRIBUTES void _hx_std_process_kill( Dynamic handle );
 HXCPP_EXTERN_CLASS_ATTRIBUTES void _hx_std_process_close( Dynamic handle );

--- a/src/hx/libs/std/Process.cpp
+++ b/src/hx/libs/std/Process.cpp
@@ -455,7 +455,7 @@ void _hx_std_process_stdin_close( Dynamic handle )
    Wait until the process terminate, then returns its exit code.
    </doc>
 **/
-int _hx_std_process_exit( Dynamic handle )
+Dynamic _hx_std_process_exit( Dynamic handle, bool block )
 {
    vprocess *p = getProcess(handle);
 
@@ -463,19 +463,38 @@ int _hx_std_process_exit( Dynamic handle )
    #ifdef NEKO_WINDOWS
    {
       DWORD rval;
-      WaitForSingleObject(p->pinf.hProcess,INFINITE);
+      DWORD wait = INFINITE;
+      if (!block)
+         wait = 0;
+      
+      WaitForSingleObject(p->pinf.hProcess,wait);
       hx::ExitGCFreeZone();
 
-      if( !GetExitCodeProcess(p->pinf.hProcess,&rval) )
+      if( !GetExitCodeProcess(p->pinf.hProcess,&rval) && block)
          return 0;
-      return rval;
+      else if (!block && rval == STILL_ACTIVE)
+         return null();
+      else
+         return rval;
    }
    #else
+   int options=0;
+   if (!block)
+      options = WNOHANG;
+   
    int rval=0;
-   while( waitpid(p->pid,&rval,0) != p->pid )
+   pid_t ret=-1;
+   while( (ret = waitpid(p->pid,&rval,options)) != p->pid )
    {
       if( errno == EINTR )
          continue;
+      
+      if (!block && ret == 0)
+      {
+         hx::ExitGCFreeZone();
+         return null();
+      }
+
       hx::ExitGCFreeZone();
       return 0;
    }
@@ -536,7 +555,7 @@ int _hx_std_process_stdout_read( Dynamic handle, Array<unsigned char> buf, int p
 int _hx_std_process_stderr_read( Dynamic handle, Array<unsigned char> buf, int pos, int len ) { return 0; }
 int _hx_std_process_stdin_write( Dynamic handle, Array<unsigned char> buf, int pos, int len ) { return 0; }
 void _hx_std_process_stdin_close( Dynamic handle ) { }
-int _hx_std_process_exit( Dynamic handle ) { return 0; }
+Dynamic _hx_std_process_exit( Dynamic handle, bool block ) { return 0; }
 int _hx_std_process_pid( Dynamic handle ) { return 0; }
 void _hx_std_process_close( Dynamic handle ) { }
 void _hx_std_process_kill( Dynamic handle ) { }


### PR DESCRIPTION
Adds support for non-blocking process exit code fetching. Should this updated function be behind a `HXCPP_API_LEVEL` ifdef?