### PR TITLE
[cppia] Allow setting callback for script load

### DIFF
--- a/include/hx/Debug.h
+++ b/include/hx/Debug.h
@@ -216,7 +216,7 @@ private:
     bool (*mTestFunction)(Dynamic e);
 };
 
-#ifdef HXCPP_SCRIPTABLE
+#if defined(HXCPP_SCRIPTABLE) && (HXCPP_API_LEVEL >= 500)
 // This is the function to call when a new script has been loaded.
 // Signature: Void -> Void
 extern Dynamic g_onScriptLoadedFunction;
@@ -303,7 +303,7 @@ void __hxcpp_dbg_setNewStackFrameFunction(Dynamic function);
 void __hxcpp_dbg_setNewThreadInfoFunction(Dynamic function);
 void __hxcpp_dbg_setAddParameterToStackFrameFunction(Dynamic function);
 void __hxcpp_dbg_setAddStackFrameToThreadInfoFunction(Dynamic function);
-#ifdef HXCPP_SCRIPTABLE
+#if defined(HXCPP_SCRIPTABLE) && (HXCPP_API_LEVEL >= 500)
 void __hxcpp_dbg_setOnScriptLoadedFunction(Dynamic function);
 #endif
 
@@ -359,7 +359,7 @@ inline void __hxcpp_dbg_setNewStackFrameFunction(Dynamic) { }
 inline void __hxcpp_dbg_setNewThreadInfoFunction(Dynamic) { }
 inline void __hxcpp_dbg_setAddParameterToStackFrameFunction(Dynamic) { }
 inline void __hxcpp_dbg_setAddStackFrameToThreadInfoFunction(Dynamic) { }
-#ifdef HXCPP_SCRIPTABLE
+#if defined(HXCPP_SCRIPTABLE) && (HXCPP_API_LEVEL >= 500)
 inline void __hxcpp_dbg_setOnScriptLoadedFunction(Dynamic) { }
 #endif
 

--- a/include/hx/Debug.h
+++ b/include/hx/Debug.h
@@ -216,6 +216,11 @@ private:
     bool (*mTestFunction)(Dynamic e);
 };
 
+#ifdef HXCPP_SCRIPTABLE
+// This is the function to call when a new script has been loaded.
+// Signature: Void -> Void
+extern Dynamic g_onScriptLoadedFunction;
+#endif
 
 
 #endif // HXCPP_DEBUGGER
@@ -298,6 +303,9 @@ void __hxcpp_dbg_setNewStackFrameFunction(Dynamic function);
 void __hxcpp_dbg_setNewThreadInfoFunction(Dynamic function);
 void __hxcpp_dbg_setAddParameterToStackFrameFunction(Dynamic function);
 void __hxcpp_dbg_setAddStackFrameToThreadInfoFunction(Dynamic function);
+#ifdef HXCPP_SCRIPTABLE
+void __hxcpp_dbg_setOnScriptLoadedFunction(Dynamic function);
+#endif
 
 bool __hxcpp_dbg_fix_critical_error(String inErr);
 
@@ -351,6 +359,9 @@ inline void __hxcpp_dbg_setNewStackFrameFunction(Dynamic) { }
 inline void __hxcpp_dbg_setNewThreadInfoFunction(Dynamic) { }
 inline void __hxcpp_dbg_setAddParameterToStackFrameFunction(Dynamic) { }
 inline void __hxcpp_dbg_setAddStackFrameToThreadInfoFunction(Dynamic) { }
+#ifdef HXCPP_SCRIPTABLE
+inline void __hxcpp_dbg_setOnScriptLoadedFunction(Dynamic) { }
+#endif
 
 // The following functions are called by Thread.cpp to notify of thread
 // created and terminated

