### PR TITLE
Fixed String.fromCharCode when using reflection

### DIFF
--- a/include/hxString.h
+++ b/include/hxString.h
@@ -354,6 +354,9 @@ public:
    // This is used by the string-wrapped-as-dynamic class
    hx::Val __Field(const ::String &inString, hx::PropertyAccess inCallProp);
 
+   // Allows for reflection to be able to get the static functions
+   static bool __GetStatic(const String&, Dynamic&, hx::PropertyAccess);
+
    // The actual implementation.
    // Note that "__s" is const - if you want to change it, you should create a new string.
    //  this allows for multiple strings to point to the same data.

--- a/src/String.cpp
+++ b/src/String.cpp
@@ -2174,6 +2174,11 @@ hx::Val String::__Field(const String &inString, hx::PropertyAccess inCallProp)
    return null();
 }
 
+bool String::__GetStatic(const ::String &inName, Dynamic &outValue, ::hx::PropertyAccess inCallProp)
+{
+   if (HX_FIELD_EQ(inName,"fromCharCode")) { outValue = fromCharCode_dyn(); return true; }
+	return false;
+}
 
 static String sStringStatics[] = {
    HX_CSTRING("fromCharCode"),
@@ -2406,6 +2411,8 @@ void String::__boot()
    Static(__StringClass) = hx::_hx_RegisterClass(HX_CSTRING("String"),TCanCast<StringData>,sStringStatics, sStringFields,
            &CreateEmptyString, &CreateString, 0, 0, 0
     );
+   __StringClass->mGetStaticField = &String::__GetStatic;
+   __StringClass->mSetStaticField = &::hx::Class_obj::SetNoStaticField;
 }
 
 


### PR DESCRIPTION
Fixes #1103 

Sorry if the code is bad, i don't know the proper way to do this. Feel free to edit this pr.

```hx
try {
    Reflect.callMethod(null, Reflect.field(String, "fromCharCode"), [65]);
    Sys.println("String.fromCharCode works from reflect.");
} catch(e:Dynamic) {
    Sys.println("[ERROR] String.fromCharCode doesn't work from reflect.");
}
```