### PR TITLE
Do not pass empty object list to linker

### DIFF
--- a/tools/hxcpp/Linker.hx
+++ b/tools/hxcpp/Linker.hx
@@ -251,7 +251,8 @@ class Linker
          }
 
          // Place list of obj files in a file called "all_objs"
-         if (mFromFile!="")
+         // In some situations with the compile cache, we might have an empty list
+         if (mFromFile!="" && objs.length!=0)
          {
             PathManager.mkdir(tmpDir);
             var fname = tmpDir + "/all_objs";


### PR DESCRIPTION
This situation may arise in some situations with the compile cache enabled. Some linkers (such as libtool on mac) throw an error if an object list is empty, so it is not safe to pass it in.

See: #1180