### PR TITLE
Avoid adding fastcall attribute on linux aarch64

### DIFF
--- a/include/hx/Object.h
+++ b/include/hx/Object.h
@@ -43,7 +43,7 @@ HXCPP_EXTERN_CLASS_ATTRIBUTES null BadCast();
 // CPPIA_CALL = fastcall on x86(32), nothing otherwise
 #if (defined(_WIN32) && !defined(_M_X64) && !defined(__x86_64__) && !defined(_ARM_) ) || \
    defined(HXCPP_X86) || defined(__i386__) || defined(__i386) || \
-   (!defined(_WIN32) && !defined(_ARM_) && !defined(__arm__) && !defined(__x86_64__) )
+   (!defined(_WIN32) && !defined(_ARM_) && !defined(__arm__) && !defined(__aarch64__) && !defined(__x86_64__) )
 
    #if defined(__GNUC__) && !defined(__APPLE__) && !defined(EMSCRIPTEN)
       #define CPPIA_CALL __attribute__ ((fastcall))


### PR DESCRIPTION
fastcall should only be added for 32 bit x86, as explained in the comment. On some linux aarch64 compilers, none of the existing defines are set, and `__aarch64__` is set instead. Adding this avoids warnings like:

```
In file included from /home/runner/haxelib/hxcpp/git/include/hxcpp.h:336:
/home/runner/haxelib/hxcpp/git/include/hx/Object.h:60:65: warning: ‘fastcall’ attribute directive ignored [-Wattributes]
   60 | typedef void (CPPIA_CALL *StackExecute)(struct StackContext *ctx);
      |                                                                 ^
In file included from /home/runner/haxelib/hxcpp/git/include/hxcpp.h:336:
/home/runner/haxelib/hxcpp/git/include/hx/Object.h:60:65: warning: ‘fastcall’ attribute directive ignored [-Wattributes]
   60 | typedef void (CPPIA_CALL *StackExecute)(struct StackContext *ctx);
      |                                                                 ^
```