### PR TITLE
Add warning if destination flag is ignored

### DIFF
--- a/tools/hxcpp/BuildTool.hx
+++ b/tools/hxcpp/BuildTool.hx
@@ -771,6 +771,8 @@ class BuildTool
                }
             }
             Profile.pop();
+         case _ if (inDestination != null):
+            Log.warn('Target \'${inTarget}\' does not output a file, so \'destination\' has been ignored');
       }
 
       if (mCopyFiles.length>0)


### PR DESCRIPTION
If the current target does not produce a file, the -Ddestination flag is currently ignored without warning.

This situation may occur commonly when 'default' points to another target, but doesn't produce a file itself. A warning will now be displayed:

```
Warning: Target 'default' does not output a file, so 'destination' has been ignored
```