### PR TITLE
Disable Windows XP compat.

### DIFF
--- a/docs/build_xml/Defines.md
+++ b/docs/build_xml/Defines.md
@@ -87,4 +87,4 @@ Defines affecting target architecture.
 | *mingw*                 | Compile for windows using mingw |
 | *HXCPP_MINGW*           | Compile for windows using mingw |
 | *NO_AUTO_MSVC*          | Do not detect msvc location, use the one already in the executable path |
-
+| *HXCPP_WINXP_COMPAT*    | Remain compatible with Windows XP. Disables condition variables. No effect on ARM. |

--- a/toolchain/finish-setup.xml
+++ b/toolchain/finish-setup.xml
@@ -96,10 +96,6 @@
 <set name="HX_TARGET_PREFIX" value="${LIBPREFIX}" />
 
 <section if="isMsvc">
-   <section unless="HXCPP_M64">
-      <set name="HXCPP_NO_WINXP_COMPAT" value="1" if="HX_WINRT || winrt" />
-      <set name="HXCPP_WINXP_COMPAT" value="1" unless="HXCPP_NO_WINXP_COMPAT" />
-   </section>
    <setup name="msvc"/>
 
    <section if="static_link" >
@@ -122,5 +118,3 @@
    </section>
 </section>
 </xml>
-
-


### PR DESCRIPTION
Can still be enabled with `HXCPP_WINXP_COMPAT`.
Required for HaxeFoundation/haxe#10503.