### PR TITLE
Respect HXCPP_CPP11 flag on android toolchain

### DIFF
--- a/toolchain/android-toolchain-clang.xml
+++ b/toolchain/android-toolchain-clang.xml
@@ -35,6 +35,8 @@
   <set name="EXEPREFIX" value="llvm" />
 </section>
 
+<set name="HXCPP_CPP11" value="1" unless="HXCPP_NO_CPP11 || HXCPP_CPP17" />
+
 <include name="toolchain/gcc-toolchain.xml"/>
 
 <compiler id="android-gcc" exe="clang++">
@@ -61,6 +63,7 @@
   <flag value="-DHXCPP_ANDROID_PLATFORM=${HXCPP_ANDROID_PLATFORM}" />
 
   <!-- Options -->
+  <cppflag value="-std=c++11" if="HXCPP_CPP11" />
   <cppflag value="-std=c++17" if="HXCPP_CPP17" />
   <flag value="-flto" if="HXCPP_OPTIMIZE_LINK" unless="debug"/>
   <flag value="-fvisibility=hidden"/>


### PR DESCRIPTION
This is already respected by other toolchains, including the old android gcc toolchain.