### PR TITLE
Add support for HXCPP_ANDROID_PLATFORM define

### DIFF
--- a/docs/build_xml/Defines.md
+++ b/docs/build_xml/Defines.md
@@ -67,7 +67,7 @@ Defines affecting target architecture.
 | *HXCPP_LINUX_ARM64*     | Run on a linux ARM64 device |
 | *winrt*                 | Compile for windowsRt/windows UWP |
 | *android*               | Compile for android |
-| *PLATFORM*              | Specify the android platform for NDK compilation |
+| *HXCPP_ANDROID_PLATFORM* | Specify the android platform for NDK compilation |
 | *ANDROID_NDK_ROOT*      | Specify the location of the android NDK toolchain |
 | *ANDROID_NDK_DIR*       | Specify the search location for finding the android NDK toolchain |
 | *HXCPP_X86*             | Compile android for x86 architecture |

--- a/toolchain/android-toolchain-clang.xml
+++ b/toolchain/android-toolchain-clang.xml
@@ -1,36 +1,36 @@
 <xml>
-    
+
+<section unless="HXCPP_ANDROID_PLATFORM" >
+  <set name="HXCPP_ANDROID_PLATFORM" value="16" />
+  <set name="HXCPP_ANDROID_PLATFORM" value="19" if="NDKV24+" />
+  <!-- 64 bit builds fail unless using platform 21 -->
+  <set name="HXCPP_ANDROID_PLATFORM" value="21" if="NDKV26+||HXCPP_X86_64||HXCPP_ARM64" />
+</section>
+
 <!-- Set architecture -->
 <section if="HXCPP_X86">
   <set name="ARCH" value="-x86" />
-  <set name="PLATFORM_NUMBER" value="21" unless="PLATFORM_NUMBER" />
   <set name="ABITRIPLE" value="i686-linux-android" />
 </section>
 
 <section if="HXCPP_X86_64">
   <set name="ARCH" value="-x86_64" />
-  <set name="PLATFORM_NUMBER" value="21" unless="PLATFORM_NUMBER" />
   <set name="ABITRIPLE" value="x86_64-linux-android" />
 </section>
 
 <section if="HXCPP_ARMV7">
   <set name="ARCH" value="-v7" />
-  <set name="PLATFORM_NUMBER" value="21" unless="PLATFORM_NUMBER" />
   <set name="ABITRIPLE" value="armv7a-linux-androideabi" />
   <set name="EXEPREFIX" value="arm-linux-androideabi" />
 </section>
 
 <section if="HXCPP_ARM64">
   <set name="ARCH" value="-64"/>
-  <set name="PLATFORM_NUMBER" value="21" unless="PLATFORM_NUMBER" />
   <set name="ABITRIPLE" value="aarch64-linux-android" />
 </section>
 
 <error value="Please set one of the architectures, eg HXCPP_ARM64, HXCPP_X86, ..." unless="ABITRIPLE" />
 
-<set name="PLATFORM" value="android-${PLATFORM_NUMBER}" />
-<set name="ANDROID_PLATFORM_DEFINE" value="HXCPP_ANDROID_PLATFORM=${PLATFORM_NUMBER}" />
-     
 <path name="${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/${ANDROID_HOST}/bin" />
 
 <section unless="NDKV22+">
@@ -47,7 +47,7 @@
 <compiler id="android-gcc" exe="clang++">
 
   <exe name="clang++" />
-  <flag value="--target=${ABITRIPLE}${PLATFORM_NUMBER}" />
+  <flag value="--target=${ABITRIPLE}${HXCPP_ANDROID_PLATFORM}" />
   
   <!-- File Related -->
   <include name="toolchain/common-defines.xml" />
@@ -64,8 +64,8 @@
   <flag value="-DHXCPP_CLANG"/>
   <flag value="-DHX_ANDROID"/>
   <flag value="-DHXCPP_LOAD_DEBUG" if="HXCPP_LOAD_DEBUG"/>
-  <flag value="-D${ANDROID_PLATFORM_DEFINE}"/>
-  
+  <flag value="-DHXCPP_ANDROID_PLATFORM=${HXCPP_ANDROID_PLATFORM}" />
+
   <!-- Options -->
   <cppflag value="-std=c++17" if="HXCPP_CPP17" />
   <flag value="-flto" if="HXCPP_OPTIMIZE_LINK" unless="debug"/>
@@ -90,7 +90,7 @@
 
   <exe name="clang++" />
   <flag value ="-shared" />
-  <flag value="--target=${ABITRIPLE}${PLATFORM_NUMBER}" />
+  <flag value="--target=${ABITRIPLE}${HXCPP_ANDROID_PLATFORM}" />
 
   <!-- Build time error, not run time -->
   <flag value="-Wl,--no-undefined" unless="HXCPP_ALLOW_UNDEFINED" />

--- a/toolchain/android-toolchain-clang.xml
+++ b/toolchain/android-toolchain-clang.xml
@@ -1,12 +1,5 @@
 <xml>
 
