### PR TITLE
Don't use a mem reference for setting object fields

### DIFF
--- a/src/hx/cppia/Cppia.cpp
+++ b/src/hx/cppia/Cppia.cpp
@@ -4657,15 +4657,10 @@ struct GetFieldByLinkage : public CppiaExpr
                      (CppiaExpr*)new MemReference<String,locThis>(this,offset);
                   break;
             case fsObject:
-               replace = object ?
-                     (CppiaExpr*)new MemReference<hx::Object *,locObj>(this,offset,object):
-                     (CppiaExpr*)new MemReference<hx::Object *,locThis>(this,offset);
-                  break;
             case fsByte:
             case fsUnknown:
                 forceNamedAccess = true;
                 break;
-                ;
          }
       }
 


### PR DESCRIPTION
The mem reference erases the underlying type to just `hx::Object*`, this is a problem when you try and set a field of a function type in a host class from a script. Script closures and functions do not extend the new callable type so by using this type erased pointer is assigned a not callable object to a callable object pointer, which then causes memory errors when invoking it.