### PR TITLE
[ci] Revert to release version of setup-haxe

### DIFF
--- a/.github/workflows/setup/action.yml
+++ b/.github/workflows/setup/action.yml
@@ -7,7 +7,7 @@ runs:
   using: composite
   steps:
     - name: install haxe
-      uses: krdlab/setup-haxe@hotfix/download-failure
+      uses: krdlab/setup-haxe@v2
       with:
         haxe-version: ${{ inputs.haxe }}
 


### PR DESCRIPTION
https://github.com/krdlab/setup-haxe/pull/62 was merged and released, so we can switch back to the release version of setup-haxe

Originally switched to this version in: #1286