### PR TITLE
Delete haxelib.xml as it is no longer used by haxelib.

### DIFF
--- a/haxelib.xml
+++ b/haxelib.xml
@@ -1,5 +1,0 @@
-<project name="hxcpp" url="http://gamehaxe.com/" license="BSD">
-    <user name="gamehaxe"/>
-    <description>Hxcpp is the runtime support for the c++ backend of the haxe compiler.  This release constains the headers, libraries and support code required to generate a fully compiled executable from haxe code.</description>
-<version name="3.1.0">See Changes.txt</version>
-</project>


### PR DESCRIPTION
I have noticed that haxelib.xml has not been used in a few years.
This lead me to making a PR removing it.
If you want to keep it, just decline the PR and tell me why It has been blocked.