### PR TITLE
Fix sysroot for android ndk 14+

### DIFF
--- a/toolchain/android-toolchain-gcc.xml
+++ b/toolchain/android-toolchain-gcc.xml
@@ -65,7 +65,12 @@
   <exe name="${EXEPREFIX}-g++" />
 
   <!-- These must appear in this order! -->
-  <flag value="--sysroot=${ANDROID_NDK_ROOT}/platforms/${PLATFORM}/${PLATFORM_ARCH}"/>
+  <flag value="--sysroot=${ANDROID_NDK_ROOT}/platforms/${PLATFORM}/${PLATFORM_ARCH}" unless="NDKV14+" />
+  <section if="NDKV14+">
+      <flag value="--sysroot=${ANDROID_NDK_ROOT}/sysroot" />
+      <flag name="-isystem" value="${ANDROID_NDK_ROOT}/sysroot/usr/include/${EXEPREFIX}" />
+      <flag value="-D__ANDROID_API__=${HXCPP_ANDROID_PLATFORM}" />
+  </section>
   <section if="NDKV8+">
     <flag value="-I${ANDROID_NDK_ROOT}/sources/cxx-stl/gnu-libstdc++/${TOOLCHAIN_VERSION}/include" />
     <flag value="-I${ANDROID_NDK_ROOT}/sources/cxx-stl/gnu-libstdc++/${TOOLCHAIN_VERSION}/libs/${ABI}/include" />
@@ -129,7 +134,7 @@
   <flag value="-finline-limit=10000"/>
   <flag value="-DANDROID=ANDROID"/>
   <flag value="-DHX_ANDROID"/>
-  <flag value="-D${ANDROID_PLATFORM_DEFINE}"/>
+  <flag value="-DHXCPP_ANDROID_PLATFORM=${HXCPP_ANDROID_PLATFORM}"/>
   <!-- todo <flag value="-Werror"/> -->
   <flag value="-Wa,--noexecstack"/>
   <flag value="-O2" unless="debug || HXCPP_OPTIMIZE_FOR_SIZE || HXCPP_OPTIMIZE_FOR_FAST"/>

--- a/tools/hxcpp/Setup.hx
+++ b/tools/hxcpp/Setup.hx
@@ -581,7 +581,7 @@ class Setup
          defines.set("PLATFORM", "android-" + best);
          androidPlatform = best;
       }
-      defines.set("ANDROID_PLATFORM_DEFINE", "HXCPP_ANDROID_PLATFORM=" + androidPlatform);
+      defines.set("HXCPP_ANDROID_PLATFORM", Std.string(androidPlatform));
       if (Log.verbose) Log.println("");
    }
 


### PR DESCRIPTION
For android ndks 14+, the previously used sysroot was deprecated and headers were moved into the unified sysroot. See: https://android.googlesource.com/platform/ndk/+/ndk-release-r16/docs/UnifiedHeaders.md

This closes #725