### PR TITLE
Use `16KB` max page size on Android.

### DIFF
--- a/toolchain/android-toolchain-clang.xml
+++ b/toolchain/android-toolchain-clang.xml
@@ -89,11 +89,14 @@
   <!-- Build time error, not run time -->
   <flag value="-Wl,--no-undefined" unless="HXCPP_ALLOW_UNDEFINED" />
 
-  <!-- Enable 16KB page size for NDK r27 and below -->
-  <flag value="-Wl,-z,max-page-size=16384" unless="NDKV28+" />
+  <!-- Disable 16KB page alignment workaround when explicitly requested -->
+  <section unless="HXCPP_ANDROID_NO_16K_PAGES">
+    <!-- Enable 16KB page size for NDK r27 and below -->
+    <flag value="-Wl,-z,max-page-size=16384" unless="NDKV28+" />
 
-  <!-- Extra 16KB alignment workaround for NDK r22 and below -->
-  <flag value="-Wl,-z,common-page-size=16384" unless="NDKV23+" />
+    <!-- Extra 16KB alignment workaround for NDK r22 and below -->
+    <flag value="-Wl,-z,common-page-size=16384" unless="NDKV23+" />
+  </section>
 
   <flag value="-stdlib=libc++" unless="NDKV20+" />
   <flag value ="-static-libstdc++" />

--- a/toolchain/android-toolchain-gcc.xml
+++ b/toolchain/android-toolchain-gcc.xml
@@ -178,8 +178,10 @@
   </section>
   <flag value="-Wl,--no-undefined" unless="dll_import" />
   <flag value="-Wl,--unresolved-symbols=ignore-in-object-files" if="dll_import" />
-  <flag value="-Wl,-z,max-page-size=16384" />
-  <flag value="-Wl,-z,common-page-size=16384" />
+  <section unless="HXCPP_ANDROID_NO_16K_PAGES">
+	<flag value="-Wl,-z,max-page-size=16384" />
+	<flag value="-Wl,-z,common-page-size=16384" />
+  </section>
   <flag value="-Wl,-z,noexecstack"/>
   <flag value="--sysroot=${ANDROID_NDK_ROOT}/platforms/${PLATFORM}/${PLATFORM_ARCH}"/>
   <flag value="-L${ANDROID_NDK_ROOT}/platforms/${PLATFORM}/${PLATFORM_ARCH}/usr/lib"/>
@@ -219,8 +221,10 @@
   <flag value="-std=c++11" if="HXCPP_CPP11"/>
   <flag value="-Wl,--no-undefined" unless="dll_import" />
   <flag value="-Wl,--unresolved-symbols=ignore-in-object-files" if="dll_import" />
-  <flag value="-Wl,-z,max-page-size=16384" />
-  <flag value="-Wl,-z,common-page-size=16384" />
+  <section unless="HXCPP_ANDROID_NO_16K_PAGES">
+	<flag value="-Wl,-z,max-page-size=16384" />
+	<flag value="-Wl,-z,common-page-size=16384" />
+  </section>
   <flag value="-Wl,-z,noexecstack"/>
   <flag value="--sysroot=${ANDROID_NDK_ROOT}/platforms/${PLATFORM}/${PLATFORM_ARCH}"/>
   <flag value="-L${ANDROID_NDK_ROOT}/platforms/${PLATFORM}/${PLATFORM_ARCH}/usr/lib"/>


### PR DESCRIPTION
This pr adds support for 16 KB page sizes on both Android toolchains.

https://developer.android.com/guide/practices/page-sizes

> Starting November 1st, 2025, all new apps and updates to existing apps submitted to Google Play and targeting Android 15+ devices must support 16 KB page sizes on 64-bit devices.

