### PR TITLE
Fix android build with ndk 19

### DIFF
--- a/toolchain/android-toolchain-clang.xml
+++ b/toolchain/android-toolchain-clang.xml
@@ -41,7 +41,8 @@
 
   <exe name="clang++" />
   <flag value="--target=${ABITRIPLE}${HXCPP_ANDROID_PLATFORM}" />
-  
+  <cppflag value="-stdlib=libc++" unless="NDKV20+" />
+
   <!-- File Related -->
   <include name="toolchain/common-defines.xml" />
   <flag value="-I${HXCPP}/include"/>
@@ -88,6 +89,7 @@
   <!-- Build time error, not run time -->
   <flag value="-Wl,--no-undefined" unless="HXCPP_ALLOW_UNDEFINED" />
 
+  <flag value="-stdlib=libc++" unless="NDKV20+" />
   <flag value ="-static-libstdc++" />
   <!-- This shows the android link line, which may be so long that it breaks the tool
      https://github.com/HaxeFoundation/hxcpp/pull/1091

--- a/toolchain/android-toolchain.xml
+++ b/toolchain/android-toolchain.xml
@@ -2,7 +2,7 @@
 
 <setup name="androidNdk" />
 
-<include name="toolchain/android-toolchain-clang.xml" if="NDKV20+" />
-<include name="toolchain/android-toolchain-gcc.xml" unless="NDKV20+" />
+<include name="toolchain/android-toolchain-clang.xml" if="NDKV19+" />
+<include name="toolchain/android-toolchain-gcc.xml" unless="NDKV19+" />
 
 </xml>

--- a/tools/hxcpp/Setup.hx
+++ b/tools/hxcpp/Setup.hx
@@ -519,7 +519,7 @@ class Setup
       if (defines.exists('HXCPP_ANDROID_PLATFORM')) {
          Log.info("", "\x1b[33;1mUsing Android NDK platform: " + defines.get("HXCPP_ANDROID_PLATFORM") + "\x1b[0m");
       }
-      else if (defines.exists('NDKV20+')) {
+      else if (defines.exists('NDKV19+')) {
          if (defines.exists("PLATFORM_NUMBER")) {
             Log.warn("The PLATFORM_NUMBER define is deprecated. Please use the HXCPP_ANDROID_PLATFORM define instead.");
             defines.set("HXCPP_ANDROID_PLATFORM", Std.string(defines.get("PLATFORM_NUMBER")));


### PR DESCRIPTION
Like r20, r19 had the preconfigured clang binaries/scripts, however, it still required explicitly passing `-stdlib=libc++`. See: https://android.googlesource.com/platform/ndk/+/refs/tags/ndk-r19/docs/BuildSystemMaintainers.md#required-android-specific-arguments