### PR TITLE
Fix misleading warnings in msvc setup scripts

### DIFF
--- a/toolchain/msvc-setup.bat
+++ b/toolchain/msvc-setup.bat
@@ -16,7 +16,7 @@ setlocal enabledelayedexpansion
 		@echo HXCPP_VARS
 		@set
 	) else (
-		echo Warning: Could not find Visual Studio 2017 VsDevCmd
+		echo Warning: Could not find Visual Studio VsDevCmd
 	)
 ) else if exist "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat" (
 	@call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat" -arch=x86 -app_platform=Desktop -no_logo

--- a/toolchain/msvc-winrt-setup.bat
+++ b/toolchain/msvc-winrt-setup.bat
@@ -10,7 +10,7 @@ setlocal enabledelayedexpansion
 		@echo HXCPP_VARS
 		@set
 	) else (
-		echo Warning: Could not find Visual Studio 2017 VsDevCmd
+		echo Warning: Could not find Visual Studio VsDevCmd
 	)
 ) else if exist "%VS140COMNTOOLS%\vsvars32.bat" (
 	@call "%VS140COMNTOOLS%\vsvars32.bat"
@@ -21,5 +21,5 @@ setlocal enabledelayedexpansion
 	@echo HXCPP_VARS
 	@set
 ) else (
-	echo Warning: Could not find x64 environment variables for Visual Studio 2015 or 2017 compiler
+	echo Warning: Could not find x64 environment variables for Visual Studio compiler
 )

--- a/toolchain/msvc-winrt64-setup.bat
+++ b/toolchain/msvc-winrt64-setup.bat
@@ -11,7 +11,7 @@ setlocal enabledelayedexpansion
 	        @set
 	        @echo HXCPP_HACK_PDBSRV=1
 	) else (
-		echo Warning: Could not find Visual Studio 2017 VsDevCmd
+		echo Warning: Could not find Visual Studio VsDevCmd
 	)
 ) else if exist "%VS140COMNTOOLS%\..\..\VC\bin\x86_amd64\vcvarsx86_amd64.bat" (
 	@call "%VS140COMNTOOLS%\..\..\VC\bin\x86_amd64\vcvarsx86_amd64.bat"
@@ -23,5 +23,5 @@ setlocal enabledelayedexpansion
 	@set
 	@echo HXCPP_HACK_PDBSRV=1
 ) else (
-	echo Warning: Could not find x64 environment variables for Visual Studio 2015 or 2017 compiler
+	echo Warning: Could not find x64 environment variables for Visual Studio compiler
 )

--- a/toolchain/msvc64-setup.bat
+++ b/toolchain/msvc64-setup.bat
@@ -17,7 +17,7 @@ setlocal enabledelayedexpansion
 		@echo HXCPP_VARS
 		@set
 	) else (
-		echo Warning: Could not find Visual Studio 2017 VsDevCmd
+		echo Warning: Could not find Visual Studio VsDevCmd
 	)
 ) else if exist "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat" (
 	@call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat" -arch=amd64 -app_platform=Desktop -no_logo


### PR DESCRIPTION
Currently, if locating MSVC via vswhere fails, hxcpp says `Could not find Visual Studio 2017 VsDevCmd`. This is misleading since vswhere is used for all versions of Visual Studio since 2017, so it makes it seem like hxcpp tried to look for the wrong version of MSVC.

Closes #1008