### PR TITLE
Don't undefine __STRICT_ANSI__ for mingw

### DIFF
--- a/toolchain/mingw-toolchain.xml
+++ b/toolchain/mingw-toolchain.xml
@@ -42,7 +42,6 @@
   <flag value="-DHXCPP_BIG_ENDIAN" if="HXCPP_BIG_ENDIAN"/>
   <cppflag value="-std=c++11" if="HXCPP_CPP11" />
   <cppflag value="-std=c++17" if="HXCPP_CPP17" />
-  <cppflag value="-U__STRICT_ANSI__" />
   <flag value="-m32" unless="HXCPP_M64"/>
   <flag value="-m64" if="HXCPP_M64"/>
   <flag value="-DHXCPP_M64" if="HXCPP_M64"/>


### PR DESCRIPTION
This was done originally for #785. However, since gcc 11.1.0, this gives a warning:
```
In file included from /usr/x86_64-w64-mingw32/include/c++/13.1.0/bits/exception.h:36,
                 from /usr/x86_64-w64-mingw32/include/c++/13.1.0/typeinfo:34,
                 from /.../hxcpp/include/hxcpp.h:27,
                 from /.../hxcpp/src/hx/Lib.cpp:1:
/usr/x86_64-w64-mingw32/include/c++/13.1.0/x86_64-w64-mingw32/bits/c++config.h:666:2: warning: #warning "__STRICT_ANSI__ seems to have been undefined; this is not supported" [-Wcpp]
  666 | #warning "__STRICT_ANSI__ seems to have been undefined; this is not supported"
      |  ^~~~~~~
```

This is due to this change: https://gcc.gnu.org/git/?p=gcc.git;a=commit;f=libstdc%2B%2B-v3/include/bits/c%2B%2Bconfig;h=767537a8b027bcb5807bb45b0268c5da98c2c7a0

The original problem in #785 doesn't happen with mingw-w64. The original mingw project is outdated (and 32 bit only) so it is safe remove this flag now. Compilation with the original mingw is already broken anyway:

<details>
<summary>Mingw compilation errors</summary>
```
Error: D:/hxcpp/src/hx/Thread.cpp:628:2: error: 'CONDITION_VARIABLE' does not name a type
  CONDITION_VARIABLE cond;
  ^
D:/hxcpp/src/hx/Thread.cpp: In constructor 'hxCondition::hxCondition()':
D:/hxcpp/src/hx/Thread.cpp:641:31: error: 'cond' was not declared in this scope
  InitializeConditionVariable(&cond);
                               ^
D:/hxcpp/src/hx/Thread.cpp:641:35: error: 'InitializeConditionVariable' was not declared in this scope
  InitializeConditionVariable(&cond);
                                   ^
D:/hxcpp/src/hx/Thread.cpp: In member function 'void hxCondition::Wait()':
D:/hxcpp/src/hx/Thread.cpp:711:30: error: 'cond' was not declared in this scope
    SleepConditionVariableCS(&cond,&cs,INFINITE);
                              ^
D:/hxcpp/src/hx/Thread.cpp:711:47: error: 'SleepConditionVariableCS' was not declared in this scope
    SleepConditionVariableCS(&cond,&cs,INFINITE);
                                               ^
D:/hxcpp/src/hx/Thread.cpp: In member function 'bool hxCondition::TimedWait(double)':
D:/hxcpp/src/hx/Thread.cpp:721:43: error: 'cond' was not declared in this scope
    return (bool)SleepConditionVariableCS(&cond, &cs, (DWORD)((FLOAT)timeout * 1000.0));
                                           ^
D:/hxcpp/src/hx/Thread.cpp:721:86: error: 'SleepConditionVariableCS' was not declared in this scope
    return (bool)SleepConditionVariableCS(&cond, &cs, (DWORD)((FLOAT)timeout * 1000.0));
                                                                                      ^
D:/hxcpp/src/hx/Thread.cpp: In member function 'void hxCondition::Signal()':
D:/hxcpp/src/hx/Thread.cpp:744:27: error: 'cond' was not declared in this scope
    WakeConditionVariable(&cond);
                           ^
D:/hxcpp/src/hx/Thread.cpp:744:31: error: 'WakeConditionVariable' was not declared in this scope
    WakeConditionVariable(&cond);
                               ^
D:/hxcpp/src/hx/Thread.cpp: In member function 'void hxCondition::Broadcast()':
D:/hxcpp/src/hx/Thread.cpp:753:30: error: 'cond' was not declared in this scope
    WakeAllConditionVariable(&cond);
                              ^
D:/hxcpp/src/hx/Thread.cpp:753:34: error: 'WakeAllConditionVariable' was not declared in this scope
    WakeAllConditionVariable(&cond);
```
</details>