### PR TITLE
Fixed `SSL CA` chain on `iOS` and `tvOS`

### DIFF
--- a/src/hx/libs/ssl/Build.xml
+++ b/src/hx/libs/ssl/Build.xml
@@ -23,8 +23,13 @@
 	<lib name="crypt32.lib" if="windows" unless="static_link" />
 	<lib name="ws2_32.lib" if="windows" unless="static_link" />
 
-	<flag value="-framework" if="macos"/>
-	<flag value="Security" if="macos"/>
+	<section if="apple" unless="static_link">
+		<flag value="-framework" />
+		<flag value="Security" />
+
+		<flag value="-framework" unless="macos" />
+		<flag value="Security" unless="macos" />
+	</section>
 </target>
 
 </xml>

--- a/src/hx/libs/ssl/Build.xml
+++ b/src/hx/libs/ssl/Build.xml
@@ -28,7 +28,7 @@
 		<flag value="Security" />
 
 		<flag value="-framework" unless="macos" />
-		<flag value="Security" unless="macos" />
+		<flag value="CoreFoundation" unless="macos" />
 	</section>
 </target>
 

--- a/src/hx/libs/ssl/SSL.cpp
+++ b/src/hx/libs/ssl/SSL.cpp
@@ -14,8 +14,11 @@ typedef int SOCKET;
 #include <hxcpp.h>
 #include <hx/OS.h>
 
-#if defined(NEKO_MAC) && !defined(IPHONE) && !defined(APPLETV)
+#if defined(NEKO_MAC) || defined(IPHONE) || defined(APPLETV)
 #include <Security/Security.h>
+#endif
+#if defined(IPHONE) || defined(APPLETV)
+#include <CoreFoundation/CoreFoundation.h>
 #endif
 
 typedef size_t socket_int;
@@ -439,6 +442,37 @@ static int verify_callback(void* param, mbedtls_x509_crt *crt, int depth, uint32
 	CertCloseStore(store, 0);
 	return 0;
 }
+#elif defined(IPHONE) || defined(APPLETV)
+static int verify_callback(void *data, mbedtls_x509_crt *crt, int depth, uint32_t *flags) {
+	// use mbedtls validate the chain structure and we validate with the iOS system trust store to replace the missing CA bundle
+	if (depth != 0) {
+		*flags = 0;
+		return 0;
+	}
+
+	CFDataRef derData = CFDataCreate(NULL, crt->raw.p, crt->raw.len);
+	if (!derData) return 0;
+
+	SecCertificateRef secCert = SecCertificateCreateWithData(NULL, derData);
+	CFRelease(derData);
+	if (!secCert) return 0;
+
+	SecPolicyRef policy = SecPolicyCreateSSL(true, NULL);
+	CFArrayRef certs = CFArrayCreate(NULL, (const void **)&secCert, 1, &kCFTypeArrayCallBacks);
+	SecTrustRef trust = NULL;
+	SecTrustCreateWithCertificates(certs, policy, &trust);
+	CFRelease(certs);
+	CFRelease(policy);
+	CFRelease(secCert);
+
+	CFErrorRef err = NULL;
+	bool trusted = SecTrustEvaluateWithError(trust, &err);
+	CFRelease(trust);
+	if (err) CFRelease(err);
+
+	if (trusted) *flags = 0;
+	return 0;
+}
 #endif
 
 Dynamic _hx_ssl_conf_new( bool server ) {
@@ -451,7 +485,7 @@ Dynamic _hx_ssl_conf_new( bool server ) {
 		conf->destroy();
 		ssl_error( ret );
 	}
-#ifdef NEKO_WINDOWS
+#if defined(NEKO_WINDOWS) || defined(IPHONE) || defined(APPLETV)
 	mbedtls_ssl_conf_verify(conf->c, verify_callback, NULL);
 #endif
 	mbedtls_ssl_conf_rng( conf->c, mbedtls_ctr_drbg_random, &ctr_drbg );
@@ -583,6 +617,10 @@ Dynamic _hx_ssl_cert_load_defaults(){
 	CFRelease(keychain);
 	if( chain != NULL )
 		return chain;
+#elif defined(IPHONE) || defined(APPLETV) // SystemRootCertificates.keychain doesn't exist on iOS and tvOS so i use a cool workaround
+    sslcert *chain = new sslcert();
+    chain->create(NULL); // creates a ssl cert with only the default ones that iOS or tvOS trust in the os
+    return chain;
 #endif
 	return null();
 }

--- a/src/hx/libs/ssl/SSL.cpp
+++ b/src/hx/libs/ssl/SSL.cpp
@@ -499,7 +499,7 @@ void _hx_ssl_conf_close( Dynamic hconf ) {
 
 void _hx_ssl_conf_set_ca( Dynamic hconf, Dynamic hcert ) {
 	sslconf *conf = val_conf(hconf);
-	if( hconf.mPtr ){
+	if( hcert.mPtr ){
 		sslcert *cert = val_cert(hcert);
 		mbedtls_ssl_conf_ca_chain( conf->c, cert->c, NULL );
 	}else{


### PR DESCRIPTION
This pr has been originally done https://github.com/FunkinCrew/hxcpp/pull/11 but since this is a pretty important fix for `hxcpp` i thought why not do it here aswell, it fixes https://github.com/HaxeFoundation/hxcpp/issues/570 by properly setting the `SSL CA` chain on `iOS` and `tvOS`.