### PR TITLE
mingw-toolchain: use same default paths for MinGW on macOS as are used on Linux

### DIFF
--- a/toolchain/mingw-toolchain.xml
+++ b/toolchain/mingw-toolchain.xml
@@ -2,7 +2,7 @@
 
 <!-- MINGW TOOLS -------------------------------------->
 
-<section if="linux_host">
+<section if="linux_host||mac_host">
   <section if="HXCPP_M64">
     <set name="HXCPP_MINGW_EXE" value="x86_64-w64-mingw32-g++" unless="HXCPP_MINGW_EXE" />
     <set name="MINGW_ROOT" value="/usr/x86_64-w64-mingw32" unless="MINGW_ROOT" />


### PR DESCRIPTION
This should help it find x86_64-w64-mingw32-g++ on macOS.