### PR TITLE
Check HXCPP_ARCH before defaulting to host arch

### DIFF
--- a/tools/hxcpp/BuildTool.hx
+++ b/tools/hxcpp/BuildTool.hx
@@ -138,17 +138,20 @@ class BuildTool
       if (m64==m32 && !arm64 && !otherArmArchitecture)
       {
          var arch = mDefines.get("HXCPP_ARCH");
-         if (arch != null) {
-            m64 = arch == "x86_64";
-            m32 = arch == "x86";
-            arm64 = arch == "arm64";
-         } else {
+         if (arch!=null)
+         {
+            m64 = arch=="x86_64";
+            m32 = arch=="x86";
+            arm64 = arch=="arm64";
+         }
+         else
+         {
             var hostArch = getArch();
 
             // Default to the current OS version.  windowsArm runs m32 code too
-            m64 = hostArch == "m64";
-            m32 = hostArch == "m32";
-            arm64 = hostArch == "arm64";
+            m64 = hostArch=="m64";
+            m32 = hostArch=="m32";
+            arm64 = hostArch=="arm64";
          }
 
          mDefines.remove(m32 ? "HXCPP_M64" : "HXCPP_M32");

--- a/tools/hxcpp/BuildTool.hx
+++ b/tools/hxcpp/BuildTool.hx
@@ -137,12 +137,20 @@ class BuildTool
       var otherArmArchitecture = mDefines.exists("HXCPP_ARMV6") || mDefines.exists("HXCPP_ARMV7") || mDefines.exists("HXCPP_ARMV7S");
       if (m64==m32 && !arm64 && !otherArmArchitecture)
       {
-         var arch = getArch();
+         var arch = mDefines.get("HXCPP_ARCH");
+         if (arch != null) {
+            m64 = arch == "x86_64";
+            m32 = arch == "x86";
+            arm64 = arch == "arm64";
+         } else {
+            var hostArch = getArch();
 
-         // Default to the current OS version.  windowsArm runs m32 code too
-         m64 = arch=="m64";
-         m32 = arch=="m32";
-         arm64 = arch=="arm64";
+            // Default to the current OS version.  windowsArm runs m32 code too
+            m64 = hostArch == "m64";
+            m32 = hostArch == "m32";
+            arm64 = hostArch == "arm64";
+         }
+
          mDefines.remove(m32 ? "HXCPP_M64" : "HXCPP_M32");
          set64(mDefines,m64,arm64);
       }


### PR DESCRIPTION
Right now HXCPP_ARCH is ignored, which means you can get situations where `HXCPP_ARM64` is set but the architecture is x86_64 so you may end up with a broken build.

See #954.