### PR TITLE
Remove #undef MBEDTLS_NET_C from mbedtls_config

### DIFF
--- a/src/hx/libs/ssl/mbedtls_config.h
+++ b/src/hx/libs/ssl/mbedtls_config.h
@@ -5,6 +5,4 @@
 #define MBEDTLS_THREADING_PTHREAD
 #endif
 
-#undef MBEDTLS_NET_C
-
 #define MBEDTLS_THREADING_C

--- a/src/hx/libs/ssl/threading_alt.h
+++ b/src/hx/libs/ssl/threading_alt.h
@@ -1,3 +1,4 @@
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
 typedef struct {


### PR DESCRIPTION
This was needed for windows because the `<windows.h>` include in `threading_alt.h` broke compilation for `net_sockets.c`.

However, we can instead define `WIN32_LEAN_AND_MEAN` before including <windows.h> in `threading_alt.h`, which avoids the issue so we can remove this #undef.

The simpler the mbedtls configuration the better, as other libraries may need to link against hxcpp's mbedtls, see: #1126.