### PR TITLE
Use hx4compat for running sys.db tests

### DIFF
--- a/test/std/compile32.hxml
+++ b/test/std/compile32.hxml
@@ -3,3 +3,4 @@
 -D HXCPP_M32
 -D HXCPP_DEBUGGER
 -cp ../unit
+-lib hx4compat

--- a/test/std/compile64.hxml
+++ b/test/std/compile64.hxml
@@ -2,3 +2,4 @@
 -cpp cpp64
 -D HXCPP_M64
 -cp ../unit
+-lib hx4compat

--- a/test/std/testAndroid.hxml
+++ b/test/std/testAndroid.hxml
@@ -3,6 +3,7 @@
 -D android
 -D exe_link
 -cp ../unit
+-lib hx4compat
 -cmd adb push arm32/Test /storage/ext_sd
 -cmd adb push Test.hx /storage/ext_sd
 -cmd adb shell "cd /storage/ext_sd && ./Test"

--- a/tools/azure-pipelines/build.yml
+++ b/tools/azure-pipelines/build.yml
@@ -53,6 +53,7 @@ jobs:
           mkdir -p ~/haxelib
           haxelib setup ~/haxelib
           haxelib install utest
+          haxelib git hx4compat https://github.com/HaxeFoundation/hx4compat
           haxelib dev hxcpp $(Build.SourcesDirectory)
           haxelib list
         displayName: Install Haxe libraries


### PR DESCRIPTION
Fixes errors in test suite:
```
Test.hx:5: characters 8-25 : Type not found : sys.db.Connection
Test.hx:6: characters 8-21 : Type not found : sys.db.Sqlite
Test.hx:7: characters 8-20 : Type not found : sys.db.Mysql
Test.hx:102: characters 38-48 : Type not found : Connection
```