### PR TITLE
Fixed the RunMain

### DIFF
--- a/tools/run/RunMain.hx
+++ b/tools/run/RunMain.hx
@@ -31,7 +31,7 @@ class RunMain
       log("     neko build.n");
 
       var gotUserResponse = false;
-      neko.vm.Thread.create(function() {
+      sys.thread.Thread.create(function() {
          Sys.sleep(30);
          if (!gotUserResponse)
          {


### PR DESCRIPTION
the neko.vm.Thread is deprecated and it is not used anymore in the latest version of haxe thats why its better to have the sys version instead of the neko version