### PR TITLE
Hardcode mOutPre in Manifester

### DIFF
--- a/tools/hxcpp/Manifester.hx
+++ b/tools/hxcpp/Manifester.hx
@@ -19,6 +19,7 @@ class Manifester
       args = args.concat(mFlags);
 
       //only windows for now
+      mOutPre = "-outputresource:";
       mOutPost = isExe ? ";1" : ";2";
 
       var result = ProcessManager.runCommand("", mExe, args.concat([manifestName,mOutPre + binName + mOutPost]) );


### PR DESCRIPTION
Commit https://github.com/HaxeFoundation/hxcpp/commit/01ef3fa595cceb6a4e045eff38191f6d6cf1cece#diff-740d630a82410c3a632c1c2894824c904ce81e2750fd946396c3187df271e1c5L1154-L1155 changed some things around and stopped parsing `mOutPre` and `mOutPost` from the toolchain xml which was causing build issues due to a missing argument:
![image](https://github.com/user-attachments/assets/706c614e-671d-4a05-8962-ed2bf14721ee)

Since `mOutPost` was hardcoded to begin with, this is a little patch to do the same for `mOutPre` and prevent build errors. 
