### PR TITLE
Use absolute path to NDK folders.

### DIFF
--- a/tools/hxcpp/Setup.hx
+++ b/tools/hxcpp/Setup.hx
@@ -47,7 +47,7 @@ class Setup
           for (file in files)
           {
              file = file.split("\\").join("/");
-             var version = getNdkVersion(file);
+             var version = getNdkVersion(ndkDir + "/" + file);
              if (inBaseVersion==0 || Std.int(version)==inBaseVersion)
              {
                 if (version>bestVersion)


### PR DESCRIPTION
Since hxcpp doesn't run from the NDK directory, it requires an absolute path to be able to access source.properties. Getting the version from the directory name is unaffected, which is likely why this went unnoticed for so long.