### PR TITLE
Fix mac ci failures

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,13 +30,27 @@ jobs:
       ext: .dll
       os: windows-latest
 
-  MacOS:
+  MacOS64:
     strategy:
       fail-fast: false
       matrix:
         haxe: [ 4.3.4, latest ]
     uses: ./.github/workflows/test.yml
-    name: Test MacOS
+    name: Test MacOS (x86_64)
+    with:
+      haxe: ${{ matrix.haxe  }}
+      arch: 64
+      sep: /
+      ext: .dylib
+      os: macos-13
+
+  MacOSArm:
+    strategy:
+      fail-fast: false
+      matrix:
+        haxe: [ 4.3.4, latest ]
+    uses: ./.github/workflows/test.yml
+    name: Test MacOS (Arm64)
     with:
       haxe: ${{ matrix.haxe  }}
       arch: Arm64

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
     name: Test MacOS
     with:
       haxe: ${{ matrix.haxe  }}
-      arch: 64
+      arch: Arm64
       sep: /
       ext: .dylib
       os: macos-latest

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - uses: Aidan63/setup-haxe@e4b347bc45596200a68804b232be9d73f80868a6
+      - uses: Aidan63/setup-haxe@3d3101bcd0a2001699fc8295f4d9eddd0724d3e9
         with:
           haxe-version: 4.3.4
 

--- a/.github/workflows/setup/action.yml
+++ b/.github/workflows/setup/action.yml
@@ -7,7 +7,7 @@ runs:
   using: composite
   steps:
     - name: install haxe
-      uses: Aidan63/setup-haxe@e4b347bc45596200a68804b232be9d73f80868a6
+      uses: Aidan63/setup-haxe@3d3101bcd0a2001699fc8295f4d9eddd0724d3e9
       with:
         haxe-version: ${{ inputs.haxe }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,9 @@ on:
         required: true
         type: string
 
+env:
+  HXCPP_ARCH_FLAG: ${{ inputs.arch == 'Arm64' && 'HXCPP_ARM64' || format('HXCPP_M{0}', inputs.arch) }}
+
 jobs:
   haxe:
     runs-on: ${{ inputs.os }}
@@ -33,7 +36,7 @@ jobs:
         with:
           haxe: ${{ inputs.haxe }}
       - name: build
-        run: haxe compile.hxml -D HXCPP_M${{ inputs.arch }}
+        run: haxe compile.hxml -D ${{ env.HXCPP_ARCH_FLAG }}
       - name: run
         run: bin${{ inputs.sep }}TestMain
 
@@ -52,13 +55,13 @@ jobs:
           haxe: ${{ inputs.haxe }}
       - name: build project
         working-directory: test/cffi/project
-        run: haxelib run hxcpp build.xml -Ddebug -DHXCPP_M${{ inputs.arch }}
+        run: haxelib run hxcpp build.xml -Ddebug -D${{ env.HXCPP_ARCH_FLAG }}
       - name: build
-        run: haxe compile.hxml --debug -D HXCPP_M${{ inputs.arch }}
+        run: haxe compile.hxml --debug -D ${{ env.HXCPP_ARCH_FLAG }}
       - name: build (utf8)
-        run: haxe compile-utf8.hxml --debug -D HXCPP_M${{ inputs.arch }}
+        run: haxe compile-utf8.hxml --debug -D ${{ env.HXCPP_ARCH_FLAG }}
       - name: build (neko)
-        run: haxe compile-neko.hxml --debug -D HXCPP_M${{ inputs.arch }}
+        run: haxe compile-neko.hxml --debug -D ${{ env.HXCPP_ARCH_FLAG }}
       - name: copy
         run: cp project/ndll/*/prime${{ inputs.ext }} bin/neko/prime.ndll
       - name: run
@@ -91,7 +94,7 @@ jobs:
         with:
           haxe: ${{ inputs.haxe }}
       - name: build
-        run: haxe compile.hxml ${{ matrix.suffix }} -D HXCPP_M${{ inputs.arch }}
+        run: haxe compile.hxml ${{ matrix.suffix }} -D ${{ env.HXCPP_ARCH_FLAG }}
       - name: run
         run: bin${{ inputs.sep }}TestMain${{ matrix.suffix }}
 
@@ -109,10 +112,10 @@ jobs:
         with:
           haxe: ${{ inputs.haxe }}
       - name: build
-        run: haxe compile.hxml -D HXCPP_M${{ inputs.arch }}
+        run: haxe compile.hxml -D ${{ env.HXCPP_ARCH_FLAG }}
       - name: run
         run: bin${{ inputs.sep }}App-debug
-        
+
   native:
       runs-on: ${{ inputs.os }}
       name: native
@@ -127,7 +130,7 @@ jobs:
           with:
             haxe: ${{ inputs.haxe }}
         - name: build
-          run: haxe compile.hxml -D HXCPP_M${{ inputs.arch }}
+          run: haxe compile.hxml -D ${{ env.HXCPP_ARCH_FLAG }}
         - name: run
           run: bin${{ inputs.sep }}Native
 
@@ -190,9 +193,9 @@ jobs:
         with:
           haxe: ${{ inputs.haxe }}
       - name: build host
-        run: haxe compile-host.hxml -D HXCPP_M${{ inputs.arch }}
+        run: haxe compile-host.hxml -D ${{ env.HXCPP_ARCH_FLAG }}
       - name: build client
-        run: haxe compile-client.hxml -D HXCPP_M${{ inputs.arch }}
+        run: haxe compile-client.hxml -D ${{ env.HXCPP_ARCH_FLAG }}
       - name: run
         run: bin${{ inputs.sep }}CppiaHost bin${{ inputs.sep }}client.cppia ${{ matrix.suffix }}
 
@@ -225,6 +228,6 @@ jobs:
       - name: install haxe libs
         run: haxelib install compile-cpp.hxml --always
       - name: build
-        run: haxe compile-cpp.hxml -D HXCPP_M${{ inputs.arch }} -D no_http
+        run: haxe compile-cpp.hxml -D ${{ env.HXCPP_ARCH_FLAG }} -D no_http
       - name: run
         run: bin${{ inputs.sep }}cpp${{ inputs.sep }}TestMain-debug

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -170,7 +170,7 @@ jobs:
         - name: build
           run: haxe compile${{ inputs.arch }}.hxml
         - name: run
-          run: cpp${{ inputs.arch }}${{ inputs.sep }}Test
+          run: ${{ inputs.arch == 'Arm64' && 'arm64' || format('cpp{0}', inputs.arch) }}${{ inputs.sep }}Test
 
   cppia:
     strategy:

--- a/test/std/compileArm64.hxml
+++ b/test/std/compileArm64.hxml
@@ -2,4 +2,4 @@
 -D HXCPP_ARM64
 -L hx4compat
 -L utest
---cpp cppArm64
+--cpp arm64

--- a/test/std/compileArm64.hxml
+++ b/test/std/compileArm64.hxml
@@ -1,0 +1,5 @@
+-m Test
+-D HXCPP_ARM64
+-L hx4compat
+-L utest
+--cpp cppArm64


### PR DESCRIPTION
Updates setup-haxe to fix libneko.dylib loading failures, and updates the test suite to run on arm64. Both x86_64 and arm64 tests run now on Mac.

Closes #1121.

cc: @Aidan63.