### PR TITLE
Remove `minimingw` haxelib

### DIFF
--- a/tools/hxcpp/BuildTool.hx
+++ b/tools/hxcpp/BuildTool.hx
@@ -2083,7 +2083,7 @@ class BuildTool
             // Choose between MSVC and MINGW
             var useMsvc = true;
 
-            if (defines.exists("mingw") || defines.exists("HXCPP_MINGW") || defines.exists("minimingw"))
+            if (defines.exists("mingw") || defines.exists("HXCPP_MINGW"))
                useMsvc = false;
             else if ( defines.exists("winrt") || defines.exists("HXCPP_MSVC_VER"))
                useMsvc = true;

--- a/tools/hxcpp/Setup.hx
+++ b/tools/hxcpp/Setup.hx
@@ -235,14 +235,6 @@ class Setup
       if (!ioDefines.exists("MINGW_ROOT"))
       {
 
-         var haxelib = PathManager.getHaxelib("minimingw","",false);
-         if (haxelib!=null && haxelib!="")
-         {
-            ioDefines.set("MINGW_ROOT", haxelib);
-            Log.v('Using haxelib version of MinGW, $haxelib');
-            return;
-         }
-
          var guesses = ["c:/MinGW"];
          for (guess in guesses)
          {


### PR DESCRIPTION
Its pretty self explanatory, this makes it so it now errors that it couldn't locate `MINGW_ROOT` instead of saying that `minimingw` is not installed instead, `minimingw` itself is pretty out of date imo.