### PR TITLE
Resolved multiple warnings on `Apple` targets.

### DIFF
--- a/src/Dynamic.cpp
+++ b/src/Dynamic.cpp
@@ -217,7 +217,7 @@ public:
    String toString()
    {
       char buf[100];
-      sprintf(buf,"Pointer(%p)", mValue);
+      snprintf(buf, sizeof(buf), "Pointer(%p)", mValue);
       return String(buf);
    }
    String __ToString() const { return String(mValue); }

--- a/src/Dynamic.cpp
+++ b/src/Dynamic.cpp
@@ -217,7 +217,7 @@ public:
    String toString()
    {
       char buf[100];
-      snprintf(buf, sizeof(buf), "Pointer(%p)", mValue);
+      snprintf(buf,sizeof(buf),"Pointer(%p)", mValue);
       return String(buf);
    }
    String __ToString() const { return String(mValue); }

--- a/src/hx/CFFI.cpp
+++ b/src/hx/CFFI.cpp
@@ -106,7 +106,7 @@ public:
          return _hxcpp_toString( Dynamic(this) );
 
       char buffer[40];
-      snprintf(buffer, sizeof(buffer), "0x%p", mHandle);
+      snprintf(buffer,sizeof(buffer),"0x%p", mHandle);
 
       return HX_CSTRING("Abstract(") +
              __hxcpp_get_kind(this) +

--- a/src/hx/CFFI.cpp
+++ b/src/hx/CFFI.cpp
@@ -106,7 +106,7 @@ public:
          return _hxcpp_toString( Dynamic(this) );
 
       char buffer[40];
-      sprintf(buffer,"0x%p", mHandle);
+      snprintf(buffer, sizeof(buffer), "0x%p", mHandle);
 
       return HX_CSTRING("Abstract(") +
              __hxcpp_get_kind(this) +

--- a/src/hx/gc/Immix.cpp
+++ b/src/hx/gc/Immix.cpp
@@ -4632,11 +4632,11 @@ public:
 
       char strBuf[100];
       if (bytes<k)
-         sprintf(strBuf,"%d", (int)bytes);
+         snprintf(strBuf,sizeof(strBuf),"%d", (int)bytes);
       else if (bytes<meg)
-         sprintf(strBuf,"%.2fk", (double)bytes/k);
+         snprintf(strBuf,sizeof(strBuf),"%.2fk", (double)bytes/k);
       else
-         sprintf(strBuf,"%.2fmb", (double)bytes/meg);
+         snprintf(strBuf,sizeof(strBuf),"%.2fmb", (double)bytes/meg);
       return strBuf;
    }
    #endif

--- a/src/hx/libs/mysql/my_api.cpp
+++ b/src/hx/libs/mysql/my_api.cpp
@@ -25,12 +25,12 @@ static void error( MYSQL *m, const char *err, const char *param ) {
 			p2[max - 2] = '.';
 			p2[max - 1] = '.';
 			p2[max] = 0;
-			sprintf(m->last_error,err,param);
+			snprintf(m->last_error,sizeof(m->last_error),err,param);
 			free(p2);
 			return;
 		}
 	}
-	sprintf(m->last_error,err,param);
+	snprintf(m->last_error,sizeof(m->last_error),err,param);
 	m->errcode = -1;
 }
 
