### PR TITLE
Fix deprecated non-prototype warnings in Zlib for non-MSVC compilers.

### DIFF
--- a/src/hx/libs/zlib/Build.xml
+++ b/src/hx/libs/zlib/Build.xml
@@ -13,6 +13,7 @@
   <compilerflag value="-DSTDC" unless="windows" />
   <compilerflag value="-DHAVE_UNISTD_H" unless="windows" />
   <compilerflag value="-Wno-deprecated-non-prototype" unless="MSVC_VER" />
+  <compilerflag value="-Wno-unknown-warning" unless="MSVC_VER" />
 
   <file name="ZLib.cpp"/>
 

--- a/src/hx/libs/zlib/Build.xml
+++ b/src/hx/libs/zlib/Build.xml
@@ -12,6 +12,7 @@
   <compilerflag value="-I${ZLIB_DIR}"/>
   <compilerflag value="-DSTDC" unless="windows" />
   <compilerflag value="-DHAVE_UNISTD_H" unless="windows" />
+  <compilerflag value="-Wno-deprecated-non-prototype" unless="MSVC_VER" />
 
   <file name="ZLib.cpp"/>
 

--- a/src/hx/libs/zlib/Build.xml
+++ b/src/hx/libs/zlib/Build.xml
@@ -12,8 +12,10 @@
   <compilerflag value="-I${ZLIB_DIR}"/>
   <compilerflag value="-DSTDC" unless="windows" />
   <compilerflag value="-DHAVE_UNISTD_H" unless="windows" />
-  <compilerflag value="-Wno-deprecated-non-prototype" unless="MSVC_VER" />
+
   <compilerflag value="-Wno-unknown-warning" unless="MSVC_VER" />
+  <compilerflag value="-Wno-unknown-warning-option" unless="MSVC_VER" />
+  <compilerflag value="-Wno-deprecated-non-prototype" unless="MSVC_VER" />
 
   <file name="ZLib.cpp"/>
 


### PR DESCRIPTION
This PR adds the `-Wno-deprecated-non-prototype` compiler flag to the Zlib build process for non-MSVC compilers. The purpose of this change is to remove warnings related to deprecated non-prototype function definitions.