### PR TITLE
[ci] Fix mariadb setup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -147,26 +147,14 @@ jobs:
           uses: ./.github/workflows/setup
           with:
             haxe: ${{ inputs.haxe }}
-        - name: install mariadb
+        - name: setup mariadb
           if: runner.os == 'Linux'
           run: |
             set -ex
-            sudo rm -R /var/lib/mysql/
-            curl -sSL https://downloads.mariadb.com/MariaDB/mariadb_repo_setup > mariadb_repo_setup
-            curl -sSL https://downloads.mariadb.com/MariaDB/mariadb_repo_setup.sha256 > mariadb_repo_setup.sha256
-            sha256sum --check mariadb_repo_setup.sha256
-            sudo bash mariadb_repo_setup
             sudo apt-get update -qqy
-            sudo apt-get remove -qqy mysql-common
-            sudo apt-get autoremove -qqy
             sudo apt-get install -qqy mariadb-server
-        - name: configure mariadb
-          if: runner.os == 'Linux'
-          run: |
-            set -ex
-            sudo systemctl unmask mysql.service
-            sudo systemctl start mysql
-            sudo mysql -u root -e "create database hxcpp; grant all privileges on hxcpp.* to hxcpp@localhost identified by 'hxcpp'; flush privileges;"
+            sudo systemctl start mariadb
+            sudo mariadb -u root -e "create database hxcpp; grant all privileges on hxcpp.* to hxcpp@localhost identified by 'hxcpp'; flush privileges;"
         - name: build
           run: haxe compile${{ inputs.arch }}.hxml
         - name: run


### PR DESCRIPTION
The previous setup steps are outdated and no longer necessary for a basic setup.

See up-to-date documentation:
https://mariadb.com/docs/server/mariadb-quickstart-guides/installing-mariadb-server-guide

This avoids an issue with the sha256sum file being incorrect:

```
+ curl -sSL https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+ curl -sSL https://downloads.mariadb.com/MariaDB/mariadb_repo_setup.sha256
+ sha256sum --check mariadb_repo_setup.sha256
sha256sum: WARNING: 1 computed checksum did NOT match
```