### PR TITLE
Fix missing header for posix counting semaphores

### DIFF
--- a/src/hx/thread/CountingSemaphore.posix.cpp
+++ b/src/hx/thread/CountingSemaphore.posix.cpp
@@ -2,6 +2,7 @@
 #include <semaphore.h>
 #include <sys/time.h>
 #include <memory>
+#include <cerrno>
 #include <hx/thread/CountingSemaphore.hpp>
 
 struct hx::thread::CountingSemaphore_obj::Impl


### PR DESCRIPTION
This is a regression in #1316. We need to include the errno header explicitly to use `errno` in case it is not included transitively. This happens for example on android with ndk 21.

Fixes #1333