### PR TITLE
Fix mysql_select_db and mysql_close

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -3,6 +3,7 @@
 * Update MIN_IOS_VERSION
 * Bug fixes
 * Upgrade to 4.2 API
+* Fixed mysql_select_db failing for newer mariadb versions due to extra 0x00 byte after database
 
 4.1.15
 ------------------------------------------------------------

--- a/Changes.md
+++ b/Changes.md
@@ -4,6 +4,7 @@
 * Bug fixes
 * Upgrade to 4.2 API
 * Fixed mysql_select_db failing for newer mariadb versions due to extra 0x00 byte after database
+* Fixed mysql_close not sending COM_QUIT before closing socket
 
 4.1.15
 ------------------------------------------------------------

--- a/src/hx/libs/mysql/my_api.cpp
+++ b/src/hx/libs/mysql/my_api.cpp
@@ -244,7 +244,8 @@ int mysql_select_db( MYSQL *m, const char *dbname ) {
 	int pcount = 0;
 	myp_begin_packet(p,0);
 	myp_write_byte(p,COM_INIT_DB);
-	myp_write_string(p,dbname);
+	// send dbname without trailing 0x00
+	myp_write(p,dbname,strlen(dbname));
 	if( !myp_send_packet(m,p,&pcount) ) {
 		error(m,"Failed to send packet",NULL);
 		return -1;

--- a/src/hx/libs/mysql/my_api.cpp
+++ b/src/hx/libs/mysql/my_api.cpp
@@ -423,6 +423,11 @@ int mysql_real_escape_string( MYSQL *m, char *sout, const char *sin, int length 
 }
 
 void mysql_close( MYSQL *m ) {
+	MYSQL_PACKET *p = &m->packet;
+	int pcount = 0;
+	myp_begin_packet(p,0);
+	myp_write_byte(p,COM_QUIT);
+	myp_send_packet(m,p,&pcount);
 	myp_close(m);
 	free(m->packet.buf);
 	free(m->infos.server_version);


### PR DESCRIPTION
after installing a new Linux server I noticed some of my tools failed to connect to a mariadb database.
some debugging and packet sniffing and comparing with PHP communication later I came to the conclusion it's the extra 0x00 byte at the end of database names in `mysql_select_db` that makes it fail.

my changes fix failing mysql tests on my system (while failing on master branch), but I haven't tested Windows or Mac. 
currently they silently fail on azure, so hopefully PR will fix CI as well.

I've also added a `COM_QUIT` packet for `mysql_close` because mariadb always complained about aborted connections since Haxe would just close socket its connection without notifying server side.