### PR TITLE
[tools] Add missing linker features for linux toolchain

### DIFF
--- a/toolchain/linux-toolchain.xml
+++ b/toolchain/linux-toolchain.xml
@@ -36,6 +36,7 @@
 <compiler id="linux" exe="g++" if="linux">
   <exe name="${CXX}" if="CXX" />
   <flag value="-c"/>
+  <flag value="-flto" if="HXCPP_OPTIMIZE_LINK" unless="debug"/>
   <flag value="-fvisibility=hidden"/>
   <cppflag value="-frtti"/>
   <flag value="-g" if="HXCPP_DEBUG_LINK"/>


### PR DESCRIPTION
- `HXCPP_DEBUG_LINK` to include debug symbols in a release build
- `HXCPP_OPTIMIZE_LINK` to enable link time optimisations (related: #541)