### PR TITLE
int64 over size_t for views

### DIFF
--- a/include/cpp/marshal/Definitions.inc
+++ b/include/cpp/marshal/Definitions.inc
@@ -129,10 +129,10 @@ namespace cpp
             bool operator!=(const ValueReference<T>& inRHS) const;
 
             template<class K>
-            K get(int index);
+            K get(int64_t index);
 
             template<class K>
-            void set(int index, K value);
+            void set(int64_t index, K value);
         };
 
         template<class T>
@@ -183,19 +183,19 @@ namespace cpp
             TPtr operator->() const;
 
             template<class K>
-            K get(int index);
+            K get(int64_t index);
 
             template<class K>
-            void set(int index, K value);
+            void set(int64_t index, K value);
         };
 
         template<class T>
         struct View final
         {
             ::cpp::Pointer<T> ptr;
-            size_t length;
+            int64_t length;
 
-            View(::cpp::Pointer<T> _ptr, size_t _length);
+            View(::cpp::Pointer<T> _ptr, int64_t _length);
 
             void clear();
             void fill(T value);

--- a/include/cpp/marshal/PointerReference.hpp
+++ b/include/cpp/marshal/PointerReference.hpp
@@ -57,14 +57,14 @@ inline cpp::marshal::PointerReference<T>::PointerReference(const Boxed<O>& inRHS
 
 template<class T>
 template<class K>
-inline K cpp::marshal::PointerReference<T>::get(int index)
+inline K cpp::marshal::PointerReference<T>::get(int64_t index)
 {
     return (*Super::ptr)[index];
 }
 
 template<class T>
 template<class K>
-inline void cpp::marshal::PointerReference<T>::set(int index, K value)
+inline void cpp::marshal::PointerReference<T>::set(int64_t index, K value)
 {
     (*Super::ptr)[index] = value;
 }

--- a/include/cpp/marshal/ValueReference.hpp
+++ b/include/cpp/marshal/ValueReference.hpp
@@ -56,14 +56,14 @@ inline cpp::marshal::ValueReference<T>::ValueReference(const Boxed<O>& inRHS) : 
 
 template<class T>
 template<class K>
-inline K cpp::marshal::ValueReference<T>::get(int index)
+inline K cpp::marshal::ValueReference<T>::get(int64_t index)
 {
     return (*Super::ptr)[index];
 }
 
 template<class T>
 template<class K>
-inline void cpp::marshal::ValueReference<T>::set(int index, K value)
+inline void cpp::marshal::ValueReference<T>::set(int64_t index, K value)
 {
     (*Super::ptr)[index] = value;
 }

--- a/include/cpp/marshal/View.hpp
+++ b/include/cpp/marshal/View.hpp
@@ -5,7 +5,7 @@
 #include <cmath>
 
 template<class T>
-inline cpp::marshal::View<T>::View(::cpp::Pointer<T> _ptr, size_t _length) : ptr(_ptr), length(_length) {}
+inline cpp::marshal::View<T>::View(::cpp::Pointer<T> _ptr, int64_t _length) : ptr(_ptr), length(_length) {}
 
 template<class T>
 inline bool cpp::marshal::View<T>::tryCopyTo(const View<T>& destination)


### PR DESCRIPTION
Seems like there were two problems here.

One is something only msvc flagged up, the `get` and `set` functions on the value type reference has an ambigious conversion if the function it calls accepts `int64_t`.

The other is that the type apple clang uses for size_t doesn't have a dynamic conversion, so I've just switched the last few size_t references to int64_t (I'll also update the haxe extern).