### PR TITLE
Fix haxelib path fallback functionality on windows

### DIFF
--- a/tools/hxcpp/PathManager.hx
+++ b/tools/hxcpp/PathManager.hx
@@ -111,8 +111,8 @@ class PathManager
          catch (e:Dynamic) {}
          
          Log.verbose = cache;
-         
-         var lines = output.split("\n");
+
+         var lines = ~/\r?\n/g.split(output);
          var result = "";
          var re = new EReg("^-D " + haxelib + "(=.*)?$", ""); //matches "-D hxcpp=3.1.0" or "-D hxcpp", but not "-D hxcpp-extras"
          for (i in 1...lines.length)


### PR DESCRIPTION
The check on line 134 would never work properly on windows, because the line had a CR character so FileSystem.exists returned false. This meant that if a library was resolved via a name that doesn't exactly match the `-D` flag set by haxelib (e.g. Hxcpp instead of hxcpp or via an alias), then it would be reported as missing.

The fix can be verified by using haxelib 4.2.0 and running `haxelib run hxcpp Build.xml` using this `Build.xml` file:

```xml
<xml>
    <echo value="${haxelib:HXCPP}" />
    <target id="default" />
</xml>
```

Currently it fails with the error:
```
Error: Could not find haxelib "HXCPP", does it need to be installed?
```
and with the fix, the path is printed without an error.

The same problem was also fixed in hxp, which uses very similar code: https://github.com/openfl/hxp/pull/34. 
