### PR TITLE
[ci] Use macos 15 intel runner

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
       arch: 64
       sep: /
       ext: .dylib
-      os: macos-13
+      os: macos-15-intel
 
   MacOSArm:
     strategy:


### PR DESCRIPTION
macos-13 is deprecated and is planned for removal on December 4th: https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/. This avoids the intermittent failures.