### PR TITLE
Fix `MinGW` not showing traces in the console.

### DIFF
--- a/src/hx/StdLibs.cpp
+++ b/src/hx/StdLibs.cpp
@@ -254,7 +254,7 @@ void __hxcpp_stdlibs_boot()
     QueryPerformanceFrequency(&qpcFrequency);
 #endif
 
-   #if defined(_MSC_VER) && !defined(HX_WINRT)
+   #if defined(HX_WINDOWS) && !defined(HX_WINRT)
    if (!AttachConsole(ATTACH_PARENT_PROCESS)) {
 
    } else if (GetConsoleWindow()) {


### PR DESCRIPTION
For some reason, unlike when the application is compiled with `MSVC`, prints do not appear in the console when using `MinGW` where the executable is launched. This PR fixes the issue by adjusting the logic so that it works on all `Windows` platforms except `WinRT`.