### PR TITLE
Dont override `libdir` on Windows `MSVC`.

### DIFF
--- a/toolchain/msvc-toolchain.xml
+++ b/toolchain/msvc-toolchain.xml
@@ -134,7 +134,6 @@
   <flag value="-NOEXP" if="HXCPP_NO_IMPLIB" />
   <lib name="${dll_import_link}" if="dll_import_link" />
   <ext value=".dll"/>
-  <libdir name="obj/lib"/>
   <flag value="-libpath:lib"/>
   <fromfile value="@"/>
   <outflag value="-out:"/>


### PR DESCRIPTION
Currently if someone wants to change the `libdir`, it'll override itself to `obj/lib`, whats funny is that from my testing, only Windows's `MSVC` has this issue currently.