### PR TITLE
[android] Bump default API level to 21.

### DIFF
--- a/toolchain/android-toolchain-clang.xml
+++ b/toolchain/android-toolchain-clang.xml
@@ -3,7 +3,7 @@
 <!-- Set architecture -->
 <section if="HXCPP_X86">
   <set name="ARCH" value="-x86" />
-  <set name="PLATFORM_NUMBER" value="19" unless="PLATFORM_NUMBER" />
+  <set name="PLATFORM_NUMBER" value="21" unless="PLATFORM_NUMBER" />
   <set name="ABITRIPLE" value="i686-linux-android" />
 </section>
 
@@ -15,7 +15,7 @@
 
 <section if="HXCPP_ARMV7">
   <set name="ARCH" value="-v7" />
-  <set name="PLATFORM_NUMBER" value="19" unless="PLATFORM_NUMBER" />
+  <set name="PLATFORM_NUMBER" value="21" unless="PLATFORM_NUMBER" />
   <set name="ABITRIPLE" value="armv7a-linux-androideabi" />
   <set name="EXEPREFIX" value="arm-linux-androideabi" />
 </section>


### PR DESCRIPTION
NDK r26 has dropped support for API levels 19 and 20.
This only affects armv7 and x86, 64-bit architectures already required API level 21 or higher.
https://github.com/android/ndk/wiki/Changelog-r26#announcements