### PR TITLE
Don't include xlocale.h on Linux without glibc

### DIFF
--- a/src/hx/libs/std/Sys.cpp
+++ b/src/hx/libs/std/Sys.cpp
@@ -30,7 +30,7 @@
    #include <limits.h>
    #ifndef ANDROID
       #include <locale.h>
-      #if !defined(BLACKBERRY) && !defined(EPPC) && !defined(GCW0) && !defined(__GLIBC__)
+      #if !defined(BLACKBERRY) && !defined(EPPC) && !defined(GCW0) && !defined(__GLIBC__) && !defined(__linux__)
          #include <xlocale.h>
       #endif
    #endif


### PR DESCRIPTION
For glibc based systems, `xlocale.h` is already excluded. On Linux distributions with musl libc (for example Alpine Linux), `xlocale.h` is unavailable as well. As there is no macro to detect musl, my suggested fix would be to rely on `__linux__` and assume that `xlocale.h` is not required on Linux systems in general.