### PR TITLE
CI - Force Update Apt

### DIFF
--- a/.github/workflows/setup/action.yml
+++ b/.github/workflows/setup/action.yml
@@ -22,7 +22,9 @@ runs:
     - name: install native libraries
       if: runner.os == 'Linux'
       shell: pwsh
-      run: sudo apt-get install -qqy gcc-multilib g++-multilib
+      run: |
+        sudo apt-get update -qqy
+        sudo apt-get install -qqy gcc-multilib g++-multilib
 
     - name: build run.n
       working-directory: tools/run


### PR DESCRIPTION
In the last two days I've started getting 404 from apt on all hxcpp linux CI runs.

https://github.com/HaxeFoundation/hxcpp/actions/runs/13216354566/job/36896083443

Forcing an update before installing seems to fix it.