### PR TITLE
Do not add host architecture if an arm architecture is set

### DIFF
--- a/tools/hxcpp/BuildTool.hx
+++ b/tools/hxcpp/BuildTool.hx
@@ -134,7 +134,8 @@ class BuildTool
       m64 = mDefines.exists("HXCPP_M64");
       m32 = mDefines.exists("HXCPP_M32");
       arm64 = mDefines.exists("HXCPP_ARM64");
-      if (m64==m32 && !arm64)
+      var otherArmArchitecture = mDefines.exists("HXCPP_ARMV6") || mDefines.exists("HXCPP_ARMV7") || mDefines.exists("HXCPP_ARMV7S");
+      if (m64==m32 && !arm64 && !otherArmArchitecture)
       {
          var arch = getArch();
 


### PR DESCRIPTION
Currently if `HXCPP_ARMV7` is set for example, hxcpp ignores it and adds the host architecture as if no architecture were set. This causes problems, for example, because it might result in both `HXCPP_ARMV7` and `HXCPP_ARM64` being set at once, which breaks some toolchains:

https://github.com/HaxeFoundation/hxcpp/blob/18f87b949464ddcf24c6a83a2f7b8f76233540bc/toolchain/iphoneos-toolchain.xml#L43-L47

(This leads to `-arch armv7 arm64` being passed to the compiler, which causes `Error: clang: error: no such file or directory: ‘arm64’`).

This patch prevents the host architecture being added if any of the following are defined: `HXCPP_ARMV6`, `HXCPP_ARMV7`, `HXCPP_ARMV7S`.