### PR TITLE
[cppia] Respect jit exceptions in interp mode

### DIFF
--- a/src/hx/cppia/Cppia.cpp
+++ b/src/hx/cppia/Cppia.cpp
@@ -439,7 +439,7 @@ struct BlockExpr : public CppiaExpr
          return;
       CppiaExpr **e = &expressions[0];
       CppiaExpr **end = e+expressions.size();
-      for(;e<end && !ctx->breakContReturn;e++)
+      for(;e<end && !ctx->breakContReturn && !ctx->exception;e++)
       {
          CPPIA_STACK_LINE((*e));
          (*e)->runVoid(ctx);
@@ -800,8 +800,7 @@ struct CallFunExpr : public CppiaExpr
    {
       unsigned char *pointer = ctx->pointer;
       function->pushArgs(ctx,thisExpr?thisExpr->runObject(ctx):ctx->getThis(false),args);
-      if (ctx->breakContReturn)
-         return;
+      BCR_VCHECK;
 
       AutoStack save(ctx,pointer);
       ctx->runVoid(function);
@@ -5948,7 +5947,7 @@ struct TVars : public CppiaVoidExpr
    {
       CppiaExpr **v = &vars[0];
       CppiaExpr **end = v + vars.size();
-      for(;v<end && !ctx->breakContReturn;v++)
+      for(;v<end && !ctx->breakContReturn && !ctx->exception;v++)
          (*v)->runVoid(ctx);
    }
 
@@ -5998,8 +5997,14 @@ struct ForExpr : public CppiaVoidExpr
 
       while(hasNext())
       {
+         if (ctx->exception)
+            return;
          var.set(ctx,getNext());
+         if (ctx->exception)
+            return;
          loop->runVoid(ctx);
+         if (ctx->exception)
+            return;
 
          if (ctx->breakContReturn)
          {
@@ -6045,6 +6050,9 @@ struct WhileExpr : public CppiaVoidExpr
       {
          loop->runVoid(ctx);
 
+         if (ctx->exception)
+            break;
+
          if (ctx->breakContReturn)
          {
             if (ctx->breakContReturn & (bcrBreak|bcrReturn))
@@ -6053,7 +6061,7 @@ struct WhileExpr : public CppiaVoidExpr
             ctx->breakContReturn = 0;
          }
 
-         if (!condition->runInt(ctx) || ctx->breakContReturn)
+         if (!condition->runInt(ctx) || ctx->breakContReturn || ctx->exception)
             break;
       }
       ctx->breakContReturn &= ~bcrLoop;

--- a/src/hx/cppia/Cppia.h
+++ b/src/hx/cppia/Cppia.h
@@ -834,9 +834,9 @@ struct BCRReturn
 };
 
 
-#define BCR_CHECK if (ctx->breakContReturn) return BCRReturn();
+#define BCR_CHECK if (ctx->breakContReturn || ctx->exception) return BCRReturn();
 #define BCR_CHECK_RET(x) if (ctx->breakContReturn) return x;
-#define BCR_VCHECK if (ctx->breakContReturn) return;
+#define BCR_VCHECK if (ctx->breakContReturn || ctx->exception) return;
 
 
 

--- a/test/cppia/Client.hx
+++ b/test/cppia/Client.hx
@@ -159,6 +159,26 @@ class Client
          return;
       }
 
+      switch LocalFunctionExceptions.testLocalCallingStatic() {
+         case Error(message):
+            Common.status = 'Failed test for throw in static called by local: ' + message;
+            return;
+         default:
+      }
+
+      switch LocalFunctionExceptions.testCatchWithinLocal() {
+         case Error(message):
+            Common.status = 'Failed test for catch in local function: ' + message;
+            return;
+         default:
+      }
+
+      switch LocalFunctionExceptions.testCatchFromLocal() {
+         case Error(message):
+            Common.status = 'Failed test for catching exception from local function: ' + message;
+            return;
+         default:
+      }
 
       final extending = new ClientExtendedExtendedRoot();
 

--- a/test/cppia/LocalFunctionExceptions.hx
+++ b/test/cppia/LocalFunctionExceptions.hx
@@ -1,0 +1,68 @@
+enum Status {
+	Ok;
+	Error(message:String);
+}
+
+class LocalFunctionExceptions {
+	static function staticFunction() {
+		throw 'Thrown from static';
+	}
+
+	public static function testLocalCallingStatic():Status {
+		function localFunction() {
+			staticFunction();
+			throw 'Thrown from local';
+		}
+
+		try {
+			localFunction();
+		} catch (e:String) {
+			if (e == 'Thrown from static') {
+				return Ok;
+			} else {
+				return Error("Incorrect exception caught from local function call");
+			}
+		}
+
+		return Error("No exception caught");
+	}
+
+	public static function testCatchWithinLocal():Status {
+		function localFunction() {
+			try {
+				staticFunction();
+			} catch (e:String) {
+				if (e == 'Thrown from static') {
+					return Ok;
+				} else {
+					return Error("Incorrect exception caught from local function call");
+				}
+			}
+			return Error("Exception from static function not caught");
+		}
+
+		return try {
+			localFunction();
+		} catch (e) {
+			Error('Exception leaked from local function: $e');
+		};
+	}
+
+	public static function testCatchFromLocal():Status {
+		function localFunction() {
+			throw 'Thrown from local';
+		}
+
+		try {
+			localFunction();
+		} catch (e:String) {
+			if (e == 'Thrown from local') {
+				return Ok;
+			} else {
+				return Error("Incorrect exception caught from local function call");
+			}
+		}
+
+		return Error("No exception caught");
+	}
+}


### PR DESCRIPTION
When running in interp mode, native c++ exception handling is used, but when running jit mode, jumps are used along with ctx->exception.

This means that an exception thrown from jit mode is not respected in interp mode. This can cause problems with local functions (which are interpreted even in jit mode). When a local function calls a compiled function that throws an exception, the exception is ignored until we return back into a compiled function.

This patch fixes the problem by checking ctx->exception when running in interp mode, to make sure that no exception has been thrown from a jit compiled function.

This fixes #876.