-<section unless="HXCPP_ANDROID_PLATFORM" >
-  <set name="HXCPP_ANDROID_PLATFORM" value="16" />
-  <set name="HXCPP_ANDROID_PLATFORM" value="19" if="NDKV24+" />
-  <!-- 64 bit builds fail unless using platform 21 -->
-  <set name="HXCPP_ANDROID_PLATFORM" value="21" if="NDKV26+||HXCPP_X86_64||HXCPP_ARM64" />
-</section>
-
 <!-- Set architecture -->
 <section if="HXCPP_X86">
   <set name="ARCH" value="-x86" />

--- a/toolchain/android-toolchain-gcc.xml
+++ b/toolchain/android-toolchain-gcc.xml
@@ -129,7 +129,7 @@
   <flag value="-finline-limit=10000"/>
   <flag value="-DANDROID=ANDROID"/>
   <flag value="-DHX_ANDROID"/>
-  <flag value="-D${ANDROID_PLATFORM_DEFINE}"/>
+  <flag value="-DHXCPP_ANDROID_PLATFORM=${HXCPP_ANDROID_PLATFORM}"/>
   <!-- todo <flag value="-Werror"/> -->
   <flag value="-Wa,--noexecstack"/>
   <flag value="-O2" unless="debug || HXCPP_OPTIMIZE_FOR_SIZE || HXCPP_OPTIMIZE_FOR_FAST"/>

--- a/tools/hxcpp/Setup.hx
+++ b/tools/hxcpp/Setup.hx
@@ -523,6 +523,28 @@ class Setup
          if (defines.exists("PLATFORM_NUMBER")) {
             Log.warn("The PLATFORM_NUMBER define is deprecated. Please use the HXCPP_ANDROID_PLATFORM define instead.");
             defines.set("HXCPP_ANDROID_PLATFORM", Std.string(defines.get("PLATFORM_NUMBER")));
+         } else {
+            var platformsJson = root + "/meta/platforms.json";
+
+            var minPlatform:Null<Int> = try {
+               haxe.Json.parse(sys.io.File.getContent(platformsJson)).min;
+            } catch (e) {
+               Log.warn("Unable to determine minimum supported Android platform: " + e.toString());
+               null;
+            };
+
+            if (minPlatform == null) {
+               Log.warn("Defaulting to Android platform 21");
+               minPlatform = 21;
+            }
+
+            // only platform version 21 and above support 64 bit
+            // https://developer.android.com/about/versions/lollipop#Perf
+            if (minPlatform < 21 && (defines.exists('HXCPP_ARM64') || defines.exists('HXCPP_X86_64'))) {
+               minPlatform = 21;
+            }
+
+            defines.set("HXCPP_ANDROID_PLATFORM", Std.string(minPlatform));
          }
       }
       else {

--- a/tools/hxcpp/Setup.hx
+++ b/tools/hxcpp/Setup.hx
@@ -516,14 +516,14 @@ class Setup
       }
       catch(e:Dynamic) { }
 
-      if(defines.exists('NDKV20+')) {
-         Log.v([
-            "x86 Platform: 16",
-            "arm Platform: 16",
-            "x86_64 Platform: 21",
-            "arm_64 Platform: 21",
-            "Frameworks should set the minSdkVersion for each APK to these values."
-         ].join('\n'));
+      if (defines.exists('HXCPP_ANDROID_PLATFORM')) {
+         Log.info("", "\x1b[33;1mUsing Android NDK platform: " + defines.get("HXCPP_ANDROID_PLATFORM") + "\x1b[0m");
+      }
+      else if (defines.exists('NDKV20+')) {
+         if (defines.exists("PLATFORM_NUMBER")) {
+            Log.warn("The PLATFORM_NUMBER define is deprecated. Please use the HXCPP_ANDROID_PLATFORM define instead.");
+            defines.set("HXCPP_ANDROID_PLATFORM", Std.string(defines.get("PLATFORM_NUMBER")));
+         }
       }
       else {
          globallySetThePlatform(root, defines);
@@ -581,7 +581,7 @@ class Setup
          defines.set("PLATFORM", "android-" + best);
          androidPlatform = best;
       }
-      defines.set("ANDROID_PLATFORM_DEFINE", "HXCPP_ANDROID_PLATFORM=" + androidPlatform);
+      defines.set("HXCPP_ANDROID_PLATFORM", Std.string(androidPlatform));
       if (Log.verbose) Log.println("");
    }
 


### PR DESCRIPTION
Originally, android min sdk version could be configured using `PLATFORM=android-xx`. This was used because it was a sub directory of the android ndk: 9e716f16735bd79fc39729f4334a73a393399427. Hxcpp used to extract the version from this define: https://github.com/HaxeFoundation/hxcpp/blob/75108a59f44c69348782f0be6204da512ebe1397/tools/hxcpp/Setup.hx#L547-L552

However, for modern ndks, PLATFORM is no longer used to resolve any directory and since #825 it is not parsed by hxcpp for ndk 20 or newer either.

This left people with no way to configure the min sdk version. To give a way of doing this again, `PLATFORM_NUMBER` was made configurable in #992. However, given that it does not have a very descriptive name this seems like it was an internal variable that should not have been exposed like this. It has also never been documented.

This PR allows setting the minimum sdk version using `HXCPP_ANDROID_PLATFORM`. This is a flag that was already used internally by hxcpp and has a much more descriptive name.

I have therefore also deprecated the PLATFORM_NUMBER define with a warning.