### PR TITLE
BuildTool: Fix xcodebuild: error: SDK macosx26 cannot be located.

### DIFF
--- a/tools/hxcpp/BuildTool.hx
+++ b/tools/hxcpp/BuildTool.hx
@@ -2264,10 +2264,32 @@ class BuildTool
                if (extract_version.match(file))
                {
                   var ver = extract_version.matched(1);
-                  var split_best = best.split(".");
                   var split_ver = ver.split(".");
-                  if (Std.parseFloat(split_ver[0]) > Std.parseFloat(split_best[0]) || Std.parseFloat(split_ver[1]) > Std.parseFloat(split_best[1]))
+                  var major_ver = Std.parseFloat(split_ver[0]);
+                  var minor_ver = Std.parseFloat(split_ver[1]);
+                  if (Math.isNaN(major_ver) || Math.isNaN(minor_ver))
+                  {
+                     // if version is the wrong format, skip it
+                     continue;
+                  }
+                  var split_best = best.split(".");
+                  var major_best = Std.parseFloat(split_best[0]);
+                  var minor_best = Std.parseFloat(split_best[1]);
+                  if (Math.isNaN(major_best) || Math.isNaN(minor_best))
+                  {
+                     // shouldn't happen, but just to be safe
                      best = ver;
+                  }
+                  else if (major_ver > major_best)
+                  {
+                     // prefer higher major version
+                     best = ver;
+                  }
+                  else if (major_ver == major_best && minor_ver > minor_best)
+                  {
+                     // if major versions are equal, prefer higher minor version
+                     best = ver;
+                  }
                }
             }
             if (best!="0.0")


### PR DESCRIPTION
My SDKs directory contains three entries:

- _MacOSX.sdk_
- _MacOSX26.0.sdk_
- _MacOSX26.sdk_

The current SDK version detection in hxcpp is preferring _MacOSX26.sdk_ over _MacOSX26.0.sdk_. This is causing `MACOSX_VER` to be set to `26`. However, **xcodebuild** seems to want both major and minor parts of the version to be specified, so `MACOSX_VER` should be set to `26.0` instead.

This change checks if the current best's minor version is parsed as `NaN` when the major versions match, which results in a real float value for the minor version to be preferred.