### PR TITLE
[ci] Use git utest for haxe 5 test suite

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -227,6 +227,8 @@ jobs:
           haxe: ${{ inputs.haxe }}
       - name: install haxe libs
         run: haxelib install compile-cpp.hxml --always
+        # haxe 4 tests don't build with latest utest
+        if: inputs.haxe != 'latest'
       - name: build
         run: haxe compile-cpp.hxml -D ${{ env.HXCPP_ARCH_FLAG }} -D no_http
       - name: run


### PR DESCRIPTION
The setup step already installs the git libraries, so this was overriding those. For haxe 5, we need to use git utest for int64 support. (see https://github.com/HaxeFoundation/haxe/pull/12410 and https://github.com/haxe-utest/utest/commit/8e99ed92b7376f1979f967ad7a729bdde47dae8f)

For haxe 4, continue to use the haxelib release as the tests don't compile with git utest. They are missing: https://github.com/HaxeFoundation/haxe/pull/11386/commits/ad257e2822e5985540d26c9d7ed6ff0037efb81b