### PR TITLE
Fix Callstack Retrieval in Critical Error Handler.

### DIFF
--- a/src/hx/Debug.cpp
+++ b/src/hx/Debug.cpp
@@ -77,14 +77,14 @@ static void CriticalErrorHandler(String inErr, bool allowFixup)
       return;
 #endif
 
-   if (sCriticalErrorHandler!=null())
-      sCriticalErrorHandler(inErr);
-
 #ifdef HXCPP_STACK_TRACE
    hx::StackContext *ctx = hx::StackContext::getCurrent();
    ctx->beginCatch(true);
    ctx->dumpExceptionStack();
 #endif
+
+   if (sCriticalErrorHandler!=null())
+      sCriticalErrorHandler(inErr);
 
     DBGLOG("Critical Error: %s\n", inErr.utf8_str());
 

--- a/src/hx/Debug.cpp
+++ b/src/hx/Debug.cpp
@@ -80,11 +80,14 @@ static void CriticalErrorHandler(String inErr, bool allowFixup)
 #ifdef HXCPP_STACK_TRACE
    hx::StackContext *ctx = hx::StackContext::getCurrent();
    ctx->beginCatch(true);
-   ctx->dumpExceptionStack();
 #endif
 
    if (sCriticalErrorHandler!=null())
       sCriticalErrorHandler(inErr);
+
+#ifdef HXCPP_STACK_TRACE
+   ctx->dumpExceptionStack();
+#endif
 
     DBGLOG("Critical Error: %s\n", inErr.utf8_str());
 


### PR DESCRIPTION
Before this fix, the critical error handler retrieved the callstack from a previous error. Now, it correctly captures the callstack from the error that triggered the crash handler.
