### PR TITLE
[ci] Release from ref instead of branch name

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -135,7 +135,7 @@ jobs:
           uses: ncipollo/release-action@v1
           with:
             tag: v${{ env.hxcpp_release }}
-            commit: ${{ github.head_ref }}
+            commit: ${{ github.ref }}
             name: Release ${{ env.hxcpp_release }}
             draft: false
             prerelease: false


### PR DESCRIPTION
The branch may have been updated since the ci started, so we need to use the full ref instead of the branch name.

The last few release runs have failed because 4.3.137 and 4.3.138 point to the same commit due to this bug.

See: https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#github-context

This will prevent the problem from happening in the future, but to fix it now we need to manually create a `4.3.139` tag.