### PR TITLE
Fix broken ndk version caching

### DIFF
--- a/tools/hxcpp/Setup.hx
+++ b/tools/hxcpp/Setup.hx
@@ -125,10 +125,13 @@ class Setup
    }
 
    static var gotNdkVersion = 0.0;
+   static var cachedNdkPath:Null<String> = null;
    static public function getNdkVersion(inDirName:String, newStyle=false):Float
    {
-      if (gotNdkVersion!=0)
+      if (gotNdkVersion!=0 && cachedNdkPath==inDirName)
          return gotNdkVersion;
+
+      cachedNdkPath = inDirName;
 
       Log.v("Try to get version from source.properties");
       var src = toPath(inDirName+"/source.properties");


### PR DESCRIPTION
Since 739241bb7b46ecb3ca7aeb11bbd47594bd4a5cd6, this function would just store the version of the last checked ndk path, so it would return the wrong value if this is not the same ndk path that was last checked.

It now only reuses the version value if the path was the same.