### PR TITLE
Add `.so` ext on Android `clang` toolchain.

### DIFF
--- a/toolchain/android-toolchain-clang.xml
+++ b/toolchain/android-toolchain-clang.xml
@@ -106,6 +106,7 @@
   -->
   <prefix value="lib"/>
   <lib name="-llog"/>
+  <ext value=".so"/>
     
 </linker>
     


### PR DESCRIPTION
For some reason if `ext` isnt specified when building, itll just create a `liblime-64null` instead of it being `liblime-64.so` on Android's `Clang` toolchain which is the intended behaviour on Android's `GCC` toolchain.