### PR TITLE
Use cwd when running `haxelib path`

### DIFF
--- a/tools/hxcpp/PathManager.hx
+++ b/tools/hxcpp/PathManager.hx
@@ -106,7 +106,7 @@ class PathManager
          
          try
          {
-            output = ProcessManager.runProcess(Sys.getEnv ("HAXEPATH"), "haxelib", [ "path", name ], true, false);
+            output = ProcessManager.runProcess("", "haxelib", [ "path", name ], true, false);
          }
          catch (e:Dynamic) {}
          


### PR DESCRIPTION
If a local haxelib repo is being used, then moving out of the cwd will break library resolution.

This was presumably done in case `haxelib` is not in `PATH`, but in that situation `HAXEPATH` is unlikely to have been set either.

Fixes: https://github.com/HaxeFoundation/haxelib/issues/618