### PR TITLE
Sqlite: Include optional defines for FTS5 and JSON1

### DIFF
--- a/src/hx/libs/sqlite/Build.xml
+++ b/src/hx/libs/sqlite/Build.xml
@@ -10,8 +10,8 @@
   <cache value="true" asLibrary="true" />
 
   <compilerflag value="-I${SQLITE_DIR}"/>
-  <compilerflag value="-DSQLITE_ENABLE_FTS5"  if="sqlite_fts5"/>
-  <compilerflag value="-DSQLITE_ENABLE_JSON1" if="sqlite_json1"/>
+  <compilerflag value="-DSQLITE_ENABLE_FTS5"  if="HXCPP_SQLITE_FTS5"/>
+  <compilerflag value="-DSQLITE_ENABLE_JSON1" if="HXCPP_SQLITE_JSON1"/>
   
   <file name="Sqlite.cpp"/>
 
@@ -25,4 +25,5 @@
 </target>
 
 </xml>
+
 


### PR DESCRIPTION
These features are pretty common in modern sqlite usage. They're included in the version we use, so might as well allow them to be enabled.