### PR TITLE
Fix endless recursion in Class_obj::GetInstanceFields

### DIFF
--- a/src/hx/Class.cpp
+++ b/src/hx/Class.cpp
@@ -195,7 +195,7 @@ String Class_obj::__ToString() const { return mName; }
 
 Array<String> Class_obj::GetInstanceFields()
 {
-   Array<String> result = mSuper ? (*mSuper)->GetInstanceFields() : Array<String>(0,0);
+   Array<String> result = mSuper && (*mSuper).mPtr != this ? (*mSuper)->GetInstanceFields() : Array<String>(0,0);
    if (mMembers.mPtr)
       for(int m=0;m<mMembers->size();m++)
       {


### PR DESCRIPTION
cpp::Pointer.mSuper points to same cpp::Pointer instance

Steps to reproduce:
1. get this repo and build debug sample https://github.com/foreignsasquatch/raylib-hx/tree/main/examples
2. add breakpoint inside while loop https://github.com/foreignsasquatch/raylib-hx/blob/main/examples/BasicWindow.hx#L12
3. start debugger session in vscode

stacktrace
https://gist.github.com/profelis/390f80bc47afc16f41b3afced4896cc6