### PR TITLE
Remove setlocale call in __hxcpp_stdlibs_boot

### DIFF
--- a/src/hx/StdLibs.cpp
+++ b/src/hx/StdLibs.cpp
@@ -283,8 +283,6 @@ void __hxcpp_stdlibs_boot()
    //_setmode(_fileno(stdin), 0x00040000); // _O_U8TEXT
    #endif
 
-   // This is necessary for UTF-8 output to work correctly.
-   setlocale(LC_ALL, "");
    setlocale(LC_NUMERIC, "C");
 
    // I think this does more harm than good.


### PR DESCRIPTION
On Windows, this meant the utf-8 string passed to `printf("%s")` was interpreted as if it is from the default system locale encoding instead of utf-8, which are incompatible so any non-ASCII text comes out garbled. This setlocale call also meant that using `chcp 65001` does not have the correct effect of being able to view the full range of utf-8 characters from print output.

Originally, this setlocale call was required due to the use of `print("%S")` (i.e. formatting `wchar_t*` string into a `char*` in 94812c34d7df0d9d50127a8ce6033c4e3f98cc9a and 88f24749bb3164b526666487f0eaf613a1501468), but the printing functions in Stdlibs.cpp no longer rely on that (since 54fb7a1af600fc63c84f9e497c679b744f6492db) so it is safe to remove.

This way, it is possible to use `chcp 65001` or equivalent to view utf-8 output correctly on windows, see: #842.