### PR TITLE
Avoid digraph in AtomicObject.

### DIFF
--- a/include/hx/StdLibs.h
+++ b/include/hx/StdLibs.h
@@ -488,7 +488,7 @@ inline void* _hx_atomic_compare_exchange_cast_ptr(void *a, void *expected, void 
 #include <atomic>
 
 struct AtomicObject: hx::Object {
-  std::atomic<::hx::Object *> aPtr;
+  std::atomic< ::hx::Object *> aPtr;
 
   AtomicObject(Dynamic val) { aPtr = val.mPtr; }
 


### PR DESCRIPTION
It appears that Apple Clang in Obj-C++ mode does not like digraphs.