### PR TITLE
Fix `_hx_std_put_env` on windows

### DIFF
--- a/src/hx/libs/std/Sys.cpp
+++ b/src/hx/libs/std/Sys.cpp
@@ -99,11 +99,11 @@ void _hx_std_put_env( String e, String v )
 #ifdef HX_WINRT
    // Do nothing
 #elif defined(NEKO_WINDOWS)
-   String set = e + HX_CSTRING("=") + (v == null()?'\0':v);
+   String set = e + HX_CSTRING("=") + (v != null()?v:"");
 
    #ifdef HX_SMART_STRINGS
    if (set.isUTF16Encoded())
-      _wputenv( set.wchar_str() );
+      _wputenv(set.wchar_str());
    else
    #endif
       putenv(set.utf8_str());
@@ -904,5 +904,3 @@ int _hx_std_sys_get_pid()
    return (getpid());
 #   endif
 }
-
-


### PR DESCRIPTION
Previously, when attempting to set an environment variable to `null` on Windows it would set it to "0" instead. Now it properly sets it to `null`.