### PR TITLE
Fixed typos

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -68,7 +68,7 @@
 * Updated version of zlib
 * Updated version of sljit
 * Updated version of pcre
-* Updated version of sqlit3
+* Updated version of sqlite3
 * Updated version of mbedtls
 * Some work on supporting utf16 strings (hx_smart_strings)
 * Added process_kill
@@ -631,7 +631,7 @@ Haxe 3.2.0
 * Added comprehensive list of reserved member names.
 * Put if/else statements in blocks.
 * Added assert, NULL, LITTLE_ENDIAN, BIG_ENDIAN as keywords.
-* Added control over how fast-cffi routines are created by requiring cpp.rtti.FastIntergerLookup to be "implemented".
+* Added control over how fast-cffi routines are created by requiring cpp.rtti.FastIntegerLookup to be "implemented".
 * Construct anonymous object fields in deterministic (as declared) order.
 * Fix code generation for some complex inline cases.
 * Added cpp.zip.Compress

--- a/Changes.md
+++ b/Changes.md
@@ -17,7 +17,7 @@
 
 4.1.15
 ------------------------------------------------------------
-* Added Arm64 suport on windows
+* Added Arm64 support on windows
 * Fixed crash with zero-sized alloc and generational GC
 * Fixed crash with generational GC when old objects come back to life
 * Fixed compile error with @:fixed Anons and arrays (socket select)
@@ -197,7 +197,7 @@
 * Support HXCPP_DEBUG_LINK on more targets
 * Support for cross compiling to windows from linux
 * Added array removeAt
-* Some telemety fixes (thanks Jeff)
+* Some telemetry fixes (thanks Jeff)
 * Check contents when comparing Dynamics with same pointer (Math.Nan!=Math.Nan)
 * Numerous WinRT fixes (thanks madrazo)
 * Fixed bug causing GC to crash marking constant strings (eg, resources)
@@ -241,7 +241,7 @@
 * Make it easier to change the generated output filename
 * Allow targets from one build.xml file to be merged into another
 * Some more work on HXCPP_COMPILE_CACHE
-* Allow automatic grouping of obj files into librarys to avoid linking all the symbols in all obj files
+* Allow automatic grouping of obj files into libraries to avoid linking all the symbols in all obj files
 * Add implicit conversion to referenced type from cpp.Reference
 * Allow build.xml files to be imported relative to importing file
 * Allow '-' in command-line defines
@@ -265,11 +265,11 @@ Haxe 3.2.0
 ------------------------------------------------------------
 
 * Improve testing
-* Allow dll_load path to be set programatically and simplified the dll search sequence.
+* Allow dll_load path to be set programmatically and simplified the dll search sequence.
 * Improved cffi_prime, and added String class
 * Fixed static linking of mysql5
 * Moved static link code in general to cpp.link package, not hxcpp package
-* URL decode now does not need to performe reallocs
+* URL decode now does not need to perform reallocs
 * Ensure HXCPP_API_LEVEL is always defined
 * Added __hxcpp_unload_all_libraries to cleanly unload dlls
 * Added some utc date functions
@@ -307,13 +307,13 @@ Haxe 3.2.0
 * Remove NekoApi binaries
 * Add Cppia binaries
 * Add Windows64 binaries
-* Make compares between Dynamic and numeric types false, unless the Dynamic is actaully numeric
+* Make compares between Dynamic and numeric types false, unless the Dynamic is actually numeric
 
 ------------------------------------------------------------
 * Even more optimizations for hashes
 * Some more optimizations for small hashes
 * Fix for google changing inlining in platform21 headers (atof, rand, srand)
-* Re-tuned Hash for small objects too (improves Anon object perforamce)
+* Re-tuned Hash for small objects too (improves Anon object performance)
 * Reverted change that automatically threw 'BadCast'.  Now required HXCPP_STRICT_CASTS
 
 ------------------------------------------------------------
@@ -322,10 +322,10 @@ Haxe 3.2.0
 * Use internal hash structure for maps - now faster.  New version of haxe makes it faster still.
 * Changed the way development versions are bootstrapped to avoid committing binaries
 * Improved mingw support
-* Dont append -debug to dll name
+* Don't append -debug to dll name
 * Reorder xml includes to allow early parts to correctly influence older parts
 * Fix busy wait in semaphore lock
-* Fixed GC issue when constructing exrernal primitive objects
+* Fixed GC issue when constructing external primitive objects
 * Added armv7s and arm64 targets for ios
 * Some fixes for neko cffi - wstring and warning for neko_init
 * Fix file read (and copy) from thread
@@ -390,7 +390,7 @@ Haxe 3.2.0
 * Use sys.io.Process instead of Sys.command to avoid threading slowdown writing to console
 * Add hxcpp.Builder to help with building multiple binaries
 * Add android x86 support
-* Drop pre-compiled support for everything excepth windows,mac,linux,ios and android
+* Drop pre-compiled support for everything except windows,mac,linux,ios and android
 * Allow libraries and files to accumulated in the build.xml
 * Supply pre-build lib files for static linking on supported platforms
 * Support for static linking of all modules
@@ -399,7 +399,7 @@ Haxe 3.2.0
 * Use build.n script to build all appropriate binaries
 * Some initial support for mysql and sqlite databases
 * Add free_abstract for safe releasing of data references
-* Change process lauching to get better thread usage on mac
+* Change process launching to get better thread usage on mac
 * Fix GC error in string resources
 * Give obj files in libraries unique names
 
@@ -419,9 +419,9 @@ Haxe 3.2.0
 * Fixed android build
 * Expanded native memory access methods
 * Fix exception dump
-* Added initial Emscriptm support
+* Added initial Emscripten support
 * Allow specification of ANDROID_HOST
-* Inital work on auto-setup of win64
+* Initial work on auto-setup of win64
 * Support call-site casting of Arrays
 
 
@@ -583,7 +583,7 @@ Haxe 3.2.0
 * Fix interface operator ==
 * Initial work on msvc10 batch file
 * Add bounds check on String.cca
-* Build static libraries, if requrested
+* Build static libraries, if requested
 * Added exe stripping
 * Added val_field_name, val_iter_fields
 * Fixed nekoapi string length
@@ -596,7 +596,7 @@ Haxe 3.2.0
 * Fixed String UTF8 Encode
 * Nekoapi is now a "ndll", not a "dso".
 * Fix array compile issue on linux
-* Fix stack setting on firced collect
+* Fix stack setting on forced collect
 
 2.06.0
 ------------------------------------------------------------
@@ -621,7 +621,7 @@ Haxe 3.2.0
 ------------------------------------------------------------
 
 * Default to IMMIX based internal garbage collection.
-* Reorginised files - split big ones, and moved common ones out of "runtime".
+* Reorganised files - split big ones, and moved common ones out of "runtime".
 * Put internal classes in "hx" namespace, or HX_ prefix for macros.
 * Remove multiple-inheritance, and use delegation instead.
 * Write "Options.txt" from compiler so dependency can be determined.

--- a/docs/CompileCache.md
+++ b/docs/CompileCache.md
@@ -2,7 +2,7 @@ The Hxcpp Cache
 ---------------
 The hxcpp compile cache is used to share object files between projects. This can alleviate the need to ship static libraries with external projects, since developers who use the library can compile the library just once, and then reuse it between projects.
 
-The cache uses a hashing mechanism to tell if the contents of a file or its dependencies has changed, and combines this with the compiler version and flags to make specific object files for each change and each compiler congiguration.  This also allows some common haxe runtime and haxe generated files to share their object files between projects, even if in different directories.
+The cache uses a hashing mechanism to tell if the contents of a file or its dependencies has changed, and combines this with the compiler version and flags to make specific object files for each change and each compiler configuration.  This also allows some common haxe runtime and haxe generated files to share their object files between projects, even if in different directories.
 
 Additional benefits include keeping some files outside the source tree, and being able to remove these temp files easily.
 
@@ -17,7 +17,7 @@ Keeping the path short can help in some border-line cases with some compilers wh
 The cache size defaults to 1 Gig.  For many cases, this is big enough.  However, on large projects, with several architectures and lots of debug information, this default can lead to "cache churn" where some files are evicted from the cache, even though they are likely to be used again.  Increasing the number of mega-bytes allocated to the cache can help here.
 
 ### Using The Cache
-To use the cashe with your own libraries, the files group should have 'cache' entry to tell hxcpp that you have considered dependency issues when designing the group.
+To use the cache with your own libraries, the files group should have 'cache' entry to tell hxcpp that you have considered dependency issues when designing the group.
 
   ```xml
   <cache value="true" project="name" asLibrary="true" />

--- a/docs/ThreadsAndStacks.md
+++ b/docs/ThreadsAndStacks.md
@@ -98,7 +98,7 @@ Enter/exit use similar technique, where the registers are captured and the botto
       * any changes here will not affect GC
 ```
 
-Now, when another thread does a collection, the gc-free thread can be scanned from 8088 to 9976, regardless of any stuff happening lower dowsn the stack.
+Now, when another thread does a collection, the gc-free thread can be scanned from 8088 to 9976, regardless of any stuff happening lower down the stack.
 
 
 ### Not Called From Main 
@@ -119,7 +119,7 @@ Top of stack can be tricky to get right when a gui framework does not really hav
  7976  int     t0
        SetTopOfStack(&t0,false) -> 7966
        __hxcpp_main();
-          setOnFrameCallack(haxeOnFrame)
+          setOnFrameCallback(haxeOnFrame)
           return;
 ```
 

--- a/docs/build_xml/Defines.md
+++ b/docs/build_xml/Defines.md
@@ -49,7 +49,7 @@ Other defines:
 | *HXCPP_VERBOSE*         | Print extra output from build tool. |
 | *HXCPP_TIMES*           | Show some basic profiling information |
 | *HXCPP_NEKO_BUILDTOOL*  | Force use of hxcpp.n, rather than compiled BuildTool.exe
-| *HXCPP_NO_COLOR*        | Do not add colour-codes to tool output |
+| *HXCPP_NO_COLOR*        | Do not add color-codes to tool output |
 | *HXCPP_KEEP_TEMP*       | Does not delete the files created for file 'embedName' option |
 
 

--- a/docs/build_xml/Linker.md
+++ b/docs/build_xml/Linker.md
@@ -1,6 +1,6 @@
 Linker
 ------
-Generally one linker is run per target to build a static library, dynamic library or exe.  The 'id' attribute of the linker specifies whch type of linking is performed.
+Generally one linker is run per target to build a static library, dynamic library or exe.  The 'id' attribute of the linker specifies which type of linking is performed.
 
 
 - *exe* - Overwrite the exe command for this linker.
@@ -43,7 +43,7 @@ Generally one linker is run per target to build a static library, dynamic librar
    ```
      + name = the complete name is specified
      + base = the name without compiler-specific extension (.a/.lib) is specified
