### PR TITLE
Expose MemType

### DIFF
--- a/include/hx/GC.h
+++ b/include/hx/GC.h
@@ -283,6 +283,10 @@ void GCPrepareMultiThreaded();
 namespace hx
 {
 
+enum MemType { memUnmanaged, memBlock, memLarge };
+
+MemType GetMemType(void*);
+
 #define HX_USE_INLINE_IMMIX_OPERATOR_NEW
 
 //#define HX_STACK_CTX ::hx::ImmixAllocator *_hx_stack_ctx =  hx::gMultiThreadMode ? hx::tlsImmixAllocator : hx::gMainThreadAlloc;

--- a/src/hx/gc/Immix.cpp
+++ b/src/hx/gc/Immix.cpp
@@ -2907,8 +2907,6 @@ typedef hx::QuickVec<BlockDataInfo *> BlockList;
 
 typedef hx::QuickVec<unsigned int *> LargeList;
 
-enum MemType { memUnmanaged, memBlock, memLarge };
-
 
 
 
@@ -5524,7 +5522,7 @@ public:
       return false;
    }
 
-   MemType GetMemType(void *inPtr)
+   hx::MemType GetMemType(void *inPtr)
    {
       BlockData *block = (BlockData *)( ((size_t)inPtr) & IMMIX_BLOCK_BASE_MASK);
 
@@ -5542,16 +5540,16 @@ public:
       */
 
       if (isBlock)
-         return memBlock;
+         return hx::memBlock;
 
       for(int i=0;i<mLargeList.size();i++)
       {
          unsigned int *blob = mLargeList[i] + 2;
          if (blob==inPtr)
-            return memLarge;
+            return hx::memLarge;
       }
 
-      return memUnmanaged;
+      return hx::memUnmanaged;
    }
 
 
@@ -5742,6 +5740,11 @@ void MarkConservative(int *inBottom, int *inTop,hx::MarkContext *__inCtx)
    #ifdef SHOW_MEM_EVENTS
    GCLOG("...]\n");
    #endif
+}
+
+MemType GetMemType(void* inPtr)
+{
+    return sGlobalAlloc->GetMemType(inPtr);
 }
 
 } // namespace hx


### PR DESCRIPTION
Makes the `MemType` enum and `GetMemType` function accessible from the `hx` namespace as mentioned in #1082.