### PR TITLE
CI - Unmask MySQL Service

### DIFF
--- a/tools/azure-pipelines/build.yml
+++ b/tools/azure-pipelines/build.yml
@@ -39,6 +39,7 @@ jobs:
           displayName: Install dependencies
         - script: |
             set -ex
+            sudo systemctl unmask mysql.service
             sudo systemctl start mysql
             sudo mysql -u root -e "create database hxcpp; grant all privileges on hxcpp.* to hxcpp@localhost identified by 'hxcpp'; flush privileges;"
           displayName: Configure MariaDB


### PR DESCRIPTION
Guessing something about the ci image changed, need to unmask the service before starting it now. Should fix the failing linux CI seen on master.