--- a/src/hx/Debugger.cpp
+++ b/src/hx/Debugger.cpp
@@ -56,7 +56,7 @@ static Dynamic g_addParameterToStackFrameFunction;
 // Signature: inThreadInfo : Dynamic -> inStackFrame : Dynamic -> Void
 static Dynamic g_addStackFrameToThreadInfoFunction;
 
-#ifdef HXCPP_SCRIPTABLE
+#if defined(HXCPP_SCRIPTABLE) && (HXCPP_API_LEVEL >= 500)
 Dynamic g_onScriptLoadedFunction{};
 #endif
 
@@ -1457,7 +1457,7 @@ void __hxcpp_dbg_setAddStackFrameToThreadInfoFunction(Dynamic function)
 }
 
 
-#ifdef HXCPP_SCRIPTABLE
+#if defined(HXCPP_SCRIPTABLE) && (HXCPP_API_LEVEL >= 500)
 void __hxcpp_dbg_setOnScriptLoadedFunction(Dynamic function)
 {
     hx::g_onScriptLoadedFunction = function;

--- a/src/hx/Debugger.cpp
+++ b/src/hx/Debugger.cpp
@@ -56,6 +56,9 @@ static Dynamic g_addParameterToStackFrameFunction;
 // Signature: inThreadInfo : Dynamic -> inStackFrame : Dynamic -> Void
 static Dynamic g_addStackFrameToThreadInfoFunction;
 
+#ifdef HXCPP_SCRIPTABLE
+Dynamic g_onScriptLoadedFunction{};
+#endif
 
 // This is the thread number of the debugger thread, extracted from
 // information about the thread that called 
@@ -1452,6 +1455,15 @@ void __hxcpp_dbg_setAddStackFrameToThreadInfoFunction(Dynamic function)
     hx::g_addStackFrameToThreadInfoFunction = function;
     GCAddRoot(&(hx::g_addStackFrameToThreadInfoFunction.mPtr));
 }
+
+
+#ifdef HXCPP_SCRIPTABLE
+void __hxcpp_dbg_setOnScriptLoadedFunction(Dynamic function)
+{
+    hx::g_onScriptLoadedFunction = function;
+    GCAddRoot(&(hx::g_onScriptLoadedFunction.mPtr));
+}
+#endif
 
 
 Dynamic __hxcpp_dbg_checkedThrow(Dynamic toThrow)

--- a/src/hx/cppia/CppiaModule.cpp
+++ b/src/hx/cppia/CppiaModule.cpp
@@ -111,6 +111,10 @@ void CppiaModule::registerDebugger()
    for(hx::UnorderedSet<int>::const_iterator i = allFileIds.begin(); i!=allFileIds.end(); ++i)
       addScriptableFile(strings[*i]);
 
+   if (hx::g_onScriptLoadedFunction != null{}) {
+      hx::g_onScriptLoadedFunction();
+   }
+
    #endif
 }
 

--- a/src/hx/cppia/CppiaModule.cpp
+++ b/src/hx/cppia/CppiaModule.cpp
@@ -111,9 +111,11 @@ void CppiaModule::registerDebugger()
    for(hx::UnorderedSet<int>::const_iterator i = allFileIds.begin(); i!=allFileIds.end(); ++i)
       addScriptableFile(strings[*i]);
 
+   #if (HXCPP_API_LEVEL >= 500)
    if (hx::g_onScriptLoadedFunction != null{}) {
       hx::g_onScriptLoadedFunction();
    }
+   #endif
 
    #endif
 }

--- a/tools/hxcpp/BuildTool.hx
+++ b/tools/hxcpp/BuildTool.hx
@@ -45,7 +45,7 @@ typedef Linkers = Hash<Linker>;
 
 class BuildTool
 {
-   public inline static var SupportedVersion = 430;
+   public inline static var SupportedVersion = 500;
 
    var mDefines:Hash<String>;
    var mCurrentIncludeFile:String;


### PR DESCRIPTION
Debugger clients may want to do some work if a script is loaded, e.g. adding breakpoints.

See related issue: #498