### PR TITLE
Fix cpp.Pointer.ofArray with empty arrays

### DIFF
--- a/include/cpp/Pointer.h
+++ b/include/cpp/Pointer.h
@@ -503,7 +503,7 @@ public:
    }
 
    template<typename T>
-	inline static AutoCast ofArray(::Array<T> array)  { return AutoCast(&array[0]); }
+	inline static AutoCast ofArray(::Array<T> array)  { return AutoCast(array->Pointer()); }
 	inline static AutoCast ofArray(Dynamic inVal)
    {
       if (inVal==null() || !inVal->__IsArray())

--- a/test/native/tests/TestPtr.hx
+++ b/test/native/tests/TestPtr.hx
@@ -213,6 +213,17 @@ class TestPtr extends Test
 
    static function notProcAddress(module:String, func:String) return null;
 
+   // See: https://github.com/HaxeFoundation/hxcpp/issues/1028
+   public function testOfEmptyArray() {
+      var empty:Array<Dynamic> = [];
+      cpp.Pointer.ofArray( empty );
+      Assert.equals( 0, empty.length );
+
+      var emptyInt:Array<Int> = [];
+      cpp.Pointer.ofArray( emptyInt );
+      Assert.equals( 0, emptyInt.length );
+   }
+
    public function testArrayAccess() {
       var array = [ 0.0, 1.1, 2.2, 3.3 ];
       var ptr = cpp.Pointer.arrayElem(array, 0);


### PR DESCRIPTION
`array[0]` had a side effect of extending an empty array to size 1. Now,
the pointer is retrieved directly without the [] access which prevents
the array being extended.

Fixes #1028.