### PR TITLE
[cppia] Fix index argument for jit array set

### DIFF
--- a/src/hx/cppia/ArrayBuiltin.cpp
+++ b/src/hx/cppia/ArrayBuiltin.cpp
@@ -1305,7 +1305,7 @@ struct ArrayBuiltin : public ArrayBuiltinBase
          case af__set:
             {
                JitTemp thisVal(compiler, jtPointer);
-               JitTemp index(compiler, jtPointer);
+               JitTemp index(compiler, jtInt);
                ExprType elemType = (ExprType)ExprTypeOf<ELEM>::value;
                JitTemp tempVal(compiler, elemType);
 


### PR DESCRIPTION
The index value should be treated as a int, not a pointer.

This fixes #1169.

Relevant to this haxe PR: https://github.com/HaxeFoundation/haxe/pull/11034