### PR TITLE
`__hxcpp_parse_int` now parses hex numbers with wrapping as before

### DIFF
--- a/src/hx/StdLibs.cpp
+++ b/src/hx/StdLibs.cpp
@@ -633,7 +633,16 @@ Dynamic __hxcpp_parse_int(const String &inString)
    while (isspace(*str)) ++str;
    bool isHex = is_hex_string(str, strlen(str));
    char *end = 0;
-   long result = isHex ? strtoul(str,&end,16) : strtol(str,&end,10);
+   long result;
+   if (isHex)
+   {
+      bool neg = str[0] == '-';
+      if (neg) str++;
+      result = strtoul(str,&end,16);
+      if (neg) result = -result;
+   }
+   else 
+      result = strtol(str,&end,10);
    #ifdef HX_WINDOWS
    if (str==end && !isHex)
    #else

--- a/src/hx/StdLibs.cpp
+++ b/src/hx/StdLibs.cpp
@@ -633,7 +633,7 @@ Dynamic __hxcpp_parse_int(const String &inString)
    while (isspace(*str)) ++str;
    bool isHex = is_hex_string(str, strlen(str));
    char *end = 0;
-   long result = strtol(str,&end,isHex ? 16 : 10);
+   long result = isHex ? strtoul(str,&end,16) : strtol(str,&end,10);
    #ifdef HX_WINDOWS
    if (str==end && !isHex)
    #else


### PR DESCRIPTION
`__hxcpp_parse_int` now parses hex numbers with wrapping as before, fixing a regression.

Old:
```haxe
Std.parseInt("0xFFFFFFFF"); // 2147483647
```

New:
```haxe
Std.parseInt("0xFFFFFFFF"); // -1
```

Closes #1052