### PR TITLE
Unconditionally enable HXCPP_ALIGN_ALLOC.

### DIFF
--- a/include/hxcpp.h
+++ b/include/hxcpp.h
@@ -68,11 +68,7 @@
    #define HXCPP_ALIGN_FLOAT
 #endif
 
-// Must allign allocs to 8 bytes to match floating point requirement?
-// Ints must br read on 4-byte boundary
-#if (!defined(HXCPP_ALIGN_FLOAT) && (defined(EMSCRIPTEN) || defined(GCW0)) )
-   #define HXCPP_ALIGN_ALLOC
-#endif
+#define HXCPP_ALIGN_ALLOC
 
 
 // Some compilers are over-enthusiastic about what they #define ...


### PR DESCRIPTION
This is required to be able to safely use `std::atomic` inside hxcpp-allocated objects.