@@ -408,7 +408,7 @@ const char *mysql_character_set_name( MYSQL *m ) {
 	const char *name = myp_charset_name(m->infos.server_charset);
 	if( name == NULL ) {
 		static char tmp[512];
-		sprintf(tmp,"#%d",m->infos.server_charset);
+		snprintf(tmp,sizeof(tmp),"#%d",m->infos.server_charset);
 		return tmp;
 	}
 	return name;

--- a/toolchain/appletvos-toolchain.xml
+++ b/toolchain/appletvos-toolchain.xml
@@ -24,8 +24,10 @@
   <!-- <cppflag value="-fvisibility-inlines-hidden"/> -->
   <pchflag value="-x" />
   <pchflag value="c++-header" />
-  <flag value="-stdlib=libstdc++" if="FORCE_LIBGCC" />
-  <flag value="-stdlib=libc++" if="HXCPP_CPP11" />
+  <cppflag value="-stdlib=libstdc++" if="FORCE_LIBGCC" />
+  <cppflag value="-stdlib=libc++" if="HXCPP_CPP11" />
+  <mmflag value="-stdlib=libstdc++" if="FORCE_LIBGCC" />
+  <mmflag value="-stdlib=libc++" if="HXCPP_CPP11" />
   <flag value="-g" if="HXCPP_DEBUG_LINK"/>
   <flag value="-O2" unless="debug"/>
   <flag value="-arch"/>
@@ -69,8 +71,10 @@
 <linker id="dll" exe="g++" >
   <exe name="xcrun --sdk appletvos${TVOS_VER} g++" if="HXCPP_GCC" />
   <exe name="xcrun --sdk appletvos${TVOS_VER} clang++" />
-  <flag value="-stdlib=libstdc++" if="FORCE_LIBGCC" />
-  <flag value="-stdlib=libc++" if="HXCPP_CPP11" />
+  <cppflag value="-stdlib=libstdc++" if="FORCE_LIBGCC" />
+  <cppflag value="-stdlib=libc++" if="HXCPP_CPP11" />
+  <mmflag value="-stdlib=libstdc++" if="FORCE_LIBGCC" />
+  <mmflag value="-stdlib=libc++" if="HXCPP_CPP11" />
   <flag value="-dynamiclib"/>
   <flag value="-arch"/>
   <flag value="arm64" if="HXCPP_ARM64" />

--- a/toolchain/appletvsim-toolchain.xml
+++ b/toolchain/appletvsim-toolchain.xml
@@ -22,8 +22,10 @@
   <!-- <cppflag value="-fvisibility-inlines-hidden"/> -->
   <pchflag value="-x" />
   <pchflag value="c++-header" />
-  <flag value="-stdlib=libstdc++" if="FORCE_LIBGCC" />
-  <flag value="-stdlib=libc++" if="HXCPP_CPP11" />
+  <cppflag value="-stdlib=libstdc++" if="FORCE_LIBGCC" />
+  <cppflag value="-stdlib=libc++" if="HXCPP_CPP11" />
+  <mmflag value="-stdlib=libstdc++" if="FORCE_LIBGCC" />
+  <mmflag value="-stdlib=libc++" if="HXCPP_CPP11" />
   <flag value="-g" if="HXCPP_DEBUG_LINK"/>
   <flag value="-O2" unless="debug"/>
   <flag value="-fmessage-length=0"/>
@@ -76,8 +78,10 @@
 <linker id="dll" exe="g++" >
   <exe name="xcrun --sdk appletvsimulator${TVOS_VER} g++" if="HXCPP_GCC" />
   <exe name="xcrun --sdk appletvsimulator${TVOS_VER} clang++" />
-  <flag value="-stdlib=libstdc++" if="FORCE_LIBGCC" />
-  <flag value="-stdlib=libc++" if="HXCPP_CPP11" />
+  <cppflag value="-stdlib=libstdc++" if="FORCE_LIBGCC" />
+  <cppflag value="-stdlib=libc++" if="HXCPP_CPP11" />
+  <mmflag value="-stdlib=libstdc++" if="FORCE_LIBGCC" />
+  <mmflag value="-stdlib=libc++" if="HXCPP_CPP11" />
   <flag value="-dynamiclib"/>
   <flag value="-arch"/>
   <flag value="i386" unless="HXCPP_M64"/>

--- a/toolchain/iphoneos-toolchain.xml
+++ b/toolchain/iphoneos-toolchain.xml
@@ -95,8 +95,10 @@
   <exe name="xcrun --sdk iphoneos${IPHONE_VER} g++" if="HXCPP_GCC" />
   <exe name="xcrun --sdk iphoneos${IPHONE_VER} clang++" />
   <flag value="-Wl,-cache_path_lto,/tmp" if="HXCPP_OPTIMIZE_LINK_INCREMENTAL" unless="debug"/>
-  <flag value="-stdlib=libstdc++" if="FORCE_LIBGCC" />
-  <flag value="-stdlib=libc++" if="HXCPP_CPP11 || HXCPP_CPP17" />
+  <cppflag value="-stdlib=libstdc++" if="FORCE_LIBGCC" />
+  <cppflag value="-stdlib=libc++" if="HXCPP_CPP11 || HXCPP_CPP17" />
+  <mmflag value="-stdlib=libstdc++" if="FORCE_LIBGCC" />
+  <mmflag value="-stdlib=libc++" if="HXCPP_CPP11 || HXCPP_CPP17" />
   <flag value="-dynamiclib"/>
   <flag value="-arch"/>
   <flag value="armv6" if="HXCPP_ARMV6" />

--- a/toolchain/iphonesim-toolchain.xml
+++ b/toolchain/iphonesim-toolchain.xml
@@ -89,8 +89,10 @@
 <linker id="dll" exe="g++" >
   <exe name="xcrun --sdk iphonesimulator${IPHONE_VER} g++" if="HXCPP_GCC" />
   <exe name="xcrun --sdk iphonesimulator${IPHONE_VER} clang++" />
-  <flag value="-stdlib=libstdc++" if="FORCE_LIBGCC" />
-  <flag value="-stdlib=libc++" if="HXCPP_CPP11 || HXCPP_CPP17" />
+  <cppflag value="-stdlib=libstdc++" if="FORCE_LIBGCC" />
+  <cppflag value="-stdlib=libc++" if="HXCPP_CPP11 || HXCPP_CPP17" />
+  <mmflag value="-stdlib=libstdc++" if="FORCE_LIBGCC" />
+  <mmflag value="-stdlib=libc++" if="HXCPP_CPP11 || HXCPP_CPP17" />
   <flag value="-dynamiclib"/>
   <flag value="-arch"/>
   <flag value="i386" unless="HXCPP_M64"/>

--- a/toolchain/mac-toolchain.xml
+++ b/toolchain/mac-toolchain.xml
@@ -49,6 +49,7 @@
   <flag value="-Wno-parentheses" />
   <flag value="-Wno-null-dereference" if="HXCPP_CLANG"/>
   <flag value="-Wno-unused-value" />
+  <flag value="-Wno-unused-command-line-argument" />
   <flag value="-Wno-format-extra-args" />
   <flag value="-Wno-overflow" />
   <flag value="-fsanitize=thread" if="HXCPP_THREAD_SANITIZE" />
@@ -86,6 +87,7 @@
   <flag value="-isysroot" unless="LEGACY_MACOSX_SDK"/>
   <flag value="${DEVELOPER_DIR}/Platforms/MacOSX.platform/Developer/SDKs/MacOSX${MACOSX_VER}.sdk" unless="LEGACY_MACOSX_SDK"/>
   <flag value="-fvisibility=hidden"/>
+  <flag value="-Wno-unused-command-line-argument" />
   <!-- <flag value="-debug" if="debug"/> -->
   <ext value=".dylib"/>
   <outflag value="-o "/>
@@ -104,6 +106,7 @@
   <flag value="Cocoa"/>
   <flag value="-isysroot" unless="LEGACY_MACOSX_SDK"/>
   <flag value="${DEVELOPER_DIR}/Platforms/MacOSX.platform/Developer/SDKs/MacOSX${MACOSX_VER}.sdk" unless="LEGACY_MACOSX_SDK"/>
+  <flag value="-Wno-unused-command-line-argument" />
   <flag value="-fsanitize=thread" if="HXCPP_THREAD_SANITIZE" />
   <!-- <flag value="-debug" if="debug"/> -->
   <flag value="-arch" />

--- a/toolchain/mac-toolchain.xml
+++ b/toolchain/mac-toolchain.xml
@@ -31,8 +31,11 @@
   <cppflag value="-Wc++14-extensions" if="HXCPP_CPP14"/>
   <cppflag value="-std=c++17" if="HXCPP_CPP17"/>
   <cppflag value="-Wc++17-extensions" if="HXCPP_CPP17"/>
-  <flag value="-stdlib=libc++" unless="STDLIBCPP" />
-  <flag value="-stdlib=libstdc++" if="STDLIBCPP" />
+  <cppflag value="-stdlib=libc++" unless="STDLIBCPP" />
+  <cppflag value="-stdlib=libstdc++" if="STDLIBCPP" />
+  <mmflag value="-stdlib=libc++" unless="STDLIBCPP" />
+  <mmflag value="-stdlib=libstdc++" if="STDLIBCPP" />
+  
   <cppflag value="-frtti"/>
   <pchflag value="-x" />
   <pchflag value="c++-header" />
@@ -49,7 +52,6 @@
   <flag value="-Wno-parentheses" />
   <flag value="-Wno-null-dereference" if="HXCPP_CLANG"/>
   <flag value="-Wno-unused-value" />
-  <flag value="-Wno-unused-command-line-argument" />
   <flag value="-Wno-format-extra-args" />
   <flag value="-Wno-overflow" />
   <flag value="-fsanitize=thread" if="HXCPP_THREAD_SANITIZE" />
@@ -75,8 +77,10 @@
   <fromfile value="" if="GCC_OLD" />
   <flag value="-Wl,-bundle,-bundle_loader,${dll_import_link}" if="dll_import_link" />
   <flag value="-Wl,-cache_path_lto,/tmp" if="HXCPP_LTO_THIN" unless="debug"/>
-  <flag value="-stdlib=libc++" unless="STDLIBCPP" />
-  <flag value="-stdlib=libstdc++" if="STDLIBCPP" />
+  <cppflag value="-stdlib=libc++" unless="STDLIBCPP" />
+  <cppflag value="-stdlib=libstdc++" if="STDLIBCPP" />
+  <mmflag value="-stdlib=libc++" unless="STDLIBCPP" />
+  <mmflag value="-stdlib=libstdc++" if="STDLIBCPP" />
   <flag value="-fpic"/>
   <flag value="-fPIC"/>
   <flag value="-dynamiclib"/>
@@ -87,7 +91,6 @@
   <flag value="-isysroot" unless="LEGACY_MACOSX_SDK"/>
   <flag value="${DEVELOPER_DIR}/Platforms/MacOSX.platform/Developer/SDKs/MacOSX${MACOSX_VER}.sdk" unless="LEGACY_MACOSX_SDK"/>
   <flag value="-fvisibility=hidden"/>
-  <flag value="-Wno-unused-command-line-argument" />
   <!-- <flag value="-debug" if="debug"/> -->
   <ext value=".dylib"/>
   <outflag value="-o "/>
@@ -101,12 +104,14 @@
   <flag value="-Wl,-rpath,${HXCPP_RPATH}" if="HXCPP_RPATH" />
   <flag value="-Wl,-cache_path_lto,/tmp" if="HXCPP_OPTIMIZE_LINK_INCREMENTAL" unless="debug"/>
   <fromfile value="" if="GCC_OLD" />
-  <flag value="-stdlib=libstdc++" if="STDLIBCPP" />
+  <cppflag value="-stdlib=libc++" unless="STDLIBCPP" />
+  <cppflag value="-stdlib=libstdc++" if="STDLIBCPP" />
+  <mmflag value="-stdlib=libc++" unless="STDLIBCPP" />
+  <mmflag value="-stdlib=libstdc++" if="STDLIBCPP" />
   <flag value="-framework"/>
   <flag value="Cocoa"/>
   <flag value="-isysroot" unless="LEGACY_MACOSX_SDK"/>
   <flag value="${DEVELOPER_DIR}/Platforms/MacOSX.platform/Developer/SDKs/MacOSX${MACOSX_VER}.sdk" unless="LEGACY_MACOSX_SDK"/>
-  <flag value="-Wno-unused-command-line-argument" />
   <flag value="-fsanitize=thread" if="HXCPP_THREAD_SANITIZE" />
   <!-- <flag value="-debug" if="debug"/> -->
   <flag value="-arch" />


### PR DESCRIPTION
* Replaced `sprintf` with `snprintf` because `sprintf` is deprecated.
* Added `-Wno-unused-command-line-argument` to MacOS toolchain to remove warnings related to unused commands, for example `clang: warning: argument unused during compilation: '-stdlib=libc++' [-Wunused-command-line-argument]`.