### PR TITLE
Make sys_read_dir errors consistent between platforms

### DIFF
--- a/src/hx/libs/std/Sys.cpp
+++ b/src/hx/libs/std/Sys.cpp
@@ -669,7 +669,7 @@ Array<String> _hx_std_sys_read_dir( String p )
    const wchar_t *path = p.wchar_str();
    size_t len = wcslen(path);
    if (len>MAX_PATH)
-      return null();
+      hx::Throw(HX_CSTRING("Invalid directory"));
 
    WIN32_FIND_DATAW d;
    HANDLE handle;
@@ -698,7 +698,7 @@ Array<String> _hx_std_sys_read_dir( String p )
    if( handle == INVALID_HANDLE_VALUE )
    {
       hx::ExitGCFreeZone();
-      return null();
+      hx::Throw(HX_CSTRING("Invalid directory"));
    }
    while( true )
    {


### PR DESCRIPTION
Haxe documentation specifies that an exception should be thrown if the path is not a valid directory:

> If `path` does not denote a valid directory, an exception is thrown.

This was already the case on all platforms except Windows, where `null` was returned. Now the behavior is consistent.