### PR TITLE
Fix dynamic constructor errors on mingw

### DIFF
--- a/include/Dynamic.h
+++ b/include/Dynamic.h
@@ -38,7 +38,7 @@ public:
    Dynamic(const cpp::Variant &inRHS) : super(inRHS.asDynamic()) { }
    template<typename T>
    Dynamic(const hx::Native<T *> &inInterface):super(inInterface.ptr ? inInterface->__GetRealObject() : (hx::Object *)0 ) { }
-   #if !defined(__GNUC__) || (defined(__WORDSIZE) && (__WORDSIZE != 64))
+   #if !defined(__GNUC__) || defined(__MINGW32__) || (defined(__WORDSIZE) && (__WORDSIZE != 64))
    Dynamic(long inVal);
    Dynamic(unsigned long inVal);
    #endif
@@ -408,7 +408,7 @@ HXCPP_EXTERN_CLASS_ATTRIBUTES hx::Class &GetInt64Class();
 template<>
 inline bool Dynamic::IsClass<int>() { return mPtr && mPtr->__GetClass()==hx::GetIntClass(); }
 template<>
-inline bool Dynamic::IsClass<double>() { return mPtr && 
+inline bool Dynamic::IsClass<double>() { return mPtr &&
    ( mPtr->__GetClass()==hx::GetIntClass() || mPtr->__GetClass()==hx::GetFloatClass()) ; }
 template<>
 inline bool Dynamic::IsClass<float>() { return mPtr && mPtr->__GetClass()==hx::GetFloatClass(); }
@@ -458,7 +458,7 @@ bool operator==(Platform::Box<T> ^inPtr, nullptr_t)
    inline bool operator op (float inLHS,const ::Dynamic &inRHS) \
       { return inRHS.IsNumeric() && ((double)inLHS op (double)inRHS); } \
    inline bool operator op (int inLHS,const ::Dynamic &inRHS) \
-      { return inRHS.IsNumeric() && (inLHS op (double)inRHS); } 
+      { return inRHS.IsNumeric() && (inLHS op (double)inRHS); }
 
 COMPARE_DYNAMIC_OP( < )
 COMPARE_DYNAMIC_OP( <= )

--- a/src/Dynamic.cpp
+++ b/src/Dynamic.cpp
@@ -302,7 +302,7 @@ public:
          diff = __GetType() - inRHS->__GetType();
       if (diff==0)
          diff = memcmp( mValue, inRHS->__GetHandle(), mLength );
-       
+
       if (diff<0) return -1;
       if (diff>0) return 1;
       return 0;
@@ -386,7 +386,7 @@ Dynamic::Dynamic(short inVal)
    mPtr = fromInt(inVal);
 }
 
-#if !defined(__GNUC__) || (defined(__WORDSIZE) && (__WORDSIZE != 64))
+#if !defined(__GNUC__) || defined(__MINGW32__) || (defined(__WORDSIZE) && (__WORDSIZE != 64))
 Dynamic::Dynamic(unsigned long inVal)
 {
    mPtr = fromInt(inVal);
@@ -642,5 +642,3 @@ void Dynamic::__boot()
    Static(__ObjcClass) = hx::_hx_RegisterClass(HX_CSTRING("objc::BoxedType"),IsPointer,sNone,sNone, 0,0,&__ObjcClass );
 #endif
 }
-
-


### PR DESCRIPTION
Currently, there are these building errors with mingw:

```
D:/Dev/Haxe/hxcpp/src/hx/libs/std/Process.cpp: In function 'Dynamic _hx_std_process_exit(Dynamic, bool)':
D:/Dev/Haxe/hxcpp/src/hx/libs/std/Process.cpp:481:17: error: conversion from 'DWORD' {aka 'long unsigned int'} to 'Dynamic' is ambiguous
  481 |          return rval;
      |                 ^~~~
In file included from D:/Dev/Haxe/hxcpp/include/hxcpp.h:357:
D:/Dev/Haxe/hxcpp/include/Dynamic.h:32:4: note: candidate: 'Dynamic::Dynamic(cpp::UInt64)'
   32 |    Dynamic(cpp::UInt64 inVal);
      |    ^~~~~~~
D:/Dev/Haxe/hxcpp/include/Dynamic.h:31:4: note: candidate: 'Dynamic::Dynamic(cpp::Int64)'
   31 |    Dynamic(cpp::Int64 inVal);
      |    ^~~~~~~
D:/Dev/Haxe/hxcpp/include/Dynamic.h:30:4: note: candidate: 'Dynamic::Dynamic(float)'
   30 |    Dynamic(float inVal);
      |    ^~~~~~~
D:/Dev/Haxe/hxcpp/include/Dynamic.h:29:4: note: candidate: 'Dynamic::Dynamic(double)'
   29 |    Dynamic(double inVal);
      |    ^~~~~~~
D:/Dev/Haxe/hxcpp/include/Dynamic.h:28:4: note: candidate: 'Dynamic::Dynamic(bool)'
   28 |    Dynamic(bool inVal);
      |    ^~~~~~~
D:/Dev/Haxe/hxcpp/include/Dynamic.h:26:4: note: candidate: 'Dynamic::Dynamic(signed char)'
   26 |    Dynamic(signed char inVal);
      |    ^~~~~~~
     D:/Dev/Haxe/hxcpp/include/Dynamic.h:25:4: note: candidate: 'Dynamic::Dynamic(unsigned char)'
   25 |    Dynamic(unsigned char inVal);
      |    ^~~~~~~
D:/Dev/Haxe/hxcpp/include/Dynamic.h:24:4: note: candidate: 'Dynamic::Dynamic(short unsigned int)'
   24 |    Dynamic(unsigned short inVal);
      |    ^~~~~~~
D:/Dev/Haxe/hxcpp/include/Dynamic.h:23:4: note: candidate: 'Dynamic::Dynamic(unsigned int)'
   23 |    Dynamic(unsigned int inVal);
      |    ^~~~~~~
D:/Dev/Haxe/hxcpp/include/Dynamic.h:22:4: note: candidate: 'Dynamic::Dynamic(short int)'
   22 |    Dynamic(short inVal);
      |    ^~~~~~~
D:/Dev/Haxe/hxcpp/include/Dynamic.h:21:4: note: candidate: 'Dynamic::Dynamic(int)'
   21 |    Dynamic(int inVal);
      |    ^~~~~~~
Error: Build failed
```
Related to d9c02ec114f7db00070b46a91a45ff3bfc353530