### PR TITLE
Set -m64 flags on mingw

### DIFF
--- a/toolchain/mingw-toolchain.xml
+++ b/toolchain/mingw-toolchain.xml
@@ -43,6 +43,7 @@
   <cppflag value="-std=c++11" if="HXCPP_CPP11" />
   <cppflag value="-U__STRICT_ANSI__" />
   <flag value="-m32" unless="HXCPP_M64"/>
+  <flag value="-m64" if="HXCPP_M64"/>
   <flag value="-DHXCPP_M64" if="HXCPP_M64"/>
   <flag value="-I${HXCPP}/include"/>
   <objdir value="obj/mingw${OBJEXT}/"/>
@@ -56,6 +57,7 @@
   <flag value="-debug" if="debug"/>
   <flag value="--enable-auto-import"/>
   <flag value="-m32" unless="HXCPP_M64"/>
+  <flag value="-m64" if="HXCPP_M64"/>
   <flag value="-static" if="no_shared_libs"/>
   <flag value="-static-libgcc" if="no_shared_libs"/>
   <flag value="-static-libstdc++" if="no_shared_libs"/>
@@ -70,6 +72,7 @@
   <flag value="-Wl,--enable-auto-import"/>
   <flag value="-mwindows" if="SUBSYSTEMWINDOWS" />
   <flag value="-m32" unless="HXCPP_M64"/>
+  <flag value="-m64" if="HXCPP_M64"/>
   <flag value="-static" if="no_shared_libs"/>
   <flag value="-static-libgcc" if="no_shared_libs" unless="linux_host"/>
   <flag value="-static-libstdc++" if="no_shared_libs" unless="linux_host"/>


### PR DESCRIPTION
In other words, the `HXCPP_M64` flag is no longer silently ignored when building with mingw.

When trying to compile 64 bit with minimingw (which only supports 32 bit compilation), it will now immediately give the error: `sorry, unimplemented: 64-bit mode not compiled in`, instead of failing later on.

Closes #1031