### PR TITLE
Set mingw define when using mingw on linux

### DIFF
--- a/tools/hxcpp/BuildTool.hx
+++ b/tools/hxcpp/BuildTool.hx
@@ -2052,6 +2052,7 @@ class BuildTool
          if(defines.exists("windows"))
          {
             defines.set("toolchain","mingw");
+            defines.set("mingw", "mingw");
             defines.set("xcompile","1");
             defines.set("BINDIR", arm64 ? "WindowsArm64" : m64 ? "Windows64":"Windows");
          }


### PR DESCRIPTION
When using mingw on windows, the mingw define is set:
https://github.com/HaxeFoundation/hxcpp/blob/54af892be2ca4c63988c99c9c524431af6c6f036/tools/hxcpp/BuildTool.hx#L2035-L2036

 So it should also be set on linux when cross compiling for consistency. It is required for adding conditions in Build.xml files.