### PR TITLE
cppia: fix crash on functions with empty bodies

### DIFF
--- a/src/hx/cppia/Cppia.cpp
+++ b/src/hx/cppia/Cppia.cpp
@@ -442,6 +442,8 @@ struct BlockExpr : public CppiaExpr
    BlockExprRun(hx::Object *,runObject,0)
    void  runVoid(CppiaCtx *ctx)
    {
+      if (expressions.size()==0)
+         return;
       CppiaExpr **e = &expressions[0];
       CppiaExpr **end = e+expressions.size();
       for(;e<end && !ctx->breakContReturn;e++)


### PR DESCRIPTION
Im building [a basic game engine around cppia](https://twitter.com/dazKind/status/1776967620970844363) and I ran into an issue where the debug version of the host would crash with the following message:
![image](https://github.com/HaxeFoundation/hxcpp/assets/5015415/674ab49f-4eec-41a4-8304-f57e0a58d106)

In the debugger I see can see that it fails here for methods that have an empty body:
![image](https://github.com/HaxeFoundation/hxcpp/assets/5015415/7623ec87-19d3-47f2-acc3-5bd7a932c019)
![image](https://github.com/HaxeFoundation/hxcpp/assets/5015415/3ca22c44-6ac7-4f72-a3bd-e3b137287692)
![image](https://github.com/HaxeFoundation/hxcpp/assets/5015415/59cc2dfb-b571-40a3-8c32-500660453ad7)

This PR adds a simple size check in runVoid to prevent the element access of an empty expressions vector.