### PR TITLE
Fix c standard error when compiling mbedtls

### DIFF
--- a/src/hx/libs/ssl/Build.xml
+++ b/src/hx/libs/ssl/Build.xml
@@ -10,6 +10,7 @@
 	<cache value="true" asLibrary="true" />
 	<compilerflag value="-I${MBEDTLS_DIR}/include"/>
 	<compilerflag value="-I${this_dir}"/>
+	<compilerflag value="-std=c99" unless="MSVC_VER" />
 
 	<file name="${this_dir}/SSL.cpp"/>
 


### PR DESCRIPTION
On some platforms (e.g. Android) it is necessary to specify the use of the c99 standard.

Closes #1064.

See also: #1041.