### PR TITLE
Custom stack traces

### DIFF
--- a/include/hx/HxcppMain.h
+++ b/include/hx/HxcppMain.h
@@ -97,7 +97,7 @@
           auto customStack = e->__Field(HX_CSTRING("__customStack"), HX_PROP_DYNAMIC).asString();
           if (::hx::IsNotNull(customStack))
           {
-              printf("%s\n", customStack.c_str());
+              printf("%s\n", customStack.utf8_str());
           }
           else
           {

--- a/include/hx/HxcppMain.h
+++ b/include/hx/HxcppMain.h
@@ -94,7 +94,7 @@
       }
       catch (Dynamic e)
       {
-          auto customStack = e->__Field(HX_CSTRING("__customStack"), HX_PROP_DYNAMIC).asString();
+          auto customStack = e->__Field(HX_CSTRING("_hx_customStack"), HX_PROP_DYNAMIC).asString();
           if (::hx::IsNotNull(customStack))
           {
               printf("%s\n", customStack.utf8_str());

--- a/include/hx/HxcppMain.h
+++ b/include/hx/HxcppMain.h
@@ -94,13 +94,22 @@
       }
       catch (Dynamic e)
       {
-         __hx_dump_stack();
-         #ifdef HX_WIN_MAIN
-         MessageBoxA(0,  e==null() ? "null" : e->toString().__CStr(), "Error", 0);
-         #else
-         printf("Error : %s\n",e==null() ? "null" : e->toString().__CStr());
-         #endif
-         return -1;
+          auto customStack = e->__Field(HX_CSTRING("__customStack"), HX_PROP_DYNAMIC).asString();
+          if (::hx::IsNotNull(customStack))
+          {
+              printf("%s\n", customStack.c_str());
+          }
+          else
+          {
+              __hx_dump_stack();
+          }
+
+#ifdef HX_WIN_MAIN
+          MessageBoxA(0, e == null() ? "null" : e->toString().__CStr(), "Error", 0);
+#else
+          printf("Error : %s\n", e == null() ? "null" : e->toString().__CStr());
+#endif
+          return -1;
       }
       return 0;
    }


### PR DESCRIPTION
See https://github.com/HaxeFoundation/haxe/pull/12213

This updates hxcpp unhandled exceptions to only call `__hx_dump_stack` if the caught object does not have a `__customStack` field, in which case that is printed out instead.