### PR TITLE
Add support to cross-compile `Windows` via `MinGW` from `MacOS`

### DIFF
--- a/tools/hxcpp/BuildTool.hx
+++ b/tools/hxcpp/BuildTool.hx
@@ -2159,7 +2159,15 @@ class BuildTool
       {
          set64(defines,m64, arm64);
          // Cross-compile?
-         if (defines.exists("linux"))
+         if (defines.exists("windows"))
+         {
+            defines.set("mac_host","1");
+            defines.set("mingw", "mingw");
+            defines.set("toolchain","mingw");
+            defines.set("xcompile","1");
+            defines.set("BINDIR", arm64 ? "WindowsArm64" : m64 ? "Windows64":"Windows");
+         }
+         else if (defines.exists("linux"))
          {
             defines.set("mac_host","1");
             defines.set("linux","linux");


### PR DESCRIPTION
Its pretty self explenetory, this makes it so `MinGW` can now be compiled from `MacOS` and not only from `Linux` or `Windows`, I dont why this hasn't been done earlier