### PR TITLE
Add support for armv7 abi in android gcc ndks

### DIFF
--- a/toolchain/android-toolchain-gcc.xml
+++ b/toolchain/android-toolchain-gcc.xml
@@ -27,7 +27,8 @@
 
 <section unless="HXCPP_X86">
   <set name="ARCH" value="-v7" if="HXCPP_ARMV7" />
-  <set name="ABI" value="armeabi" />
+  <set name="ABI" value="armeabi" unless="HXCPP_ARMV7" />
+  <set name="ABI" value="armeabi-v7a" if="HXCPP_ARMV7"/>
   <set name="PLATFORM_ARCH" value="arch-arm" />
   <set name="TOOLCHAIN" value="arm-linux-androideabi-${TOOLCHAIN_VERSION}" />
   <set name="EXEPREFIX" value="arm-linux-androideabi" />


### PR DESCRIPTION
Restoration of #724. `armeabi` is for `armv5` which was removed in r17, so trying to use it there causes an error.