-     + hxbase = the name without extension and architecture (-v7/.iphoinesim) is specified
+     + hxbase = the name without extension and architecture (-v7/.iphonesim) is specified
 
 - *prefix* - Prefix for generated files.
    ```xml

--- a/docs/build_xml/Targets.md
+++ b/docs/build_xml/Targets.md
@@ -35,7 +35,7 @@ Targets can contain the following nodes:
    ```
      + name = the complete name is specified
      + base = the name without compiler-specific extension (.a/.lib) is specified
-     + hxbase = the name without extension and architecture (-v7/.iphoinesim) is specified
+     + hxbase = the name without extension and architecture (-v7/.iphonesim) is specified
 
 - *flag* - Add a single link flag.
    ```xml

--- a/haxelib.xml
+++ b/haxelib.xml
@@ -1,5 +1,5 @@
 <project name="hxcpp" url="http://gamehaxe.com/" license="BSD">
     <user name="gamehaxe"/>
-    <description>Hxcpp is the runtime support for the c++ backend of the haxe compiler.  This release constains the headers, libraries and support code required to generate a fully compiled executable from haxe code.</description>
+    <description>Hxcpp is the runtime support for the c++ backend of the haxe compiler.  This release contains the headers, libraries and support code required to generate a fully compiled executable from haxe code.</description>
 <version name="3.1.0">See Changes.txt</version>
 </project>

--- a/include/Array.h
+++ b/include/Array.h
@@ -387,7 +387,7 @@ namespace cpp
 
 // --- Array_obj ------------------------------------------------------------------
 //
-// The Array_obj specializes the ArrayBase, adding typing where required
+// The Array_obj specialises the ArrayBase, adding typing where required
 
 
 namespace hx

--- a/include/Array.h
+++ b/include/Array.h
@@ -387,7 +387,7 @@ namespace cpp
 
 // --- Array_obj ------------------------------------------------------------------
 //
-// The Array_obj specialises the ArrayBase, adding typing where required
+// The Array_obj specializes the ArrayBase, adding typing where required
 
 
 namespace hx

--- a/include/hx/CFFI.h
+++ b/include/hx/CFFI.h
@@ -404,7 +404,7 @@ inline bool resizeByteData(value inValue, int inNewLen)
 #define copy_string(str,len) alloc_string_len(str,len)
 
 
-// The "Check" macros throw an error if assumtion is false
+// The "Check" macros throw an error if assumption is false
 #define val_check_kind(v,t)	if( !val_is_kind(v,t) ) hx_failure("invalid kind");
 #define val_check_function(f,n) if( !val_is_function(f) || (val_fun_nargs(f) != (n) && val_fun_nargs(f) != faVarArgs) ) hx_failure("Bad function");
 #define val_check(v,t)		if( !val_is_##t(v) ) hx_failure("type not " #t);

--- a/include/hx/CFFILoader.h
+++ b/include/hx/CFFILoader.h
@@ -2,7 +2,7 @@
 #define HX_CFFI_LOADER_H
 
 /*
-  This file will only be incuded in one cpp file in the ndll library -
+  This file will only be included in one cpp file in the ndll library -
     the one with IMPLEMENT_API #defined.
 
   The other files will refer to the val_ functions via the "extern" in CFFI.h
@@ -12,12 +12,12 @@
   The pointers starts off as function pointers to bootstrap code, so when they are first called
    the bootstrap uses the "ResolveProc" to find the correct version of the function for the particular
    platform, and replaces the function pointer with this value. Subsequent calls then go directly
-   to the correct fucntion.
+   to the correct function.
 
   The ResolveProc can come from:
    Explicitly setting - the proc is set when a dll is loaded into the hxcpp exe
    Via 'GetProcAddress' on the exe - if symbols are needed and the proc has not been set
-   Internal implementation (CFFINekoLoader) - when linking agaist a neko process.
+   Internal implementation (CFFINekoLoader) - when linking against a neko process.
     - Old code used to find this in NekoApi.dll, but the glue code is now built into each ndll directly.
 
   For static linking, the functions are resolved at link time.

--- a/include/hx/ErrorCodes.h
+++ b/include/hx/ErrorCodes.h
@@ -1,7 +1,7 @@
 #ifndef HX_ERROR_CODES
 #define HX_ERROR_CODES
 
-// --- Exteral constants, used inline
+// --- External constants, used inline
 #define HX_INVALID_CAST          Dynamic(HX_CSTRING("Invalid Cast"))
 #define HX_INVALID_INTERFACE     Dynamic(HX_CSTRING("Object does not implement interface"))
 #define HX_INDEX_OUT_OF_BOUNDS   Dynamic(HX_CSTRING("Index Out of Bounds"))

--- a/include/hx/FieldRef.h
+++ b/include/hx/FieldRef.h
@@ -6,7 +6,7 @@ namespace hx
 
 // --- FieldRef ----------------------------------------------------------
 //
-//  This is used to provide syntaxe for setting fields by name.  This is because
+//  This is used to provide syntax for setting fields by name.  This is because
 //   the field can't be returned by reference, because it may not exist as a dynamic.
 //
 //  eg, consider class 'A' with variable 'x':

--- a/include/hx/GC.h
+++ b/include/hx/GC.h
@@ -360,7 +360,7 @@ public:
 
 
 
-   // These allocate the function using the garbage-colleced malloc
+   // These allocate the function using the garbage-collected malloc
    inline static void *alloc(ImmixAllocator *alloc, size_t inSize, bool inContainer, const char *inName )
    {
       #ifdef HXCPP_GC_NURSERY

--- a/include/hx/Memory.h
+++ b/include/hx/Memory.h
@@ -1,6 +1,6 @@
 #ifdef HX_MEMORY_H_OVERRIDE
 // Users can define their own header to use here, but there is no API
-// compatibility gaurantee for future changes.
+// compatibility guarantee for future changes.
 #include HX_MEMORY_H_OVERRIDE
 
 // Todo - special version?

--- a/include/hx/StackContext.h
+++ b/include/hx/StackContext.h
@@ -408,7 +408,7 @@ struct StackContext : public hx::ImmixAllocator
       bool mIsUnwindingException;
 
       #ifdef HXCPP_STACK_SCRIPTABLE
-         // TODO - combine CppaCtx and StackContext
+         // TODO - combine CppiaCtx and StackContext
       #endif
 
       #ifdef HXCPP_DEBUGGER

--- a/include/hx/StackContext.h
+++ b/include/hx/StackContext.h
@@ -19,7 +19,7 @@
 #define HXCPP_STACK_LINE
 #endif
 
-// Do we need to keep a stack trace - for basic exception handelling, also needed for the debugger
+// Do we need to keep a stack trace - for basic exception handling, also needed for the debugger
 // At a minimum, you can track the functions calls and nothing else
 #if (defined(HXCPP_STACK_LINE) || defined(HXCPP_TELEMETRY) || defined(HXCPP_PROFILER) || defined(HXCPP_DEBUG)) && !defined(HXCPP_STACK_TRACE)
    #define HXCPP_STACK_TRACE

--- a/include/hx/StdString.h
+++ b/include/hx/StdString.h
@@ -1,5 +1,5 @@
-#ifndef HX_STD_STRING_INCLUDEDED
-#define HX_STD_STRING_INCLUDEDED
+#ifndef HX_STD_STRING_INCLUDED
+#define HX_STD_STRING_INCLUDED
 
 #include <string>
 

--- a/include/hx/StringAlloc.h
+++ b/include/hx/StringAlloc.h
@@ -20,11 +20,11 @@ template<int STACK>
 class StringAlloc : public IStringAlloc
 {
    char buffer[STACK];
-   size_t alloced;
+   size_t allocated;
    char   *heap;
 
    public:
-      inline StringAlloc() : alloced(0), heap(0) { }
+      inline StringAlloc() : allocated(0), heap(0) { }
       ~StringAlloc()
       {
          if (heap)
@@ -34,10 +34,10 @@ class StringAlloc : public IStringAlloc
       {
          if (inBytes<=STACK)
             return buffer;
-         if (inBytes>alloced)
+         if (inBytes>allocated)
          {
-            alloced = inBytes;
-            heap = (char *)realloc(heap, alloced);
+            allocated = inBytes;
+            heap = (char *)realloc(heap, allocated);
          }
          return heap;
       }

--- a/include/hx/Thread.h
+++ b/include/hx/Thread.h
@@ -1,6 +1,6 @@
 #ifdef HX_THREAD_H_OVERRIDE
 // Users can define their own header to use here, but there is no API
-// compatibility gaurantee for future changes.
+// compatibility guarantee for future changes.
 #include HX_THREAD_H_OVERRIDE
 #else
 

--- a/include/hx/Tls.h
+++ b/include/hx/Tls.h
@@ -1,6 +1,6 @@
 #ifdef HX_TLS_H_OVERRIDE
 // Users can define their own header to use here, but there is no API
-// compatibility gaurantee for future changes.
+// compatibility guarantee for future changes.
 #include HX_TLS_H_OVERRIDE
 #else
 

--- a/include/hxString.h
+++ b/include/hxString.h
@@ -24,7 +24,7 @@ class HXCPP_EXTERN_CLASS_ATTRIBUTES String
    friend class StringOffset;
 
 public:
-  // These allocate the function using the garbage-colleced malloc
+  // These allocate the function using the garbage-collected malloc
    void *operator new( size_t inSize );
    inline void* operator new( size_t, void* ptr ) { return ptr; }
    void operator delete( void * ) { }

--- a/include/hxcpp.h
+++ b/include/hxcpp.h
@@ -68,7 +68,7 @@
    #define HXCPP_ALIGN_FLOAT
 #endif
 
-// Must allign allocs to 8 bytes to match floating point requirement?
+// Must align allocs to 8 bytes to match floating point requirement?
 // Ints must br read on 4-byte boundary
 #if (!defined(HXCPP_ALIGN_FLOAT) && (defined(EMSCRIPTEN) || defined(GCW0)) )
    #define HXCPP_ALIGN_ALLOC
@@ -189,7 +189,7 @@ typedef char HX_CHAR;
 
 #ifdef HX_SMART_STRINGS
   #define HX_FIELD_EQ(name,field) (name.isAsciiEncoded() && !::memcmp(name.raw_ptr(), field, sizeof(field)/sizeof(char)))
-  // No null check is performedd...
+  // No null check is performed...
   #define HX_QSTR_EQ(name,field) (name.length==field.length && field.isAsciiEncodedQ() && !::memcmp(name.raw_ptr(), field.raw_ptr() , field.length) )
   // field is known to be isAsciiEncodedQ
   #define HX_QSTR_EQ_AE(name,field) (name.length==field.length && !::memcmp(name.raw_ptr(), field.raw_ptr() , field.length) )
@@ -246,7 +246,7 @@ namespace cpp
 // Extended mapping - old way
 namespace haxe { namespace io { typedef unsigned char Unsigned_char__; } }
 
-// --- Forward decalarations --------------------------------------------
+// --- Forward declarations --------------------------------------------
 
 class null;
 namespace hx { class Object; }

--- a/include/null.h
+++ b/include/null.h
@@ -5,7 +5,7 @@
 
 // --- null value  ---------------------------------------------------------
 //
-// This is used by external operatator and return statments - Most will
+// This is used by external operator and return statements - Most will
 //  use operator overloading to convert to the null pointer
 
 
@@ -199,7 +199,7 @@ struct Null
    T    value;
 };
 
-} // end namesapce hx
+} // end namespace hx
 
 typedef null Void;
 

--- a/src/Array.cpp
+++ b/src/Array.cpp
@@ -47,8 +47,8 @@ void ArrayBase::reserve(int inSize) const
 
       if (mBase)
       {
-         bool wasUnamanaged = mAlloc<0;
-         if (wasUnamanaged)
+         bool wasUnmanaged = mAlloc<0;
+         if (wasUnmanaged)
          {
             char *base=(char *)hx::InternalNew(bytes,false);
             memcpy(base,mBase,length*elemSize);
@@ -98,8 +98,8 @@ void ArrayBase::Realloc(int inSize) const
 
       if (mBase)
       {
-         bool wasUnamanaged = mAlloc<0;
-         if (wasUnamanaged)
+         bool wasUnmanaged = mAlloc<0;
+         if (wasUnmanaged)
          {
             char *base=(char *)hx::InternalNew(bytes,false);
             memcpy(base,mBase,length*elemSize);
@@ -222,9 +222,9 @@ void ArrayBase::__SetSizeExact(int inSize)
       int bytes = inSize * elemSize;
       if (mBase)
       {
-         bool wasUnamanaged = mAlloc<0;
+         bool wasUnmanaged = mAlloc<0;
 
-         if (wasUnamanaged)
+         if (wasUnmanaged)
          {
             char *base=(char *)(AllocAtomic() ? hx::NewGCPrivate(0,bytes) : hx::NewGCBytes(0,bytes));
             memcpy(base,mBase,std::min(length,inSize)*elemSize);

--- a/src/ExampleMain.cpp
+++ b/src/ExampleMain.cpp
@@ -28,7 +28,7 @@
    init call.  The inclusion of the extra static library will require the library
    in the link line, and may requires additional dependencies to be linked.
    Also note, that there may be licensing implications with static linking
-   thirdparty libraries.
+   third party libraries.
 
 */
 
@@ -46,7 +46,7 @@ extern "C" int main(int argc, char *argv[])
 	// Do this first
 	hxcpp_set_top_of_stack();
 
-   // Register additional ndll libaries ...
+   // Register additional ndll libraries ...
    // nme_register_prims();
 
 	//printf("Begin!\n");

--- a/src/ObjcData.mm
+++ b/src/ObjcData.mm
@@ -75,7 +75,7 @@ id _hx_value_to_objc(Dynamic d)
          {
             return _hx_value_to_objc( d->__Field( HX_CSTRING("b"), hx::paccDynamic ) );
          }
-         // else fallthough...
+         // else fallthrough...
         
       case vtFunction:
       case vtEnum:

--- a/src/String.cpp
+++ b/src/String.cpp
@@ -983,7 +983,7 @@ unsigned int String::calcHash() const
 
 
 
-// InternalCreateConstBuffer is not uft16 aware whenit come to hashes
+// InternalCreateConstBuffer is not uft16 aware when it comes to hashes
 static void fixHashPerm16(const String &str)
 {
    unsigned int hash = str.calcHash();

--- a/src/hx/Debug.cpp
+++ b/src/hx/Debug.cpp
@@ -372,13 +372,13 @@ void StackContext::beginCatch(bool inAll)
    if (inAll)
    {
       mExceptionStack.clear();
-      // Copy remaineder of stack frames to exception stack...
+      // Copy remainder of stack frames to exception stack...
       // This will use the default operator=, which will copy the pointers.
       // This is what we want, since the pointers are pointers to constant data
       for(int i=mStackFrames.size()-1;i>=0;--i)
          mExceptionStack.push( *mStackFrames[i] );
    }
-   // Lock-in the excpetion stack
+   // Lock-in the exception stack
    mIsUnwindingException = false;
 }
 
@@ -484,7 +484,7 @@ HXCPP_EXTERN_CLASS_ATTRIBUTES void NullReference(const char *type, bool allowFix
 }
 
 
-} // end namspace hx
+} // end namespace hx
 
 #ifndef HXCPP_DEBUGGER
 void __hxcpp_execution_trace(int inLevel) { }

--- a/src/hx/Debugger.cpp
+++ b/src/hx/Debugger.cpp
@@ -46,8 +46,8 @@ static Dynamic g_newParameterFunction;
 //            StackFrame : Dynamic
 static Dynamic g_newStackFrameFunction;
 // This is the function to call to create a new ThreadInfo
-// Signature: number : Int -> statu s: Int -> breakpoint : Int ->
-//                     ThreadInfo :  Dynamic
+// Signature: number : Int -> status : Int -> breakpoint : Int ->
+//                     ThreadInfo : Dynamic
 static Dynamic g_newThreadInfoFunction;
 // This is the function to call to add a Parameter to a StackFrame.
 // Signature: inStackFrame : Dynamic -> inParameter : Dynamic -> Void
@@ -677,7 +677,7 @@ public:
         stack->mDebugger->Break(breakStatus, breakpointNumber, 0);
       }
 
-      static bool shoudBreakOnLine()
+      static bool shouldBreakOnLine()
       {
          return gBreakpoints->IsEmpty() || gStepType != hx::STEP_NONE;
       }
@@ -1506,7 +1506,7 @@ void __hxcpp_execution_trace(int inLevel)
 {
     hx::sExecutionTrace = (hx::ExecutionTrace)inLevel;
     hx::gShouldCallHandleBreakpoints =
-          hx::Breakpoints::shoudBreakOnLine() || (hx::sExecutionTrace==hx::exeTraceLines);
+          hx::Breakpoints::shouldBreakOnLine() || (hx::sExecutionTrace==hx::exeTraceLines);
 }
 
 

--- a/src/hx/Hash.cpp
+++ b/src/hx/Hash.cpp
@@ -782,7 +782,7 @@ void __string_hash_set_int64(HX_MAP_THIS_ARG, String inKey, cpp::Int64 inValue)
                   return false;
             return true;
          }
-         // fallthough...
+         // fallthrough...
          #endif
          return !memcmp(inKey.__s, bigString.__s+offset, len);
       }

--- a/src/hx/Hash.h
+++ b/src/hx/Hash.h
@@ -185,7 +185,7 @@ public:
 
 
 
-// An Dyanamic element must use the GC code to get a hash
+// An Dynamic element must use the GC code to get a hash
 template<typename VALUE,bool WEAK>
 struct TDynamicElement
 {

--- a/src/hx/TelemetryTracy.cpp
+++ b/src/hx/TelemetryTracy.cpp
@@ -199,7 +199,7 @@ void hx::tlmSampleEnter(hx::Telemetry* telemetry, hx::StackFrame* frame)
 			0);
 
 	#if HXCPP_TRACY_INCLUDE_CALLSTACKS
-		// Note: Tracy doesnt support Callstacks outside this scope: depth >= 1 && depth < 63
+		// Note: Tracy doesn't support Callstacks outside this scope: depth >= 1 && depth < 63
 		// Determine depth from tracyZones vector: +1 since we are about to add one
 		auto depth = telemetry->tracyZones.size() + 1;
 

--- a/src/hx/Thread.cpp
+++ b/src/hx/Thread.cpp
@@ -11,7 +11,7 @@ static HxMutex g_threadInfoMutex;
 static int g_nextThreadNumber = 1;
 
 
-// How to manage hxThreadInfo references for non haxe threads (main, extenal)?
+// How to manage hxThreadInfo references for non haxe threads (main, external)?
 // HXCPP_THREAD_INFO_PTHREAD - use pthread api
 // HXCPP_THREAD_INFO_LOCAL - use thread_local storage
 // HXCPP_THREAD_INFO_SINGLETON - use one structure for all threads. Not ideal.
@@ -258,7 +258,7 @@ THREAD_FUNC_TYPE hxThreadFunc( void *inInfo )
 	// Release the creation function
 	info[0]->mSemaphore->Set();
 
-    // Call the debugger function to annouce that a thread has been created
+    // Call the debugger function to announce that a thread has been created
     //__hxcpp_dbg_threadCreatedOrTerminated(info[0]->GetThreadNumber(), true);
 
 	if ( info[0]->mFunction.GetPtr() )
@@ -267,7 +267,7 @@ THREAD_FUNC_TYPE hxThreadFunc( void *inInfo )
 		info[0]->mFunction->__run();
 	}
 
-    // Call the debugger function to annouce that a thread has terminated
+    // Call the debugger function to announce that a thread has terminated
     //__hxcpp_dbg_threadCreatedOrTerminated(info[0]->GetThreadNumber(), false);
 
 	hx::UnregisterCurrentThread();

--- a/src/hx/cppia/ArrayBuiltin.cpp
+++ b/src/hx/cppia/ArrayBuiltin.cpp
@@ -1151,12 +1151,12 @@ struct ArrayBuiltin : public ArrayBuiltinBase
    }
 
 
-   static hx::Object *SLJIT_CALL runGetIteratator( Array_obj<ELEM> *inArray )
+   static hx::Object *SLJIT_CALL runGetIterator( Array_obj<ELEM> *inArray )
    {
       return inArray->iterator().mPtr;
    }
 
-   static hx::Object *SLJIT_CALL runGetKeyValueIteratator( Array_obj<ELEM> *inArray )
+   static hx::Object *SLJIT_CALL runGetKeyValueIterator( Array_obj<ELEM> *inArray )
    {
       return inArray->keyValueIterator().mPtr;
    }
@@ -1729,14 +1729,14 @@ struct ArrayBuiltin : public ArrayBuiltinBase
          case afIterator:
             {
                thisExpr->genCode(compiler, sJitTemp0, etObject);
-               compiler->callNative( (void *)runGetIteratator, sJitTemp0.as(jtPointer) );
+               compiler->callNative( (void *)runGetIterator, sJitTemp0.as(jtPointer) );
                compiler->convertReturnReg(etObject, inDest, destType);
                break;
             }
          case afKeyValueIterator:
             {
                thisExpr->genCode(compiler, sJitTemp0, etObject);
-               compiler->callNative( (void *)runGetKeyValueIteratator, sJitTemp0.as(jtPointer) );
+               compiler->callNative( (void *)runGetKeyValueIterator, sJitTemp0.as(jtPointer) );
                compiler->convertReturnReg(etObject, inDest, destType);
                break;
             }

--- a/src/hx/cppia/Cppia.cpp
+++ b/src/hx/cppia/Cppia.cpp
@@ -814,7 +814,7 @@ struct CallFunExpr : public CppiaExpr
       CPPIALOG("callScriptable %p(%p) -> %p\n", inCtx, CppiaCtx::getCurrent(), inScriptable );
       CPPIALOG(" name = %s\n", inScriptable->getName());
       inScriptable->runFunction(inCtx);
-      CPPIALOG(" Done scipt callable\n");
+      CPPIALOG(" Done script callable\n");
    }
 
 
@@ -1678,7 +1678,7 @@ inline void SetVal(String &out, const T &value) { out = String(value); }
 template<typename T>
 inline void SetVal(Dynamic &out, const T &value) { out = value; }
 
-//template<typname RETURN>
+//template<typename RETURN>
 struct CallHaxe : public CppiaExpr
 {
    Expressions args;
@@ -1711,7 +1711,7 @@ struct CallHaxe : public CppiaExpr
             case sigVoid: 
                if (i==0) // return void ok
                   break;
-               // fallthough
+               // fallthrough
             default:
                throw "Bad haxe signature";
          }
@@ -3318,7 +3318,7 @@ struct CallMember : public CppiaExpr
          if (func.signature)
          {
             if (callSuperField && !func.superExecute)
-               CPPIALOG("Warning - calling super host '%s' from cppia can lead to infinte recursion\n", field.utf8_str());
+               CPPIALOG("Warning - calling super host '%s' from cppia can lead to infinite recursion\n", field.utf8_str());
 
             //CPPIALOG(" found function %s\n", func.signature );
             replace = new CallHaxe( this, func, thisExpr, args, false, callSuperField && func.superExecute);
@@ -4665,7 +4665,7 @@ struct GetFieldByLinkage : public CppiaExpr
       }
 
       // It is ok for interfaces to look up members by name - and variables that turn
-      //  out to actaully be Dynamic (eg template types)
+      //  out to actually be Dynamic (eg template types)
       if (!type->isInterface && !type->isDynamic && !forceNamedAccess)
       {
          CPPIALOG("   GetFieldByLinkage %s (%p %p %p) '%s' fallback\n", type->name.out_str(), object, type->haxeClass.mPtr, type->cppiaClass, field.out_str());

--- a/src/hx/cppia/Cppia.h
+++ b/src/hx/cppia/Cppia.h
@@ -335,7 +335,7 @@ CppiaExpr *createStaticAccess(CppiaExpr *inSrc, ExprType inType, void *inPtr);
 CppiaExpr *createStaticAccess(CppiaExpr *inSrc, FieldStorage inType, void *inPtr);
 hx::Object * CPPIA_CALL createClosure(CppiaCtx *ctx, ScriptCallable *inFunction);
 hx::Object *createMemberClosure(hx::Object *, ScriptCallable *inFunction);
-hx::Object *createEnumClosure(struct CppiaEnumConstructor &inContructor);
+hx::Object *createEnumClosure(struct CppiaEnumConstructor &inConstructor);
 
 hx::Object *DynamicToArrayType(hx::Object *obj, ArrayType arrayType);
 

--- a/src/hx/cppia/CppiaClasses.cpp
+++ b/src/hx/cppia/CppiaClasses.cpp
@@ -153,9 +153,9 @@ public:
 
 
 
-hx::Object *createEnumClosure(CppiaEnumConstructor &inContructor)
+hx::Object *createEnumClosure(CppiaEnumConstructor &inConstructor)
 {
-   return new EnumConstructorClosure(inContructor);
+   return new EnumConstructorClosure(inConstructor);
 }
 
 

--- a/src/hx/cppia/CppiaCompiler.cpp
+++ b/src/hx/cppia/CppiaCompiler.cpp
@@ -495,7 +495,7 @@ public:
             // test failed, but test nan
             JumpId notNan = sljit_emit_jump(compiler,SLJIT_ORDERED_F64);
 
-            // is nan - fallthough
+            // is nan - fallthrough
             // test passed, but was nan
             comeFrom(passed);
             JumpId good = sljit_emit_jump(compiler,SLJIT_JUMP);

--- a/src/hx/cppia/CppiaFunction.cpp
+++ b/src/hx/cppia/CppiaFunction.cpp
@@ -10,7 +10,7 @@ static int sTypeSize[] = { 0, 0, sizeof(hx::Object *), sizeof(String), sizeof(Fl
 
 // --- ScriptCallable ----------------------------------------------------
 
-String sInvalidArgCount = HX_CSTRING("Invalid arguement count");
+String sInvalidArgCount = HX_CSTRING("Invalid argument count");
 
 
 #ifdef CPPIA_JIT

--- a/src/hx/cppia/CppiaVars.cpp
+++ b/src/hx/cppia/CppiaVars.cpp
@@ -643,7 +643,7 @@ void CppiaStackVar::genDefault(CppiaCompiler *compiler, const CppiaConst &inDefa
       {
          case fsByte:
          case fsBool: 
-            //Fallthough...
+            //Fallthrough...
             //compiler->callNative( (void *)objToInt, sJitTemp0.as(jtPointer) );
             //compiler->move( destPos.as(jtByte), sJitReturnReg.as(jtByte));
             //compiler->move( destPos.as(jtInt), sJitReturnReg.as(jtInt));

--- a/src/hx/cppia/sljit_src/sljitConfigInternal.h
+++ b/src/hx/cppia/sljit_src/sljitConfigInternal.h
@@ -35,7 +35,7 @@
      sljit_s16, sljit_u16 : signed and unsigned 16 bit integer type
      sljit_s32, sljit_u32 : signed and unsigned 32 bit integer type
      sljit_sw, sljit_uw   : signed and unsigned machine word, enough to store a pointer
-     sljit_p              : unsgined pointer value (usually the same as sljit_uw, but
+     sljit_p              : unsigned pointer value (usually the same as sljit_uw, but
                             some 64 bit ABIs may use 32 bit pointers)
      sljit_f32            : 32 bit single precision floating point value
      sljit_f64            : 64 bit double precision floating point value
@@ -522,7 +522,7 @@ typedef double sljit_f64;
 #endif
 #endif /* SLJIT_INDIRECT_CALL */
 
-/* The offset which needs to be substracted from the return address to
+/* The offset which needs to be subtracted from the return address to
 determine the next executed instruction after return. */
 #ifndef SLJIT_RETURN_ADDRESS_OFFSET
 #if (defined SLJIT_CONFIG_SPARC_32 && SLJIT_CONFIG_SPARC_32)

--- a/src/hx/cppia/sljit_src/sljitLir.c
+++ b/src/hx/cppia/sljit_src/sljitLir.c
@@ -309,7 +309,7 @@
 
 #elif (defined SLJIT_DEBUG && SLJIT_DEBUG)
 
-/* Assertion failure occures if an invalid argument is passed. */
+/* Assertion failure occurs if an invalid argument is passed. */
 #undef SLJIT_ARGUMENT_CHECKS
 #define SLJIT_ARGUMENT_CHECKS 1
 
@@ -1713,7 +1713,7 @@ SLJIT_API_FUNC_ATTRIBUTE struct sljit_jump* sljit_emit_cmp(struct sljit_compiler
 #endif
 
 	if (SLJIT_UNLIKELY((src1 & SLJIT_IMM) && !(src2 & SLJIT_IMM))) {
-		/* Immediate is prefered as second argument by most architectures. */
+		/* Immediate is preferred as second argument by most architectures. */
 		switch (condition) {
 		case SLJIT_LESS:
 			condition = SLJIT_GREATER;

--- a/src/hx/cppia/sljit_src/sljitLir.h
+++ b/src/hx/cppia/sljit_src/sljitLir.h
@@ -88,7 +88,7 @@ of sljitConfigInternal.h */
 #define SLJIT_SUCCESS			0
 /* After the call of sljit_generate_code(), the error code of the compiler
    is set to this value to avoid future sljit calls (in debug mode at least).
-   The complier should be freed after sljit_generate_code(). */
+   The compiler should be freed after sljit_generate_code(). */
 #define SLJIT_ERR_COMPILED		1
 /* Cannot allocate non executable memory. */
 #define SLJIT_ERR_ALLOC_FAILED		2
@@ -545,7 +545,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_enter(struct sljit_compiler *compi
 
 /* The machine code has a context (which contains the local stack space size,
    number of used registers, etc.) which initialized by sljit_emit_enter. Several
-   functions (like sljit_emit_return) requres this context to be able to generate
+   functions (like sljit_emit_return) requires this context to be able to generate
    the appropriate code. However, some code fragments (like inline cache) may have
    no normal entry point so their context is unknown for the compiler. Their context
    can be provided to the compiler by the sljit_set_context function.
@@ -571,8 +571,8 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_return(struct sljit_compiler *comp
    dst/dstw by sljit_emit_fast_enter (the type of the value stored by this function
    is sljit_p), and sljit_emit_fast_return can use this as a return value later. */
 
-/* Note: only for sljit specific, non ABI compilant calls. Fast, since only a few machine
-   instructions are needed. Excellent for small uility functions, where saving registers
+/* Note: only for sljit specific, non ABI compliant calls. Fast, since only a few machine
+   instructions are needed. Excellent for small utility functions, where saving registers
    and setting up a new stack frame would cost too much performance. However, it is still
    possible to return to the address of the caller (or anywhere else). */
 
@@ -596,7 +596,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_fast_return(struct sljit_compiler 
 */
 
 /*
-   IMPORATNT NOTE: memory access MUST be naturally aligned except
+   IMPORTANT NOTE: memory access MUST be naturally aligned except
                    SLJIT_UNALIGNED macro is defined and its value is 1.
 
      length | alignment
@@ -611,7 +611,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_fast_return(struct sljit_compiler 
 
    Note:   Different architectures have different addressing limitations.
            A single instruction is enough for the following addressing
-           modes. Other adrressing modes are emulated by instruction
+           modes. Other addressing modes are emulated by instruction
            sequences. This information could help to improve those code
            generators which focuses only a few architectures.
 
@@ -1200,7 +1200,7 @@ SLJIT_API_FUNC_ATTRIBUTE struct sljit_const* sljit_emit_const(struct sljit_compi
 
 /* After the code generation the address for label, jump and const instructions
    are computed. Since these structures are freed by sljit_free_compiler, the
-   addresses must be preserved by the user program elsewere. */
+   addresses must be preserved by the user program elsewhere. */
 static SLJIT_INLINE sljit_uw sljit_get_label_addr(struct sljit_label *label) { return label->addr; }
 static SLJIT_INLINE sljit_uw sljit_get_jump_addr(struct sljit_jump *jump) { return jump->addr; }
 static SLJIT_INLINE sljit_uw sljit_get_const_addr(struct sljit_const *const_) { return const_->addr; }

--- a/src/hx/cppia/sljit_src/sljitNativeARM_32.c
+++ b/src/hx/cppia/sljit_src/sljitNativeARM_32.c
@@ -63,7 +63,7 @@ static const sljit_u8 reg_map[SLJIT_NUMBER_OF_REGISTERS + 5] = {
 #define RN(rn) (reg_map[rn] << 16)
 
 /* --------------------------------------------------------------------- */
-/*  Instrucion forms                                                     */
+/*  Instruction forms                                                    */
 /* --------------------------------------------------------------------- */
 
 /* The instruction includes the AL condition.
@@ -307,7 +307,7 @@ static sljit_uw patch_pc_relative_loads(sljit_uw *last_pc_patch, sljit_uw *code_
 	return counter;
 }
 
-/* In some rare ocasions we may need future patches. The probability is close to 0 in practice. */
+/* In some rare occasions we may need future patches. The probability is close to 0 in practice. */
 struct future_patch {
 	struct future_patch* next;
 	sljit_s32 index;
@@ -1166,7 +1166,7 @@ static sljit_s32 generate_int(struct sljit_compiler *compiler, sljit_s32 reg, sl
 	sljit_uw imm2;
 	sljit_s32 rol;
 
-	/* Step1: Search a zero byte (8 continous zero bit). */
+	/* Step1: Search a zero byte (8 continuous zero bit). */
 	mask = 0xff000000;
 	rol = 8;
 	while(1) {

--- a/src/hx/cppia/sljit_src/sljitNativeARM_64.c
+++ b/src/hx/cppia/sljit_src/sljitNativeARM_64.c
@@ -59,7 +59,7 @@ static const sljit_u8 reg_map[SLJIT_NUMBER_OF_REGISTERS + 8] = {
 #define VM(vm) ((vm) << 16)
 
 /* --------------------------------------------------------------------- */
-/*  Instrucion forms                                                     */
+/*  Instruction forms                                                    */
 /* --------------------------------------------------------------------- */
 
 #define ADC 0x9a000000

--- a/src/hx/cppia/sljit_src/sljitNativeARM_T2_32.c
+++ b/src/hx/cppia/sljit_src/sljitNativeARM_T2_32.c
@@ -78,7 +78,7 @@ static const sljit_u8 reg_map[SLJIT_NUMBER_OF_REGISTERS + 5] = {
 	(COPY_BITS(imm, 11, 26, 1) | COPY_BITS(imm, 8, 12, 3) | (imm & 0xff))
 
 /* --------------------------------------------------------------------- */
-/*  Instrucion forms                                                     */
+/*  Instruction forms                                                    */
 /* --------------------------------------------------------------------- */
 
 /* dot '.' changed to _

--- a/src/hx/cppia/sljit_src/sljitNativeMIPS_common.c
+++ b/src/hx/cppia/sljit_src/sljitNativeMIPS_common.c
@@ -68,7 +68,7 @@ static const sljit_u8 reg_map[SLJIT_NUMBER_OF_REGISTERS + 5] = {
 };
 
 /* --------------------------------------------------------------------- */
-/*  Instrucion forms                                                     */
+/*  Instruction forms                                                    */
 /* --------------------------------------------------------------------- */
 
 #define S(s)		(reg_map[s] << 21)
@@ -301,7 +301,7 @@ static SLJIT_INLINE sljit_ins* detect_jump_type(struct sljit_jump *jump, sljit_i
 		}
 	}
 	else {
-		/* J instuctions. */
+		/* J instructions. */
 		if ((jump->flags & IS_MOVABLE) && (target_addr & ~0xfffffff) == (jump->addr & ~0xfffffff)) {
 			jump->flags |= PATCH_J;
 			inst[0] = inst[-1];
@@ -695,7 +695,7 @@ static const sljit_ins data_transfer_insts[16 + 4] = {
 
 #undef ARCH_32_64
 
-/* reg_ar is an absoulute register! */
+/* reg_ar is an absolute register! */
 
 /* Can perform an operation using at most 1 instruction. */
 static sljit_s32 getput_arg_fast(struct sljit_compiler *compiler, sljit_s32 flags, sljit_s32 reg_ar, sljit_s32 arg, sljit_sw argw)
@@ -703,7 +703,7 @@ static sljit_s32 getput_arg_fast(struct sljit_compiler *compiler, sljit_s32 flag
 	SLJIT_ASSERT(arg & SLJIT_MEM);
 
 	if ((!(flags & WRITE_BACK) || !(arg & REG_MASK)) && !(arg & OFFS_REG_MASK) && argw <= SIMM_MAX && argw >= SIMM_MIN) {
-		/* Works for both absoulte and relative addresses. */
+		/* Works for both absolute and relative addresses. */
 		if (SLJIT_UNLIKELY(flags & ARG_TEST))
 			return 1;
 		FAIL_IF(push_inst(compiler, data_transfer_insts[flags & MEM_MASK] | S(arg & REG_MASK)

--- a/src/hx/cppia/sljit_src/sljitNativePPC_common.c
+++ b/src/hx/cppia/sljit_src/sljitNativePPC_common.c
@@ -110,7 +110,7 @@ static const sljit_u8 reg_map[SLJIT_NUMBER_OF_REGISTERS + 7] = {
 };
 
 /* --------------------------------------------------------------------- */
-/*  Instrucion forms                                                     */
+/*  Instruction forms                                                    */
 /* --------------------------------------------------------------------- */
 #define D(d)		(reg_map[d] << 21)
 #define S(s)		(reg_map[s] << 21)
@@ -548,7 +548,7 @@ SLJIT_API_FUNC_ATTRIBUTE void* sljit_generate_code(struct sljit_compiler *compil
 /* Other inp_flags. */
 
 #define ARG_TEST	0x000100
-/* Integer opertion and set flags -> requires exts on 64 bit systems. */
+/* Integer operation and set flags -> requires exts on 64 bit systems. */
 #define ALT_SIGN_EXT	0x000200
 /* This flag affects the RC() and OERC() macros. */
 #define ALT_SET_FLAGS	0x000400
@@ -724,7 +724,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_return(struct sljit_compiler *comp
    s/l - store/load (1 bit)
    u/s - signed/unsigned (1 bit)
    w/b/h/i - word/byte/half/int allowed (2 bit)
-   It contans 32 items, but not all are different. */
+   It contains 32 items, but not all are different. */
 
 /* 64 bit only: [reg+imm] must be aligned to 4 bytes. */
 #define INT_ALIGNED	0x10000

--- a/src/hx/cppia/sljit_src/sljitNativeSPARC_common.c
+++ b/src/hx/cppia/sljit_src/sljitNativeSPARC_common.c
@@ -100,7 +100,7 @@ static const sljit_u8 reg_map[SLJIT_NUMBER_OF_REGISTERS + 6] = {
 };
 
 /* --------------------------------------------------------------------- */
-/*  Instrucion forms                                                     */
+/*  Instruction forms                                                    */
 /* --------------------------------------------------------------------- */
 
 #define D(d)		(reg_map[d] << 25)
@@ -528,7 +528,7 @@ static sljit_s32 getput_arg_fast(struct sljit_compiler *compiler, sljit_s32 flag
 	if (!(flags & WRITE_BACK) || !(arg & REG_MASK)) {
 		if ((!(arg & OFFS_REG_MASK) && argw <= SIMM_MAX && argw >= SIMM_MIN)
 				|| ((arg & OFFS_REG_MASK) && (argw & 0x3) == 0)) {
-			/* Works for both absoulte and relative addresses (immediate case). */
+			/* Works for both absolute and relative addresses (immediate case). */
 			if (SLJIT_UNLIKELY(flags & ARG_TEST))
 				return 1;
 			FAIL_IF(push_inst(compiler, data_transfer_insts[flags & MEM_MASK]

--- a/src/hx/cppia/sljit_src/sljitNativeTILEGX_64.c
+++ b/src/hx/cppia/sljit_src/sljitNativeTILEGX_64.c
@@ -59,7 +59,7 @@ static const sljit_u8 reg_map[SLJIT_NUMBER_OF_REGISTERS + 6] = {
 #define TMP_REG3_mapped 6
 #define ADDR_TMP_mapped 7
 
-/* Flags are keept in volatile registers. */
+/* Flags are kept in volatile registers. */
 #define EQUAL_FLAG 8
 /* And carry flag as well. */
 #define ULESS_FLAG 9
@@ -813,7 +813,7 @@ static sljit_s32 push_3_buffer(struct sljit_compiler *compiler, tilegx_mnemonic 
 		inst_buf[inst_buf_index].output_registers = 1L << op0;
 		break;
 	default:
-		printf("unrecoginzed opc: %s\n", opcode->name);
+		printf("unrecognized opc: %s\n", opcode->name);
 		SLJIT_UNREACHABLE();
 	}
 
@@ -858,7 +858,7 @@ static sljit_s32 push_2_buffer(struct sljit_compiler *compiler, tilegx_mnemonic 
 		inst_buf[inst_buf_index].output_registers = 1L << op0;
 		break;
 	default:
-		printf("unrecoginzed opc: %s\n", opcode->name);
+		printf("unrecognized opc: %s\n", opcode->name);
 		SLJIT_UNREACHABLE();
 	}
 
@@ -1282,7 +1282,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_return(struct sljit_compiler *comp
 	return JR(RA);
 }
 
-/* reg_ar is an absoulute register! */
+/* reg_ar is an absolute register! */
 
 /* Can perform an operation using at most 1 instruction. */
 static sljit_s32 getput_arg_fast(struct sljit_compiler *compiler, sljit_s32 flags, sljit_s32 reg_ar, sljit_s32 arg, sljit_sw argw)
@@ -1291,7 +1291,7 @@ static sljit_s32 getput_arg_fast(struct sljit_compiler *compiler, sljit_s32 flag
 
 	if ((!(flags & WRITE_BACK) || !(arg & REG_MASK))
 			&& !(arg & OFFS_REG_MASK) && argw <= SIMM_16BIT_MAX && argw >= SIMM_16BIT_MIN) {
-		/* Works for both absoulte and relative addresses. */
+		/* Works for both absolute and relative addresses. */
 		if (SLJIT_UNLIKELY(flags & ARG_TEST))
 			return 1;
 
@@ -1697,7 +1697,7 @@ static SLJIT_INLINE sljit_s32 emit_single_op(struct sljit_compiler *compiler, sl
 				else if (src2 != dst)
 					overflow_ra = reg_map[src2];
 				else {
-					/* Rare ocasion. */
+					/* Rare occasion. */
 					FAIL_IF(ADD(TMP_EREG2, reg_map[src1], ZERO));
 					overflow_ra = TMP_EREG2;
 				}
@@ -1780,7 +1780,7 @@ static SLJIT_INLINE sljit_s32 emit_single_op(struct sljit_compiler *compiler, sl
 				if (src1 != dst)
 					overflow_ra = reg_map[src1];
 				else {
-					/* Rare ocasion. */
+					/* Rare occasion. */
 					FAIL_IF(ADD(TMP_EREG2, reg_map[src1], ZERO));
 					overflow_ra = TMP_EREG2;
 				}
@@ -1807,7 +1807,7 @@ static SLJIT_INLINE sljit_s32 emit_single_op(struct sljit_compiler *compiler, sl
 				if (src1 != dst)
 					overflow_ra = reg_map[src1];
 				else {
-					/* Rare ocasion. */
+					/* Rare occasion. */
 					FAIL_IF(ADD(TMP_EREG2, reg_map[src1], ZERO));
 					overflow_ra = TMP_EREG2;
 				}

--- a/src/hx/cppia/sljit_src/sljitNativeX86_common.c
+++ b/src/hx/cppia/sljit_src/sljitNativeX86_common.c
@@ -88,7 +88,7 @@ static const sljit_u8 reg_map[SLJIT_NUMBER_OF_REGISTERS + 3] = {
 #define TMP_REG3	(SLJIT_NUMBER_OF_REGISTERS + 4)
 
 /* Note: r12 & 0x7 == 0b100, which decoded as SIB byte present
-   Note: avoid to use r12 and r13 for memory addessing
+   Note: avoid to use r12 and r13 for memory addressing
    therefore r12 is better for SAVED_EREG than SAVED_REG. */
 #ifndef _WIN64
 /* 1st passed in rdi, 2nd argument passed in rsi, 3rd in rdx. */
@@ -148,7 +148,7 @@ static const sljit_u8 reg_lmap[SLJIT_NUMBER_OF_REGISTERS + 5] = {
 #define EX86_SSE2		(EX86_SSE2_OP1 | EX86_SSE2_OP2)
 
 /* --------------------------------------------------------------------- */
-/*  Instrucion forms                                                     */
+/*  Instruction forms                                                    */
 /* --------------------------------------------------------------------- */
 
 #define ADD		(/* BINARY */ 0 << 3)

--- a/src/hx/cppia/sljit_src/sljitUtils.c
+++ b/src/hx/cppia/sljit_src/sljitUtils.c
@@ -70,7 +70,7 @@ static HANDLE allocator_mutex = 0;
 
 static SLJIT_INLINE void allocator_grab_lock(void)
 {
-	/* No idea what to do if an error occures. Static mutexes should never fail... */
+	/* No idea what to do if an error occurs. Static mutexes should never fail... */
 	if (!allocator_mutex)
 		allocator_mutex = CreateMutex(NULL, TRUE, NULL);
 	else
@@ -90,7 +90,7 @@ static HANDLE global_mutex = 0;
 
 SLJIT_API_FUNC_ATTRIBUTE void SLJIT_CALL sljit_grab_lock(void)
 {
-	/* No idea what to do if an error occures. Static mutexes should never fail... */
+	/* No idea what to do if an error occurs. Static mutexes should never fail... */
 	if (!global_mutex)
 		global_mutex = CreateMutex(NULL, TRUE, NULL);
 	else

--- a/src/hx/gc/GcRegCapture.cpp
+++ b/src/hx/gc/GcRegCapture.cpp
@@ -131,7 +131,7 @@ void CaptureArm64(RegisterCaptureBuffer &outBuffer)
 
 namespace hx {
 
-// Put this function here so we can be reasonablly sure that "this" register and
+// Put this function here so we can be reasonably sure that "this" register and
 // the 4 registers that may be used to pass args are on the stack.
 int RegisterCapture::Capture(int *inTopOfStack,int **inBuf,int &outSize,int inMaxSize, int *inBottom)
 {

--- a/src/hx/gc/GcRegCapture.h
+++ b/src/hx/gc/GcRegCapture.h
@@ -20,7 +20,7 @@
 
    #if defined(HXCPP_ARM64)
       //#define HXCPP_CAPTURE_ARM64
-      // Awlays use setjmp on arm64
+      // Always use setjmp on arm64
       #include <setjmp.h>
       #define HXCPP_CAPTURE_SETJMP
    #endif

--- a/src/hx/gc/Immix.cpp
+++ b/src/hx/gc/Immix.cpp
@@ -5766,7 +5766,7 @@ void MarkConservative(int *inBottom, int *inTop,hx::MarkContext *__inCtx)
                {
                   #ifdef HX_WATCH
                   if (isWatch)
-                     GCLOG(" pin alloced %p (%p)\n", vptr,ptr);
+                     GCLOG(" pin allocated %p (%p)\n", vptr,ptr);
                   #endif
                   lastPin = vptr;
                   info->pin();

--- a/src/hx/gc/Immix.cpp
+++ b/src/hx/gc/Immix.cpp
@@ -95,7 +95,7 @@ static bool sgInternalEnable = true;
 static void *sgObject_root = 0;
 // With virtual inheritance, stack pointers can point to the middle of an object
 #ifdef _MSC_VER
-// MSVC optimizes by taking the address of an initernal data member
+// MSVC optimizes by taking the address of an internal data member
 static int sgCheckInternalOffset = sizeof(void *)*2;
 static int sgCheckInternalOffsetRows = 1;
 #else
@@ -109,7 +109,7 @@ int gInAlloc = false;
 static size_t sWorkingMemorySize          = 10*1024*1024;
 
 #ifdef HXCPP_GC_MOVING
-// Just not sure what this shold be
+// Just not sure what this should be
 static size_t sgMaximumFreeSpace  = 1024*1024*1024;
 #else
 static size_t sgMaximumFreeSpace  = 1024*1024*1024;
@@ -2088,7 +2088,7 @@ void MarkAllocUnchecked(void *inPtr,hx::MarkContext *__inCtx)
       }
       else
       {
-         // Large nursury object
+         // Large nursery object
          ((unsigned char *)inPtr)[HX_ENDIAN_MARK_ID_BYTE] = gByteMarkID;
       }
    }
@@ -3159,7 +3159,7 @@ public:
          gSpecialObjectLock = new HxMutex();
       }
       // Until we add ourselves, the collector will not wait
-      //  on us - ie, we are assumed ot be in a GC free zone.
+      //  on us - ie, we are assumed to be in a GC free zone.
       AutoLock lock(*gThreadStateChangeLock);
       mLocalAllocs.push(inAlloc);
       // TODO Attach debugger
@@ -3167,8 +3167,8 @@ public:
 
    bool ReturnToPoolLocked(LocalAllocator *inAlloc)
    {
-      // Until we add ourselves, the colled will not wait
-      //  on us - ie, we are assumed ot be in a GC free zone.
+      // Until we add ourselves, the collector will not wait
+      //  on us - ie, we are assumed to be in a GC free zone.
       for(int p=0;p<LOCAL_POOL_SIZE;p++)
       {
          if (!mLocalPool[p])
@@ -3240,7 +3240,7 @@ public:
          __hxcpp_gc_safe_point();
 
       //Should we force a collect ? - the 'large' data are not considered when allocating objects
-      // from the blocks, and can 'pile up' between smalll object allocations
+      // from the blocks, and can 'pile up' between small object allocations
       if ((inSize+mLargeAllocated > mLargeAllocForceRefresh) && sgInternalEnable)
       {
          #ifdef SHOW_MEM_EVENTS
@@ -3345,7 +3345,7 @@ public:
       if (inDelta>0)
       {
          //Should we force a collect ? - the 'large' data are not considered when allocating objects
-         // from the blocks, and can 'pile up' between smalll object allocations
+         // from the blocks, and can 'pile up' between small object allocations
          if (inDelta>0 && (inDelta+mLargeAllocated > mLargeAllocForceRefresh) && sgInternalEnable)
          {
             //GCLOG("onMemoryChange alloc causing collection");
@@ -3379,7 +3379,7 @@ public:
    // This contains some "lock free" code that triggers the thread sanitizer.
    //  * mOwned can only be changed with the mZeroLock
    //  * mFreeBlocks may increase size, but it is not critical whether the mNextFreeBlockOfSize
-   //     is increased since skipping only leads to a bit of extra searhing for the
+   //     is increased since skipping only leads to a bit of extra searching for the
    //     next allocation
    #if defined(__has_feature)
      #if __has_feature(thread_sanitizer)
@@ -3867,7 +3867,7 @@ public:
          }
          else
          {
-            // Partialy cleared, then ran out of to blocks - remove from allocation this round
+            // Partially cleared, then ran out of to blocks - remove from allocation this round
             if (from)
             {
                // Could maybe be a bit smarter here
@@ -3992,7 +3992,7 @@ public:
                            int size = ((header & IMMIX_ALLOC_SIZE_MASK) >> IMMIX_ALLOC_SIZE_SHIFT);
                            int allocSize = size + sizeof(int);
 
-                           // Find dest reqion ...
+                           // Find dest region ...
                            while(destHole==0 || destLen < ALIGN_PADDING(destPos) + allocSize)
                            {
                               if (destHole==0)
@@ -4074,7 +4074,7 @@ public:
             }
             else
             {
-               // Partialy cleared, then ran out of to blocks - remove from allocation this round
+               // Partially cleared, then ran out of to blocks - remove from allocation this round
                if (from && moveObjs)
                {
                   // Could maybe be a bit smarter here
@@ -4469,7 +4469,7 @@ public:
       }
       else
       {
-         printf("Finishe non-runnning thread?\n");
+         printf("Finished non-runnning thread?\n");
          DebuggerTrap();
       }
    }
@@ -4936,7 +4936,7 @@ public:
       bool generational = false; 
 
       #ifdef HXCPP_GC_GENERATIONAL
-      bool compactSurviors = false;
+      bool compactSurvivors = false;
 
       if (sGcMode==gcmGenerational)
       {
@@ -5043,7 +5043,7 @@ public:
 
 
       #ifdef HXCPP_GC_GENERATIONAL
-      if (compactSurviors)
+      if (compactSurvivors)
       {
          MoveSurvivors(&rememberedSet);
       }
@@ -5193,7 +5193,7 @@ public:
                sgTimeToNextTableUpdate = 3;
             calcMoveOrder( );
 
-            // Borrow some blocks to ensuure space to defrag into
+            // Borrow some blocks to ensure space to defrag into
             int workingBlocks = mAllBlocks.size()*3/2 - stats.emptyBlocks;
             int borrowed = 0;
             while( mAllBlocks.size()<workingBlocks )
@@ -5464,7 +5464,7 @@ public:
    }
 
 
-   // buils mFreeBlocks and maybe starts the async-zero process on mZeroList
+   // builds mFreeBlocks and maybe starts the async-zero process on mZeroList
    void createFreeList()
    {
       mFreeBlocks.clear();
@@ -5516,7 +5516,7 @@ public:
          mZeroList.setSize(mFreeBlocks.size());
          memcpy( &mZeroList[0], &mFreeBlocks[0], mFreeBlocks.size()*sizeof(void *));
 
-         // Only use one thread for parallel zeroing.  Try to get though the work wihout
+         // Only use one thread for parallel zeroing.  Try to get though the work without
          //  slowing down the main thread
          StartThreadJobs(inJit ? tpjAsyncZeroJit : tpjAsyncZero, mZeroList.size(), false, 1);
       }
@@ -6157,8 +6157,8 @@ public:
    //   will not be waited on. mReadyForCollect will be cleared when the zone is left.
    //
    //  The mMoreHoles/spaceOversize/spaceEnd get zeroed without a lock.  The timing should
-   //   not be critical since the allocation code shold expect that these are volatile.
-   //   If the allocation works, all is good.  If it fails then the collection will happed soon.
+   //   not be critical since the allocation code should expect that these are volatile.
+   //   If the allocation works, all is good.  If it fails then the collection will happen soon.
    #if defined(__has_feature)
      #if __has_feature(thread_sanitizer)
       __attribute__((no_sanitize("thread")))
@@ -6361,7 +6361,7 @@ public:
          }
          else
          {
-            // For opmtimized windows 64 builds, this dummy var technique does not
+            // For optimized windows 64 builds, this dummy var technique does not
             //  quite work, since the compiler might recycle one of the earlier stack
             //  slots, and place dummy behind the stack values we are actually trying to
             //  capture.  Moving the dummy into the GetFreeBlock seems to have fixed this.
@@ -6389,7 +6389,7 @@ public:
          }
 
          // Other thread may have started collect, in which case we may just
-         //  overwritted the 'mMoreHoles' and 'spaceEnd' termination attempt
+         //  overwrite the 'mMoreHoles' and 'spaceEnd' termination attempt
          if (hx::gPauseForCollect)
          {
             mMoreHoles = 0;

--- a/src/hx/libs/mysql/my_api.cpp
+++ b/src/hx/libs/mysql/my_api.cpp
@@ -218,7 +218,7 @@ send_cnx_packet:
 			save_error(m,p);
 			return NULL;
 		case 0xFE: // EOF
-			// we are asked to send old password authentification
+			// we are asked to send old password authentication
 			if( p->size == 1 ) {
 				char hpass[SEED_LENGTH_323 + 1];
 				myp_encrypt_pass_323(pass,scramble_buf,hpass);

--- a/src/hx/libs/sqlite/Sqlite.cpp
+++ b/src/hx/libs/sqlite/Sqlite.cpp
@@ -158,7 +158,7 @@ struct database : public hx::Object
    void __Visit(hx::VisitContext *__inCtx) { HX_VISIT_MEMBER(last); }
    #endif
 
-   String toString() { return HX_CSTRING("Sqlite Databse"); }
+   String toString() { return HX_CSTRING("Sqlite Database"); }
 };
 
 static void sqlite_error( sqlite3 *db ) {

--- a/src/hx/libs/std/File.cpp
+++ b/src/hx/libs/std/File.cpp
@@ -167,7 +167,7 @@ int _hx_std_file_write( Dynamic handle, Array<unsigned char> s, int p, int n )
    file_read : 'file -> s:string -> p:int -> l:int -> int
    <doc>
    Read up to [l] chars into the string [s] starting at position [p].
-   Returns the number of chars readed which is > 0 (or 0 if l == 0).
+   Returns the number of chars read which is > 0 (or 0 if l == 0).
    </doc>
 **/
 int _hx_std_file_read( Dynamic handle, Array<unsigned char> buf, int p, int n )

--- a/src/hx/libs/std/Process.cpp
+++ b/src/hx/libs/std/Process.cpp
@@ -339,7 +339,7 @@ Dynamic _hx_std_process_run( String cmd, Array<String> vargs, int inShowParam )
    process_stdout_read : 'process -> buf:string -> pos:int -> len:int -> int
    <doc>
    Read up to [len] bytes in [buf] starting at [pos] from the process stdout.
-   Returns the number of bytes readed this way. Raise an exception if this
+   Returns the number of bytes read this way. Raise an exception if this
    process stdout is closed and no more data is available for reading.
 
         For hxcpp, the input buffer is in bytes, not characters
@@ -372,7 +372,7 @@ int _hx_std_process_stdout_read( Dynamic handle, Array<unsigned char> buf, int p
    process_stderr_read : 'process -> buf:string -> pos:int -> len:int -> int
    <doc>
    Read up to [len] bytes in [buf] starting at [pos] from the process stderr.
-   Returns the number of bytes readed this way. Raise an exception if this
+   Returns the number of bytes read this way. Raise an exception if this
    process stderr is closed and no more data is available for reading.
    </doc>
 **/
@@ -402,7 +402,7 @@ int _hx_std_process_stderr_read( Dynamic handle, Array<unsigned char> buf, int p
    process_stdin_write : 'process -> buf:string -> pos:int -> len:int -> int
    <doc>
    Write up to [len] bytes from [buf] starting at [pos] to the process stdin.
-   Returns the number of bytes writen this way. Raise an exception if this
+   Returns the number of bytes written this way. Raise an exception if this
    process stdin is closed.
    </doc>
 **/

--- a/src/hx/libs/std/Socket.cpp
+++ b/src/hx/libs/std/Socket.cpp
@@ -241,7 +241,7 @@ int _hx_std_socket_send( Dynamic o, Array<unsigned char> buf, int p, int l )
 /**
    socket_recv : 'socket -> buf:string -> pos:int -> len:int -> int
    <doc>Read up to [len] bytes from [buf] starting at [pos] from a connected socket.
-   Return the number of bytes readed.</doc>
+   Return the number of bytes read.</doc>
 **/
 int _hx_std_socket_recv( Dynamic o, Array<unsigned char> buf, int p, int l )
 {
@@ -905,7 +905,7 @@ Array<int> _hx_std_socket_host( Dynamic o )
 }
 
 /**
-   socket_set_timeout : 'socket -> timout:number? -> void
+   socket_set_timeout : 'socket -> timeout:number? -> void
    <doc>Set the socket send and recv timeout in seconds to the given value (or null for blocking)</doc>
 **/
 void _hx_std_socket_set_timeout( Dynamic o, Dynamic t )

--- a/src/hx/libs/std/Sys.cpp
+++ b/src/hx/libs/std/Sys.cpp
@@ -271,7 +271,7 @@ String _hx_std_sys_string()
 #elif defined(EPPC)
    return HX_CSTRING("EPPC");
 #else
-#error Unknow system string
+#error Unknown system string
 #endif
 }
 

--- a/test/cffi/src/TestCffi.hx
+++ b/test/cffi/src/TestCffi.hx
@@ -105,7 +105,7 @@ class TestCffi extends Test
 
       #if !neko
       Assert.isTrue( valIsBuffer(bytes) );
-      // Can't acess neko buffer from haxe code
+      // Can't access neko buffer from haxe code
       bytes = appendString(bytes,"World");
       var result = bufferToString(bytes);
       Assert.equals("Hello World", result);

--- a/test/cppia/ClientExtends.hx
+++ b/test/cppia/ClientExtends.hx
@@ -41,7 +41,7 @@ class ClientExtends extends HostBase implements IClientInterface implements ICli
 
    override public function whoStartedYou() : String  return super.whoStartedYou();
 
-   // override IHostInteface 
+   // override IHostInterface
    override public function whoOverridesYou() return "ClientExtends";
 
    // new IClientInterface

--- a/test/cppia/CppiaHost.hx
+++ b/test/cppia/CppiaHost.hx
@@ -35,7 +35,7 @@ class CppiaHost
       /*
       if (new HostExtends().getYou().extendOnly != 1)
       {
-         Sys.println("extend-overide type failed");
+         Sys.println("extend-override type failed");
          Sys.exit(-1);
       }
       */
@@ -96,7 +96,7 @@ class CppiaHost
                //
             case _:
                Sys.println("Unexpected items in array");
-               Sys.exit(-1);   
+               Sys.exit(-1);
          }
          #end
       }

--- a/test/cppia/HostBase.hx
+++ b/test/cppia/HostBase.hx
@@ -52,7 +52,7 @@ class HostBase implements IHostInterface
 
    public function update() return "HostBase update";
 
-   // IHostInteface 
+   // IHostInterface 
    public function hostImplOnly(i:Int, s:String, f:Float) : String return i+s+f;
    public function whoStartedYou() return "HostBase";
    public function whoOverridesYou() return "No one";

--- a/test/haxe/gc/TestGC.hx
+++ b/test/haxe/gc/TestGC.hx
@@ -48,7 +48,7 @@ class TestGC extends Test {
 	}
 
    // Null<int> for numbers < 256 are special cases
-   // Infact, there are no guarantees that Null<Int> will be actual objects in the future
+   // In fact, there are no guarantees that Null<Int> will be actual objects in the future
    /*
 	function create1234():Void {
 		var object:Null<Int> = 1234;

--- a/test/native/externs/RectangleApi.hx
+++ b/test/native/externs/RectangleApi.hx
@@ -1,7 +1,7 @@
 package externs;
 
 // This class acts as a container for the Rectangle implementation, which will get included
-//  in the cpp file, and therfore get compiled and linked with the correct flags
+//  in the cpp file, and therefore get compiled and linked with the correct flags
 @:cppInclude("./RectangleImpl.cpp")
 @:keep
 class RectangleApi

--- a/test/native/tests/TestPtr.hx
+++ b/test/native/tests/TestPtr.hx
@@ -114,7 +114,7 @@ class TestPtr extends Test
       Stdlib.free(a);
    }
    
-    public function testExtened() {
+    public function testExtended() {
       var test = NativeGc.allocateExtended( TestPtr, Stdlib.sizeof(Int) * 5 );
       var a : Pointer<Int> = cast Pointer.endOf(test);
       for(i in 0...5)

--- a/test/native/tests/TestRectangle.hx
+++ b/test/native/tests/TestRectangle.hx
@@ -46,7 +46,7 @@ class TestRectangle extends Test
       // Take address ...
       var rectPtr:RectanglePtr = rectangle;
 
-      // Pointer-like sysntax
+      // Pointer-like syntax
       rectPtr.width = 3;
       rectPtr.height = 5;
       var dynamicPtr:Dynamic  = rectPtr;

--- a/test/native/tests/TestRgb.hx
+++ b/test/native/tests/TestRgb.hx
@@ -8,7 +8,7 @@ class TestRgb extends Test
 {
    public function testCreate()
    {
-      // Pointer-like sysntax
+      // Pointer-like syntax
       var rgbPtr = RGB.create(255,0,128);
       Assert.equals( rgbPtr.ptr.toInt(), 0xff0080 );
       rgbPtr.ptr.deleteMe();

--- a/test/std/Test.hx
+++ b/test/std/Test.hx
@@ -130,7 +130,7 @@ class Test extends utest.Test
       v(Std.string(later));
 
       var diff:Float = untyped __global__.__hxcpp_timezone_offset(now.mSeconds);
-      v("timezone offet:" + diff);
+      v("timezone offset:" + diff);
    }
 
    function testCompress()

--- a/toolchain/android-toolchain-clang.xml
+++ b/toolchain/android-toolchain-clang.xml
@@ -78,7 +78,7 @@
   <flag value="-fpic"/>
   <flag value="-O2" unless="debug"/>
   
-  <!-- Warning Supression -->
+  <!-- Warning Suppression -->
   <flag value="-Wno-invalid-offsetof" />
   <flag value="-Wno-return-type-c-linkage" />
   <flag value="-Wno-parentheses" />

--- a/toolchain/android-toolchain-gcc.xml
+++ b/toolchain/android-toolchain-gcc.xml
@@ -4,7 +4,7 @@
 <!--
   Configure build via variables, otherwise defaults will be used:
      Set the path to the exact ndk to use with ANDROID_NDK_ROOT,
-        or set where all your ndks are installed with ANDROID_NDK_DIR and hxcpp will guess.
+        or set where all your NDKs are installed with ANDROID_NDK_DIR and hxcpp will guess.
         Set the version number by setting the variable:
            NDKV?? - base version of ndk to use, hxcpp will find the letter, like "NDKV10" -> may end up with "10c"
      TOOLCHAIN_VERSION - the compiler number, like "4.8" or "4.4.3"

--- a/toolchain/emscripten-toolchain.xml
+++ b/toolchain/emscripten-toolchain.xml
@@ -1,7 +1,7 @@
 <xml>
 
 <!--
-  The Emscipten hxcpp compiler can be invoked from haxe with the 'emscripten' define.
+  The Emscripten hxcpp compiler can be invoked from haxe with the 'emscripten' define.
     haxe -main Main -cpp cpp -D emscripten
 
   Setup:
@@ -14,7 +14,7 @@
     If -D HXCPP_LINK_EMSCRIPTEN_EXT=".html" is passed or specified, then an additional html output,
     eg, Test.html, will be generated.
 
-      Specifying HXCPP_LINK_EMRUN adds code ro redirect output secially for the emrun server.
+      Specifying HXCPP_LINK_EMRUN adds code to redirect output specially for the emrun server.
 
       The resulting can be used for running the code in a browser from a local server.
         eg: $EMSDK/upstream/emscripten/emrun(.bat) cpp/Test.html

--- a/toolchain/example.hxcpp_config.xml
+++ b/toolchain/example.hxcpp_config.xml
@@ -61,7 +61,7 @@
      <!-- Add this if your compiler does not support precompiled headers -->
      <!-- <set name="NO_PRECOMPILED_HEADERS" value="1"/> -->
 
-     <!-- Older versions of gcc do not suport the @file syntax for an obj file list
+     <!-- Older versions of gcc do not support the @file syntax for an obj file list
           and precompiled headers.  Set this if you have these issues -->
      <!-- <set name="GCC_OLD" value="1" /> -->
 

--- a/toolchain/finish-setup.xml
+++ b/toolchain/finish-setup.xml
@@ -110,10 +110,10 @@
    <set name="HX_TARGET_SUFFIX" value="-19" if="MSVC19 static_link" />
 
    <section if="HXCPP_OPTIMIZE_LINK_INCREMENTAL" unless="debug || MSVC19">
-      <echo value="Warning: INCREMENTAL requies Visual Studio 2015+"/>
+      <echo value="Warning: INCREMENTAL requires Visual Studio 2015+"/>
       <!-- without INCREMENTAL -->
       <unset name="HXCPP_OPTIMIZE_LINK_INCREMENTAL"/>
-      <set name="HXCPP_OPTIMIZE_LINK" value="1"/> 
+      <set name="HXCPP_OPTIMIZE_LINK" value="1"/>
       <set name="OBJOPT" value="-opt" if="HXCPP_OPTIMIZE_LINK || HXCPP_OPTIMIZE_LINK_INCREMENTAL" unless="debug" />
       <set name="OBJEXT" value="${M64}${F32}${STAT}${OBJDBG}${OBJOPT}${NOCONSOLE}${RPI}${APIFP}${PRIME}" />
    </section>

--- a/toolchain/setup.xml
+++ b/toolchain/setup.xml
@@ -1,7 +1,7 @@
 <xml>
 
    <!-- You can override this file to setup your own toolchain. 
-        You should peobably include thie following line -->
+        You should probably include this following line -->
 
    <include name="${HXCPP_CONFIG}" section="vars" noerror="1"/>
  

--- a/tools/build/Build.hx
+++ b/tools/build/Build.hx
@@ -1,7 +1,7 @@
 class Build extends hxcpp.Builder
 {
    // Create a build in 'bin' directory, with the "stdlibc++" flags for compatibility
-   //  This flasg should not make a difference because hxcpp does not use stdlibc++
+   //  This flags should not make a difference because hxcpp does not use stdlibc++
    override public function wantLegacyIosBuild() { return true; }
 
    override public function wantWindows64() { return true; }

--- a/tools/hxcpp/BuildTool.hx
+++ b/tools/hxcpp/BuildTool.hx
@@ -1835,11 +1835,11 @@ class BuildTool
       Log.println('   Build project from "file.xml".  options:');
       Log.println('    ${BOLD}-D${NORMAL}${ITALIC}value${NORMAL} -- Specify a define to use when processing other commands');
       Log.println('    ${BOLD}-verbose${NORMAL} -- Print additional information (when available)');
-      Log.println('    ${BOLD}-dirty [groudId|all]${NORMAL} -- always rebuild files in given group');
+      Log.println('    ${BOLD}-dirty [groupId|all]${NORMAL} -- always rebuild files in given group');
       Log.println(' ${BOLD}haxelib run hxcpp${NORMAL} ${ITALIC}${WHITE}file.cppia${NORMAL}');
       Log.println('   Run cppia script using default Cppia host');
       Log.println(' ${BOLD}haxelib run hxcpp${NORMAL} ${ITALIC}${WHITE}file.js${NORMAL}');
-      Log.println('    Run emscripten compiled scipt "file.js"');
+      Log.println('    Run emscripten compiled script "file.js"');
       Log.println(' ${BOLD}haxelib run hxcpp${NORMAL} ${ITALIC}${WHITE}cache [command] [project]${NORMAL}');
       Log.println('   Perform command on cache, either on specific project or all. commands:');
       Log.println('    ${BOLD}clear${NORMAL} -- remove all files from cache');

--- a/tools/hxcpp/BuildTool.hx
+++ b/tools/hxcpp/BuildTool.hx
@@ -1530,7 +1530,7 @@ class BuildTool
          if (isRootDir || (FileSystem.exists(last) && FileSystem.isDirectory(last)))
          {
             // When called from haxelib, the last arg is the original directory, and
-            //  the current direcory is the library directory.
+            //  the current directory is the library directory.
             HXCPP = PathManager.standardize(Sys.getCwd());
             defines.set("HXCPP",HXCPP);
             args.pop();
@@ -1690,7 +1690,7 @@ class BuildTool
          }
          else if (arg=="-v" || arg=="-verbose")
             Log.verbose = true;
-         else if (arg=="-nocolor")
+         else if (arg=="-nocolor" || arg=="-nocolour")
             Log.colorSupported = false;
          else if (arg.substr(0,2)=="-I")
             include_path.push(PathManager.standardize(arg.substr(2)));

--- a/tools/hxcpp/Compiler.hx
+++ b/tools/hxcpp/Compiler.hx
@@ -191,7 +191,7 @@ class Compiler
       if (ext!=null)
          ext = ext.toLowerCase();
       else
-         Log.error("Unkown extension for " + inFile.mName);
+         Log.error("Unknown extension for " + inFile.mName);
 
 
       addIdentity(ext,args);
@@ -494,7 +494,7 @@ class Compiler
          return CompileCache.getCacheName(inFile.getCacheProject(),md5,mExt);
       }
       else
-         throw "Unkown source contents " + sourceName;
+         throw "Unknown source contents " + sourceName;
       return "";
    }
 

--- a/tools/run/RunMain.hx
+++ b/tools/run/RunMain.hx
@@ -20,7 +20,7 @@ class RunMain
          Sys.exit(-1);
       }
 
-      log('This version of hxcpp ($dir) appears to be a source/developement version.');
+      log('This version of hxcpp ($dir) appears to be a source/development version.');
       log("Before this can be used, you need to:");
       log(" 1. Rebuild the main command-line tool, this can be done with:");
       log("     cd tools/hxcpp");


### PR DESCRIPTION
Also added -nocolour due to HXCPP_NO_COLOUR

If there are any typo's you would want me to revert, please do mention below or in a code review, or push a commit to revert that typo

Edit:
i noticed that HXCPP_NO_WASM_EXEPTIONS has a typo
and \_hx\_**reslove**\_virtual_array also