### PR TITLE
Fix Immix working memory overflow with big blocks

### DIFF
--- a/include/hx/GC.h
+++ b/include/hx/GC.h
@@ -158,10 +158,10 @@ extern int gPauseForCollect;
 
 
 // Minimum total memory - used + buffer for new objects
-extern int sgMinimumWorkingMemory;
+extern size_t sgMinimumWorkingMemory;
 
 // Minimum free memory - not counting used memory
-extern int sgMinimumFreeSpace;
+extern size_t sgMinimumFreeSpace;
 
 // Also ensure that the free memory is larger than this amount of used memory
 extern int sgTargetFreeSpacePercentage;

--- a/src/hx/gc/GcCommon.cpp
+++ b/src/hx/gc/GcCommon.cpp
@@ -27,11 +27,11 @@ extern void __hxt_new_string(void* result, int size);
 namespace hx
 {
 #if defined(HX_MACOS) || defined(HX_WINDOWS) || defined(HX_LINUX) || defined(__ORBIS__)
-int sgMinimumWorkingMemory       = 20*1024*1024;
-int sgMinimumFreeSpace           = 10*1024*1024;
+size_t sgMinimumWorkingMemory       = 20*1024*1024;
+size_t sgMinimumFreeSpace           = 10*1024*1024;
 #else
-int sgMinimumWorkingMemory       = 8*1024*1024;
-int sgMinimumFreeSpace           = 4*1024*1024;
+size_t sgMinimumWorkingMemory       = 8*1024*1024;
+size_t sgMinimumFreeSpace           = 4*1024*1024;
 #endif
 // Once you use more than the minimum, this kicks in...
 int sgTargetFreeSpacePercentage  = 100;
@@ -48,7 +48,7 @@ void CommonInitAlloc()
    const char *minimumWorking = getenv("HXCPP_MINIMUM_WORKING_MEMORY");
    if (minimumWorking)
    {
-      int mem =  atoi(minimumWorking);
+      size_t mem = strtoull(minimumWorking, 0, 10);
       if (mem>0)
          sgMinimumWorkingMemory = mem;
    }
@@ -56,7 +56,7 @@ void CommonInitAlloc()
    const char *minimumFreeSpace = getenv("HXCPP_MINIMUM_FREE_SPACE");
    if (minimumFreeSpace)
    {
-      int mem =  atoi(minimumFreeSpace);
+      size_t mem = strtoull(minimumFreeSpace, 0, 10);
       if (mem>0)
          sgMinimumFreeSpace = mem;
    }

--- a/src/hx/gc/Immix.cpp
+++ b/src/hx/gc/Immix.cpp
@@ -3543,11 +3543,11 @@ public:
       #if defined(SHOW_MEM_EVENTS_VERBOSE) || defined(SHOW_FRAGMENTATION_BLOCKS)
       if (inJustBorrowing)
       {
-         GCLOG("Borrow Blocks %d = %d k\n", mAllBlocks.size(), (mAllBlocks.size() << IMMIX_BLOCK_BITS)>>10);
+         GCLOG("Borrow Blocks %d = %d k\n", mAllBlocks.size(), (int)(GetWorkingMemory() >> 10));
       }
       else
       {
-         GCLOG("Blocks %d = %d k\n", mAllBlocks.size(), (mAllBlocks.size() << IMMIX_BLOCK_BITS)>>10);
+         GCLOG("Blocks %d = %d k\n", mAllBlocks.size(), (int)(GetWorkingMemory() >> 10));
       }
       #endif
 
@@ -5235,7 +5235,7 @@ public:
       #endif
 
       // Large alloc target
-      int blockSize =  mAllBlocks.size()<<IMMIX_BLOCK_BITS;
+      size_t blockSize =  GetWorkingMemory();
       if (blockSize > mLargeAllocSpace)
          mLargeAllocSpace = blockSize;
       mLargeAllocForceRefresh = mLargeAllocated + mLargeAllocSpace;


### PR DESCRIPTION
## Summary

Fixes an overflow in Immix working memory accounting when `HXCPP_GC_BIG_BLOCKS` is enabled.

The problematic code computes the regular Immix heap size through an `int`:

```cpp
int blockSize = mAllBlocks.size() << IMMIX_BLOCK_BITS;
```
With big blocks, this can overflow once regular heap usage grows past roughly 2 GiB. The fix uses `GetWorkingMemory()`, which performs the shift through `size_t`.
This also stores related GC memory tuning thresholds as `size_t` and parses large environment variable values with `strtoull.`
## Context
In a large OpenFL/hxcpp game, the regular heap consistently failed once it passed 2 GiB with:
```
Memory exhausted.
try HXCPP_GC_BIG_BLOCKS.
```
After enabling `HXCPP_GC_BIG_BLOCKS,` the game no longer crashed immediately, but it froze for a very long time instead, making it unplayable.
With this fix, the same game can continue past that threshold. I was able to reach 12+ GiB of regular heap usage without hitting the previous stall/failure mode.
## Repro
[HxcppBigBlocksHeapOverflowRepro.zip](https://github.com/user-attachments/files/27495862/HxcppBigBlocksHeapOverflowRepro.zip)
It retains many regular hxcpp objects until multi-GiB heap usage.
The repro is not a perfect match for the original game: without the fix, it usually stalls around 7-8 GiB rather than just past 2 GiB. However, it still demonstrates the same failure mode and shows that the fix lets the program continue to the configured target.