### PR TITLE
Clean up String::create handling with HX_SMART_STRINGS disabled

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -237,6 +237,7 @@ jobs:
         run: haxe compile-cpp.hxml -D ${{ env.HXCPP_ARCH_FLAG }} -D no_http
       - name: run
         run: bin${{ inputs.sep }}cpp${{ inputs.sep }}TestMain-debug
+
   build_tool:
     runs-on: ${{ inputs.os }}
     name: build tool tests
@@ -255,3 +256,19 @@ jobs:
             haxelib run hxcpp $xml
             haxelib run hxcpp $xml clean
           done
+
+  regression:
+    runs-on: ${{ inputs.os }}
+    name: regression tests
+    defaults:
+      run:
+        working-directory: test/regression
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: setup
+        uses: ./.github/workflows/setup
+        with:
+          haxe: ${{ inputs.haxe }}
+      - name: run
+        run: haxe --run Run -D ${{ env.HXCPP_ARCH_FLAG }}

--- a/include/hxString.h
+++ b/include/hxString.h
@@ -42,6 +42,7 @@ public:
    inline String(const char16_t *inPtr) { *this = create(inPtr); }
    inline String(const char *inPtr) { *this = create(inPtr); }
 
+   // If inLen is -1, the input string is treated as null terminated.
    static String create(const wchar_t *inPtr,int inLen=-1);
    static String create(const char16_t *inPtr,int inLen=-1);
    static String create(const char *inPtr,int inLen=-1);

--- a/src/String.cpp
+++ b/src/String.cpp
@@ -454,6 +454,9 @@ inline String TCopyString(const T *inString,int inLength)
       }
       else
       {
+         if (inLength == 0) {
+            return String::emptyString;
+         }
          int length = inLength > 0 ? inLength : 0;
          const char *ptr = TConvertToUTF8(inString, &length, 0, true );
          return String(ptr,length);

--- a/src/String.cpp
+++ b/src/String.cpp
@@ -446,9 +446,6 @@ inline String TCopyString(const T *inString,int inLength)
       return String();
 
    #ifndef HX_SMART_STRINGS
-      if (inLength<0)
-         for(inLength=0; !inString[inLength]; inString++) { }
-
       if (sizeof(T)==1)
       {
          int len = 0;
@@ -457,7 +454,7 @@ inline String TCopyString(const T *inString,int inLength)
       }
       else
       {
-         int length = inLength;
+         int length = inLength > 0 ? inLength : 0;
          const char *ptr = TConvertToUTF8(inString, &length, 0, true );
          return String(ptr,length);
       }

--- a/test/regression/Issue849/Main.hx
+++ b/test/regression/Issue849/Main.hx
@@ -1,0 +1,10 @@
+function main() {
+	// char
+	trace(untyped __cpp__('::String::create("Hello world")'));
+
+	// wchar_t
+	trace(untyped __cpp__('::String::create(L"Hello world")'));
+
+	// char16_t
+	trace(untyped __cpp__('::String::create(u"Hello world")'));
+}

--- a/test/regression/Issue849/Main.hx
+++ b/test/regression/Issue849/Main.hx
@@ -7,4 +7,15 @@ function main() {
 
 	// char16_t
 	trace(untyped __cpp__('::String::create(u"Hello world")'));
+
+	// explicit 0 length
+
+	// char
+	trace(untyped __cpp__('::String::create("Hello world", 0)'));
+
+	// wchar_t
+	trace(untyped __cpp__('::String::create(L"Hello world", 0)'));
+
+	// char16_t
+	trace(untyped __cpp__('::String::create(u"Hello world", 0)'));
 }

--- a/test/regression/Issue849/build.hxml
+++ b/test/regression/Issue849/build.hxml
@@ -1,0 +1,3 @@
+-cpp bin
+-D disable-unicode-strings
+-m Main

--- a/test/regression/Issue849/stdout.txt
+++ b/test/regression/Issue849/stdout.txt
@@ -1,0 +1,3 @@
+Main.hx:3: Hello world
+Main.hx:6: Hello world
+Main.hx:9: Hello world

--- a/test/regression/Issue849/stdout.txt
+++ b/test/regression/Issue849/stdout.txt
@@ -1,3 +1,6 @@
 Main.hx:3: Hello world
 Main.hx:6: Hello world
 Main.hx:9: Hello world
+Main.hx:14: 
+Main.hx:17: 
+Main.hx:20: 

--- a/test/regression/Run.hx
+++ b/test/regression/Run.hx
@@ -1,0 +1,64 @@
+import sys.io.Process;
+import sys.io.File;
+import sys.FileSystem;
+
+using StringTools;
+
+function runOutput(test:String):String {
+	final slash = Sys.systemName() == "Windows" ? "\\" : "/";
+	final proc = new Process([test, "bin", 'Main'].join(slash));
+	final code = proc.exitCode();
+
+	if (code != 0) {
+		throw 'return code was $code';
+	}
+
+	return proc.stdout.readAll().toString().replace("\r\n", "\n");
+}
+
+function main() {
+	var successes = 0;
+	var total = 0;
+
+	final args = Sys.args();
+
+	for (test in FileSystem.readDirectory(".")) {
+		if (!FileSystem.isDirectory(test)) {
+			continue;
+		}
+
+		total++;
+
+		final buildExitCode = Sys.command("haxe", ["-C", test, "build.hxml"].concat(args));
+		if (buildExitCode != 0) {
+			Sys.println('Failed to build test $test. Exit code: $buildExitCode');
+			continue;
+		}
+
+		final expectedStdout = File.getContent('$test/stdout.txt').replace("\r\n", "\n");
+		final actualStdout = try {
+			runOutput(test);
+		} catch (e) {
+			Sys.println('Test $test failed: $e');
+			continue;
+		};
+
+		if (actualStdout != expectedStdout) {
+			Sys.println('Test $test failed: Output did not match');
+
+			Sys.println("Expected stdout:");
+			Sys.println(expectedStdout);
+			Sys.println("Actual stdout:");
+			Sys.println(actualStdout);
+			continue;
+		}
+
+		successes++;
+	}
+
+	Sys.println('Regression tests complete. Successes: $successes / $total');
+
+	if (successes < total) {
+		Sys.exit(1);
+	}
+}


### PR DESCRIPTION
d119a07ef9e41b938fb4aebb3e6469c22c1e536f fixed an issue with incorrect handling of `length < 0`, however, it also introduced an unnecessary additional loop to get the length of the string, separate from the conversion/copy loop. This can be cleaned up because `GCStringDup` already has the correct handling of `length < 0`, and for `TConvertToUTF8` putting length as 0 has the same effect. This way the string only has to be iterated through once for the conversion/copy.

Also, there was still broken behaviour when using `String::create(_, 0)`. With `HX_SMART_STRINGS`, this always returns an empty string, whereas without `HX_SMART_STRINGS` the behaviour depends on the char type. This PR fixes this so it always returns an empty string.

This also adds a test for #849, to make sure it doesn't cause a regression. (Presumably, #814 is also covered by this test)