### PR TITLE
[tools] Add check for invalid ANDROID_NDK_ROOT

### DIFF
--- a/tools/hxcpp/Setup.hx
+++ b/tools/hxcpp/Setup.hx
@@ -434,6 +434,14 @@ class Setup
       else
       {
          root = defines.get("ANDROID_NDK_ROOT");
+
+         if (!FileSystem.exists(root)) {
+            Log.error('ANDROID_NDK_ROOT ["$root"] directory does not exist');
+         }
+         if (!FileSystem.isDirectory(root)) {
+            Log.error('ANDROID_NDK_ROOT ["$root"] is not a diretory');
+         }
+
          Log.setup("\x1b[33;1mUsing Android NDK root: " + root + "\x1b[0m");
       }
 


### PR DESCRIPTION
If `ANDROID_NDK_ROOT` is set to a directory that doesn't exist, confusing errors will occur later on, so it's best to catch that case here.