### PR TITLE
line buffered cpp stdout

### DIFF
--- a/src/hx/StdLibs.cpp
+++ b/src/hx/StdLibs.cpp
@@ -282,7 +282,7 @@ void __hxcpp_stdlibs_boot()
    //  It does not cause fread to return immediately - as perhaps desired.
    //  But it does cause some new-line characters to be lost.
    //setbuf(stdin, 0);
-   setbuf(stdout, 0);
+   setvbuf(stdout, NULL, _IOLBF, BUFSIZ);
    setbuf(stderr, 0);
 }
 
@@ -307,7 +307,7 @@ void __trace(Dynamic inObj, Dynamic info)
       //PRINTF("%s:%d: %s\n", filename, line, text.raw_ptr() ? text.out_str(&convertBuf) : "null");
       PRINTF("%s:%d: %s\n", filename, line, text.raw_ptr() ? text.out_str(&convertBuf) : "null");
    }
-
+   fflush(stdout);
 }
 
 void __hxcpp_exit(int inExitCode)
@@ -589,6 +589,7 @@ void __hxcpp_println_string(const String &inV)
 {
    hx::strbuf convertBuf;
    PRINTF("%s\n", inV.out_str(&convertBuf));
+   fflush(stdout);
 }
 
 


### PR DESCRIPTION
attempts to solve (at least the cpp part of) https://github.com/HaxeFoundation/haxe/issues/8830

- changes unbuffered stdout to be line-buffered
- flushes after each `trace`/`println`

<details><summary>examples</summary><br>

its noticeably faster on my end!

https://github.com/user-attachments/assets/bcb770ca-1ee4-4e59-9e77-1e0847def3bd

---

and the test case from https://github.com/HaxeFoundation/haxe/issues/8830

```haxe
class TraceTest {

    public static function main() {
        var start = haxe.Timer.stamp();
        for (i in 1...2000)
            trace(i);
        var duration =  Math.round((haxe.Timer.stamp() - start)*100) / 100;
        trace('Duration: $duration seconds.');
    }
}
```

![image](https://github.com/user-attachments/assets/439b430d-8b49-40e8-a190-77fdfc7ca64a)

</details>

---

im new to contributing to this repo and kinda new to c++ in general so criticism or suggestions are very much appreciated