### PR TITLE
CI - Host and Localhost tests

### DIFF
--- a/test/std/Test.hx
+++ b/test/std/Test.hx
@@ -420,17 +420,30 @@ class Test
 
    }
 
-   public static function testHost()
+   public static function testLocalhost()
    {
       log("Test Host");
       try
       {
       var localhost = Host.localhost();
       v('localhost :$localhost');
-      var host = new Host(localhost);
+      if (localhost == null || localhost.length == 0)
+         return error("null or empty localhost");
+      return ok();
+      }
+      catch(e:Dynamic)
+      {
+         return error("Unexpected error in testHost: " + e);
+      }
+   }
+
+   public static function testHost()
+   {
+      log("Test Host");
+      try
+      {
+      var host = new Host("github.com");
       v('host :$host');
-      // var reverse = host.reverse();
-      // v('reverse :$reverse');
       return ok();
       }
       catch(e:Dynamic)


### PR DESCRIPTION
The Mac CI has been failing for quite some time now due to a host address resolution test which tries to resolve the localhost. Resolving localhost addresses on mac runners on github actions and azure pipelines has been broken for the last year or so.

https://github.com/actions/runner-images/issues/8649

To work around this I've split up the tests. Using `Host.localhost` for testing if we can get the localhost address, and `new Host("github.com")` to test if we can resolve an address. Github should be a pretty safe url to test against.

With this hopefully the CI will be consistently green again!