### PR TITLE
Remove unnecessary zlib warning flags

### DIFF
--- a/src/hx/libs/zlib/Build.xml
+++ b/src/hx/libs/zlib/Build.xml
@@ -13,10 +13,6 @@
   <compilerflag value="-DSTDC" unless="windows" />
   <compilerflag value="-DHAVE_UNISTD_H" unless="windows" />
 
-  <compilerflag value="-Wno-unknown-warning" unless="MSVC_VER" />
-  <compilerflag value="-Wno-unknown-warning-option" unless="MSVC_VER" />
-  <compilerflag value="-Wno-deprecated-non-prototype" unless="MSVC_VER" />
-
   <file name="ZLib.cpp"/>
 
   <!-- HXCPP_LINK_NO_ZLIB may be set too late, so use filterout as well. -->


### PR DESCRIPTION
See: https://github.com/HaxeFoundation/hxcpp/pull/1144#issuecomment-2311630672
> Once hxcpp starts using zlib 1.3 this change can be removed as mentioned https://github.com/madler/zlib/issues/842#issue-1853663795

These were used to suppress warnings in zlib 1.2, but now that we are on zlib 1.3 they are no longer necessary. In fact, they cause warnings with some compilers so it's better to remove them:

```
cc1plus: warning: command-line option ‘-Wno-deprecated-non-prototype’ is valid for C/ObjC but not for C++
cc1plus: note: unrecognized command-line option ‘-Wno-unknown-warning-option’ may have been intended to silence earlier diagnostics
cc1plus: note: unrecognized command-line option ‘-Wno-unknown-warning’ may have been intended to silence earlier diagnostics
```