### PR TITLE
Better ANSI Color Support Detection

### DIFF
--- a/tools/hxcpp/BuildTool.hx
+++ b/tools/hxcpp/BuildTool.hx
@@ -1603,8 +1603,11 @@ class BuildTool
       }
 
 
-      if (defines.exists("HXCPP_NO_COLOUR") || defines.exists("HXCPP_NO_COLOR"))
+      if (Sys.getEnv("HXCPP_COLOUR") != null || Sys.getEnv("HXCPP_COLOR") != null)
+         Log.colorSupported = !(defines.exists("HXCPP_NO_COLOUR") || defines.exists("HXCPP_NO_COLOR"));
+      else if (defines.exists("HXCPP_NO_COLOUR") || defines.exists("HXCPP_NO_COLOR"))
          Log.colorSupported = false;
+
       Log.verbose = defines.exists("HXCPP_VERBOSE");
       Log.showSetup = defines.exists("HXCPP_LOG_SETUP");
       exitOnThreadError = defines.exists("HXCPP_EXIT_ON_ERROR");

--- a/tools/hxcpp/Log.hx
+++ b/tools/hxcpp/Log.hx
@@ -135,22 +135,29 @@ class Log
    {
       if (colorSupported == null)
       {
-         if (!BuildTool.isWindows)
-         {
-            var result = -1;
-            try
-            {
-               var process = new Process ("tput", [ "colors" ]);
-               result = process.exitCode ();
-               process.close ();
-            }
-            catch (e:Dynamic) {};
+         var term = Sys.getEnv("TERM");
 
-            colorSupported = (result == 0);
+         if (term == "dumb")
+         {
+            colorSupported = false;
          }
          else
          {
-            colorSupported = (Sys.getEnv("TERM") == "xterm" || Sys.getEnv("ANSICON") != null);
+            if (colorSupported != true && term != null)
+            {
+               colorSupported = ~/(?i)-256(color)?$/.match(term)
+                  || ~/(?i)^screen|^xterm|^vt100|^vt220|^rxvt|color|ansi|cygwin|linux/.match(term);
+            }
+
+            if (colorSupported != true)
+            {
+               colorSupported = Sys.getEnv("TERM_PROGRAM") == "iTerm.app"
+                  || Sys.getEnv("TERM_PROGRAM") == "Apple_Terminal"
+                  || Sys.getEnv("COLORTERM") != null
+                  || Sys.getEnv("ANSICON") != null
+                  || Sys.getEnv("ConEmuANSI") != null
+                  || Sys.getEnv("WT_SESSION") != null;
+            }
          }
       }
 
@@ -160,8 +167,7 @@ class Log
       }
       else
       {
-         var colorCodes:EReg = ~/\x1b\[[^m]+m/g;
-         return colorCodes.replace(output, "");
+         return ~/\x1b\[[0-9;]*m/g.replace(output, "");
       }
    }
 


### PR DESCRIPTION
This PR improves how we check for ANSI color support by handling more terminals and CI environments and simplifying the detection logic in `stripColor`.