### PR TITLE
[tools] Add HXCPP_NO_VENDORED flag for system libs

### DIFF
--- a/src/hx/libs/regexp/Build.xml
+++ b/src/hx/libs/regexp/Build.xml
@@ -31,15 +31,23 @@
   <depend name="${this_dir}/Build.xml" dateOnly="true" />
   <cache value="true" asLibrary="true" />
 
-  <compilerflag value="-I${PCRE_DIR}"/>
+  <compilerflag value="-I${PCRE_DIR}" unless="HXCPP_NO_VENDORED" />
 
   <file name="${this_dir}/RegExp.cpp"/>
 </files>
 
 <target id="haxe">
   <files id="hxcpp_regexp" />
-  <files id="pcre2-8" />
-  <files id="pcre2-16" if="hxcpp_smart_strings" />
+
+  <section unless="HXCPP_NO_VENDORED">
+    <files id="pcre2-8" />
+    <files id="pcre2-16" if="hxcpp_smart_strings" />
+  </section>
+
+  <section if="HXCPP_NO_VENDORED" unless="static_link">
+    <lib name="-lpcre2-8" />
+    <lib name="-lpcre2-16" if="hxcpp_smart_strings" />
+  </section>
 </target>
 
 </xml>

--- a/src/hx/libs/sqlite/Build.xml
+++ b/src/hx/libs/sqlite/Build.xml
@@ -9,16 +9,20 @@
   <depend name="${this_dir}/Build.xml" dateOnly="true" />
   <cache value="true" asLibrary="true" />
 
-  <compilerflag value="-I${SQLITE_DIR}"/>
-
   <file name="Sqlite.cpp"/>
 
-  <depend name="${SQLITE_DIR}/sqlite3.h" />
-  <file name="${SQLITE_DIR}/sqlite3.c" tags="" />
+  <section unless="HXCPP_NO_VENDORED" >
+    <compilerflag value="-I${SQLITE_DIR}" unless="HXCPP_NO_VENDORED" />
+
+    <depend name="${SQLITE_DIR}/sqlite3.h" />
+    <file name="${SQLITE_DIR}/sqlite3.c" tags="" />
+  </section>
+
 </files>
 
 <target id="haxe">
   <files id="hxcpp_sqlite"/>
+  <lib name="-lsqlite3" if="HXCPP_NO_VENDORED" unless="static_link" />
   <lib name="-lpthread" if="linux" unless="static_link" />
 </target>
 

--- a/src/hx/libs/ssl/Build.xml
+++ b/src/hx/libs/ssl/Build.xml
@@ -9,7 +9,7 @@
 	<depend name="${this_dir}/Build.xml" dateOnly="true" />
 	<cache value="true" asLibrary="true" />
 
-	<include name="${HXCPP}/project/thirdparty/mbedtls-flags.xml" />
+	<include name="${HXCPP}/project/thirdparty/mbedtls-flags.xml" unless="HXCPP_NO_VENDORED" />
 
 	<file name="${this_dir}/SSL.cpp"/>
 </files>
@@ -17,7 +17,13 @@
 <target id="haxe">
 	<!-- the order is important, mbedtls needs to come after hxcpp_ssl -->
 	<files id="hxcpp_ssl" />
-	<files id="mbedtls" />
+	<files id="mbedtls" unless="HXCPP_NO_VENDORED" />
+
+	<section if="HXCPP_NO_VENDORED" unless="static_link">
+		<lib name="-lmbedx509" />
+		<lib name="-lmbedtls" />
+		<lib name="-lmbedcrypto" />
+	</section>
 
 	<lib name="advapi32.lib" if="windows" unless="static_link" />
 	<lib name="crypt32.lib" if="windows" unless="static_link" />

--- a/src/hx/zip/zlib/Build.xml
+++ b/src/hx/zip/zlib/Build.xml
@@ -39,7 +39,7 @@
     <cache value="true" asLibrary="true" />
     <addTwice value="1" />
 
-    <compilerflag value="-I${ZLIB_DIR}"/>
+    <compilerflag value="-I${ZLIB_DIR}" unless="HXCPP_NO_VENDORED" />
     <compilerflag value="-I${this_dir}"/>
 
     <file name="ZLibUncompress.cpp"/>
@@ -48,7 +48,8 @@
 
   <target id="haxe">
     <files id="hxcpp_zlib_impl" />
-    <files id="zlib_sources" unless="HXCPP_LINK_NO_ZLIB"/>
+    <files id="zlib_sources" unless="HXCPP_LINK_NO_ZLIB || HXCPP_NO_VENDORED"/>
+    <lib name="-lz" if="HXCPP_NO_VENDORED" unless="static_link" />
   </target>
 
 </xml>


### PR DESCRIPTION
This allows using libraries provided by the system instead of the vendored sources. This can lead to a faster build and also gives more flexibility to have a newer version or for example in the context of packaging software for linux.

Closes #1093