### PR TITLE
Avoid out of bounds access in String::fromCharCode

### DIFF
--- a/src/String.cpp
+++ b/src/String.cpp
@@ -1380,7 +1380,7 @@ Dynamic String::charCodeAt(int inPos) const
 
 String String::fromCharCode( int c )
 {
-   if (c<=255)
+   if (0<=c && c<=255)
    {
       return sConstStrings[c];
    }


### PR DESCRIPTION
If c is negative (this can happen if char is signed), then accessing sConstStrings[c] is an out of bounds memory access. This results in a string being created from garbage memory, which can lead to seg faults later on.

Taking the other branch is safer in this case. While the behaviour with negative values is unspecified, it is unsafe to give out of bounds access to memory like this.

This is partly the cause of the crash in #865.