### PR TITLE
Replace `<::cpp::Int64>` with `< ::cpp::Int64>` to fix template errors

### DIFF
--- a/include/Array.h
+++ b/include/Array.h
@@ -44,7 +44,7 @@ template<> struct ReturnNull<unsigned char> { typedef Dynamic type; };
 template<> struct ReturnNull<short> { typedef Dynamic type; };
 template<> struct ReturnNull<unsigned short> { typedef Dynamic type; };
 template<> struct ReturnNull<unsigned int> { typedef Dynamic type; };
-template<> struct ReturnNull<::cpp::Int64> { typedef Dynamic type; };
+template<> struct ReturnNull< ::cpp::Int64> { typedef Dynamic type; };
 
 template<typename T>
 struct ArrayTraits { enum { StoreType = arrayObject }; };
@@ -53,7 +53,7 @@ template<> struct ArrayTraits<float> { enum { StoreType = arrayFloat}; };
 template<> struct ArrayTraits<double> { enum { StoreType = arrayFloat}; };
 template<> struct ArrayTraits<Dynamic> { enum { StoreType = arrayObject }; };
 template<> struct ArrayTraits<String> { enum { StoreType = arrayString }; };
-template<> struct ArrayTraits<::cpp::Int64> { enum { StoreType = arrayInt64 }; };
+template<> struct ArrayTraits< ::cpp::Int64> { enum { StoreType = arrayInt64 }; };
 
 }
 
@@ -461,7 +461,7 @@ template<> inline bool *NewNull<bool>() { bool b=0; return (bool *)hx::NewGCPriv
 template<> inline double *NewNull<double>() { double d=0.0; return (double *)hx::NewGCPrivate(&d,sizeof(d)); }
 template<> inline float *NewNull<float>() { float d=0.0f; return (float *)hx::NewGCPrivate(&d,sizeof(d)); }
 template<> inline unsigned char *NewNull<unsigned char>() { unsigned char u=0; return (unsigned char *)hx::NewGCPrivate(&u,sizeof(u)); }
-template<> inline ::cpp::Int64 *NewNull<::cpp::Int64>() { ::cpp::Int64 i=0; return (::cpp::Int64 *)hx::NewGCPrivate(&i,sizeof(i)); }
+template<> inline ::cpp::Int64 *NewNull< ::cpp::Int64>() { ::cpp::Int64 i=0; return (::cpp::Int64 *)hx::NewGCPrivate(&i,sizeof(i)); }
 
 
 bool DynamicEq(const Dynamic &a, const Dynamic &b);
@@ -478,7 +478,7 @@ template<> struct ArrayClassId<signed int> { enum { id=hx::clsIdArrayInt }; };
 template<> struct ArrayClassId<float> { enum { id=hx::clsIdArrayFloat32 }; };
 template<> struct ArrayClassId<double> { enum { id=hx::clsIdArrayFloat64 }; };
 template<> struct ArrayClassId<String> { enum { id=hx::clsIdArrayString }; };
-template<> struct ArrayClassId<::cpp::Int64> { enum { id=hx::clsIdArrayInt64 }; };
+template<> struct ArrayClassId< ::cpp::Int64> { enum { id=hx::clsIdArrayInt64 }; };
 
 // sort...
 #include <algorithm>

--- a/include/Dynamic.h
+++ b/include/Dynamic.h
@@ -421,7 +421,7 @@ inline bool Dynamic::IsClass<String>() { return mPtr && mPtr->__GetClass()==hx::
 template<>
 inline bool Dynamic::IsClass<Dynamic>() { return true; }
 template<>
-inline bool Dynamic::IsClass<::cpp::Int64>() { return mPtr && mPtr->__GetClass()==hx::GetInt64Class(); }
+inline bool Dynamic::IsClass< ::cpp::Int64>() { return mPtr && mPtr->__GetClass()==hx::GetInt64Class(); }
 
 inline String Dynamic::operator+(const String &s) const { return Cast<String>() + s; }
 

--- a/include/hx/Class.h
+++ b/include/hx/Class.h
@@ -33,7 +33,7 @@ template<>
 inline hx::Class &ClassOf<String>() { return GetStringClass(); }
 
 template<>
-inline hx::Class &ClassOf<::cpp::Int64>() { return GetInt64Class(); }
+inline hx::Class &ClassOf< ::cpp::Int64>() { return GetInt64Class(); }
 
 
 template<typename T>

--- a/src/Array.cpp
+++ b/src/Array.cpp
@@ -1017,13 +1017,13 @@ void VirtualArray_obj::MakeInt64Array()
    if (store==arrayEmpty && base)
    {
       int len = base->length;
-      base = new Array_obj<::cpp::Int64>(len, len);
+      base = new Array_obj< ::cpp::Int64>(len, len);
    }
    else if (!base)
-      base = new Array_obj<::cpp::Int64>(0, 0);
+      base = new Array_obj< ::cpp::Int64>(0, 0);
    else
    {
-      Array<::cpp::Int64> result = Dynamic(base);
+      Array< ::cpp::Int64> result = Dynamic(base);
       base = result.mPtr;
    }
    store = arrayInt64;


### PR DESCRIPTION
On hxcpp 4.3.2, I got template build errors related to usage `<::cpp::Int64>` when using native code that includes <hxcpp.h> like the one in [linc_dialogs](https://github.com/ceramic-engine/linc_dialogs).

It seems the way to go is to simply keep a space between `<` and `::` so that the compiler doesn't parse it wrong. This pull request does just that.

@Aidan63 you might be interested in this PR as it's related to your Int64 changes.