### PR TITLE
Fix undefined behaviour in View::tryCopyTo overlap

### DIFF
--- a/include/cpp/marshal/View.hpp
+++ b/include/cpp/marshal/View.hpp
@@ -15,7 +15,10 @@ inline bool cpp::marshal::View<T>::tryCopyTo(const View<T>& destination) const
         return false;
     }
 
-    std::memcpy(destination.ptr.ptr, ptr.ptr, sizeof(T) * length);
+    if (ptr.ptr + length < destination.ptr.ptr || destination.ptr.ptr + length < ptr.ptr)
+        std::memcpy(destination.ptr.ptr, ptr.ptr, sizeof(T) * length);
+    else
+        std::memmove(destination.ptr.ptr, ptr.ptr, sizeof(T) * length);
 
     return true;
 }

--- a/test/native/tests/marshalling/view/TestView.hx
+++ b/test/native/tests/marshalling/view/TestView.hx
@@ -291,5 +291,13 @@ class TestView extends Test {
 		Assert.same(buffer, biggerDst.slice(0, 10));
 		Assert.same(buffer, matchingDst);
 		Assert.same(buffer.slice(0, smallerDst.length), smallerDst);
+
+		final overlapped = buffer.copy();
+
+		final regionA = overlapped.asView().slice(2, 5);
+		final regionB = overlapped.asView().slice(4, 5);
+
+		Assert.isTrue(regionB.tryCopyTo(regionA));
+		Assert.same([0, 1, 4, 5, 6, 7, 8, 7, 8, 9], overlapped);
 	}
 }


### PR DESCRIPTION
This was causing random failures in the haxe test suite: https://github.com/HaxeFoundation/hxcpp/pull/1286#issuecomment-3711828931

The part where it was going wrong was here: https://github.com/HaxeFoundation/haxe/blob/3aed86e98aaa6097c3b8c9ab5c1aee5f70faa2f9/tests/unit/src/unit/TestBytes.hx#L47

The new implementation uses memcpy for this blit, which is undefined behaviour since the source and destination regions overlap. See: https://en.cppreference.com/w/cpp/string/byte/memcpy.html
> If any of the following conditions is satisfied, the behavior is undefined:
  [...]
    - Copying takes place between objects that overlap.

`std::memmove` is the alternative which is safe to use for overlapping blocks: https://en.cppreference.com/w/cpp/string/byte/memmove.html. This is also what is used in the ArrayBase::Blit method: https://github.com/HaxeFoundation/hxcpp/blob/4cff17a5a5e2076750f00a1bf74379a9f1ee57e9/src/Array.cpp#L179-L182

