### PR TITLE
[tools] Fix mingw toolchain rc file handling

### DIFF
--- a/toolchain/mingw-toolchain.xml
+++ b/toolchain/mingw-toolchain.xml
@@ -4,16 +4,19 @@
 
 <section if="linux_host||mac_host">
   <section if="HXCPP_M64">
-    <set name="HXCPP_MINGW_EXE" value="x86_64-w64-mingw32-g++" unless="HXCPP_MINGW_EXE" />
-    <set name="MINGW_ROOT" value="/usr/x86_64-w64-mingw32" unless="MINGW_ROOT" />
+    <set name="ABITRIPLE" value="x86_64-w64-mingw32" />
   </section>
   <section unless="HXCPP_M64">
-    <set name="HXCPP_MINGW_EXE" value="i686-w64-mingw32-g++" unless="HXCPP_MINGW_EXE" />
-    <set name="MINGW_ROOT" value="/usr/i686-w64-mingw32" unless="MINGW_ROOT" />
+    <set name="ABITRIPLE" value="i686-w64-mingw32" />
   </section>
+  <set name="EXEPREFIX" value="${ABITRIPLE}" />
+  <set name="HXCPP_MINGW_EXE" value="${EXEPREFIX}-g++" unless="HXCPP_MINGW_EXE" />
+  <set name="HXCPP_MINGW_RC_EXE" value="${EXEPREFIX}-windres" unless="HXCPP_MINGW_RC_EXE" />
+  <set name="MINGW_ROOT" value="/usr/${ABITRIPLE}" unless="MINGW_ROOT" />
 </section>
 
 <set name="HXCPP_MINGW_EXE" value="g++.exe" unless="HXCPP_MINGW_EXE"/>
+<set name="HXCPP_MINGW_RC_EXE" value="windres.exe" unless="HXCPP_MINGW_RC_EXE" />
 
 
 <setup name="mingw" />
@@ -45,6 +48,9 @@
   <objdir value="obj/mingw${OBJEXT}/"/>
   <outflag value="-o"/>
   <ext value=".o"/>
+
+  <rcexe name="${HXCPP_MINGW_RC_EXE}" />
+  <rcext value=".o" />
 </compiler>
 
 <linker id="dll" exe="g++">


### PR DESCRIPTION
Currently, the toolchain just passes the .rc file to the c++ compiler which results in the following warning:
```
 - Running command: x86_64-w64-mingw32-g++ -c -Wno-overflow -g -O2 -DHXCPP_M64 -DHXCPP_VISIT_ALLOCS -DHX_SMART_STRINGS -DHXCPP_API_LEVEL=430 -DHX_WINDOWS -m64 -DHXCPP_M64 -I/.../hxcpp/include ./ApplicationMain.rc -o/.../HelloWorld/Export/windows/obj/obj/mingw64-nc/20eab515_ApplicationMain.o
x86_64-w64-mingw32-g++: warning: ./ApplicationMain.rc: linker input file unused because linking not done
```
This means no object file is generated for the .rc, so this is followed by an error during link time:
```
 - Link: ApplicationMain.exe: x86_64-w64-mingw32-g++ -o ApplicationMain.exe -Wl,--enable-auto-import -mwindows -m64 -L/usr/x86_64-w64-mingw32/lib/libs @obj/mingw64-nc/all_objs -lws2_32
/usr/lib/gcc/x86_64-w64-mingw32/15.2.0/../../../../x86_64-w64-mingw32/bin/ld: cannot find obj/mingw64-nc/20eab515_ApplicationMain.o: No such file or directory
collect2: error: ld returned 1 exit status
Error: Error while running command
x86_64-w64-mingw32-g++ -o ApplicationMain.exe -Wl,--enable-auto-import -mwindows -m64 -L/usr/x86_64-w64-mingw32/lib/libs @obj/mingw64-nc/all_objs -lws2_32
```

`windres` is a utility that's part of mingw for processing `.rc` files, so that should be used here. We want to generate `.o` files instead of `.res` files like with msvc, since mingw cannot process `.res` files.

With this patch it is possible to build a haxe app using `-D resourceFile=ApplicationMain.rc` without linking errors. It is possible to verify that the resource has been added correctly, for example if the company name has been set:
```sh
exiftool bin/HelloWorld.exe | grep -i company
```