### PR TITLE
Include string in Immix.cpp for GC logging

### DIFF
--- a/src/hx/gc/Immix.cpp
+++ b/src/hx/gc/Immix.cpp
@@ -7,6 +7,7 @@
 #include "GcRegCapture.h"
 #include <hx/Unordered.h>
 
+#include <string>
 #include <stdlib.h>
 
 


### PR DESCRIPTION
Tried to compile a project with GC debug logging (HXCPP_GC_DEBUG_LEVEL) and found it failed to compile with string not found in std errors. Including string in immix gets things working.