### PR TITLE
Fix mingw dll issues

### DIFF
--- a/toolchain/mingw-toolchain.xml
+++ b/toolchain/mingw-toolchain.xml
@@ -71,10 +71,8 @@
   <flag value="-mwindows" if="SUBSYSTEMWINDOWS" />
   <flag value="-m32" unless="HXCPP_M64"/>
   <flag value="-static" if="no_shared_libs"/>
-  <flag value="-static-libgcc" if="no_shared_libs" unless="linux_host"/>
-  <flag value="-static-libstdc++" if="no_shared_libs" unless="linux_host"/>
-  <flag value="-static-libgcc" if="linux_host"/>
-  <flag value="-static-libstdc++" if="linux_host"/>
+  <flag value="-static-libgcc" if="no_shared_libs" />
+  <flag value="-static-libstdc++" if="no_shared_libs" />
   <flag value="-L${MINGW_ROOT}/lib/libs" />
   <ext value=".exe"/>
   <outflag value="-o "/>

--- a/toolchain/mingw-toolchain.xml
+++ b/toolchain/mingw-toolchain.xml
@@ -78,10 +78,12 @@
   <outflag value="-o "/>
 </linker>
 
-<copyFile toolId="exe" name="libgcc_s_dw2-1.dll" from="${MINGW_ROOT}/bin" allowMissing="true" unless="no_shared_libs"/>
+<copyFile toolId="exe" name="libgcc_s_dw2-1.dll" from="${MINGW_ROOT}/bin" allowMissing="true" unless="no_shared_libs || HXCPP_M64" />
+<copyFile toolId="exe" name="libgcc_s_seh-1.dll" from="${MINGW_ROOT}/bin" allowMissing="true" if="HXCPP_M64" unless="no_shared_libs"/>
 <copyFile toolId="exe" name="libstdc++-6.dll" from="${MINGW_ROOT}/bin" allowMissing="true" unless="no_shared_libs"/>
 <copyFile toolId="exe" name="libwinpthread-1.dll" from="${MINGW_ROOT}/sys-root/mingw/bin" allowMissing="true" unless="no_shared_libs"/>
 <copyFile toolId="exe" name="libwinpthread-1.dll" from="${MINGW_ROOT}/lib" allowMissing="true" unless="no_shared_libs"/>
+<copyFile toolId="exe" name="libwinpthread-1.dll" from="${MINGW_ROOT}/bin" allowMissing="true" unless="no_shared_libs"/>
 
 <linker id="static_link" exe="ar" >
   <ext value="${LIBEXT}"/>


### PR DESCRIPTION
Allow dynamic linking (of std library) when cross compiling from linux (std library is GPL, so static linking is not always desired), update copied dlls to include 64 bit gcc library, and add another winpthread path.