### PR TITLE
Thread Changes Cleanup

### DIFF
--- a/include/hx/StdLibs.h
+++ b/include/hx/StdLibs.h
@@ -299,15 +299,14 @@ double __hxcpp_time_stamp();
 
 // --- vm/threading --------------------------------------------------------------------
 
-#if (HXCPP_API_LEVEL>=500)
-Dynamic __hxcpp_thread_create(hx::Callable<void()> inFunc);
-#else
+#if (HXCPP_API_LEVEL<500)
+
 Dynamic __hxcpp_thread_create(Dynamic inFunc);
-#endif
+
 Dynamic __hxcpp_thread_current();
 void    __hxcpp_thread_send(Dynamic inThread, Dynamic inMessage);
 Dynamic __hxcpp_thread_read_message(bool inBlocked);
-bool __hxcpp_is_current_thread(hx::Object *inThread);
+bool __hxcpp_is_current_thread(hx::Object* inThread);
 
 Dynamic __hxcpp_mutex_create();
 void    __hxcpp_mutex_acquire(Dynamic);
@@ -324,21 +323,23 @@ void __hxcpp_condition_acquire(Dynamic);
 bool __hxcpp_condition_try_acquire(Dynamic);
 void __hxcpp_condition_release(Dynamic);
 void __hxcpp_condition_wait(Dynamic);
-bool __hxcpp_condition_timed_wait(Dynamic,double);
+bool __hxcpp_condition_timed_wait(Dynamic, double);
 void __hxcpp_condition_signal(Dynamic);
 void __hxcpp_condition_broadcast(Dynamic);
 
 Dynamic __hxcpp_lock_create();
-bool    __hxcpp_lock_wait(Dynamic inlock,double inTime);
+bool    __hxcpp_lock_wait(Dynamic inlock, double inTime);
 void    __hxcpp_lock_release(Dynamic inlock);
 
 Dynamic __hxcpp_deque_create();
-void    __hxcpp_deque_add(Dynamic q,Dynamic inVal);
-void    __hxcpp_deque_push(Dynamic q,Dynamic inVal);
-Dynamic __hxcpp_deque_pop(Dynamic q,bool block);
+void    __hxcpp_deque_add(Dynamic q, Dynamic inVal);
+void    __hxcpp_deque_push(Dynamic q, Dynamic inVal);
+Dynamic __hxcpp_deque_pop(Dynamic q, bool block);
 
 Dynamic __hxcpp_tls_get(int inID);
-void    __hxcpp_tls_set(int inID,Dynamic inVal);
+void    __hxcpp_tls_set(int inID, Dynamic inVal);
+
+#endif
 
 bool _hx_atomic_exchange_if(::cpp::Pointer<cpp::AtomicInt> inPtr, int test, int newVal  );
 int _hx_atomic_inc(::cpp::Pointer<cpp::AtomicInt> inPtr );

--- a/include/hx/thread/Thread.hpp
+++ b/include/hx/thread/Thread.hpp
@@ -25,13 +25,6 @@ namespace hx
 
 			virtual String getName() = 0;
 			virtual void setName(const String& name) = 0;
-
-			virtual String toString() override = 0;
-
-			virtual void __Mark(HX_MARK_PARAMS) override = 0;
-#ifdef HXCPP_VISIT_ALLOCS
-			virtual void __Visit(HX_VISIT_PARAMS) override = 0;
-#endif
 		};
 	}
 }

--- a/src/hx/Profiler.cpp
+++ b/src/hx/Profiler.cpp
@@ -1,9 +1,10 @@
 #include <hxcpp.h>
 #include <map>
 #include <vector>
-#include <hx/Thread.h>
 #include <hx/OS.h>
 #include <mutex>
+#include <thread>
+#include <chrono>
 
 
 #ifdef HX_WINRT
@@ -49,7 +50,8 @@ public:
         gThreadRefCount += 1;
 
         if (gThreadRefCount == 1) {
-            HxCreateDetachedThread(ProfileMainLoop, 0);
+            std::thread thread(ProfileMainLoop);
+            thread.detach();
         }
     }
 
@@ -214,18 +216,16 @@ private:
         int childrenPlusSelf;
     };
 
-    static THREAD_FUNC_TYPE ProfileMainLoop(void *)
+    static void ProfileMainLoop()
     {
         int millis = 1;
 
         while (gThreadRefCount > 0) { 
-            HxSleep(millis);
+            std::this_thread::sleep_for(std::chrono::milliseconds(millis));
 
             int count = gProfileClock + 1;
             gProfileClock = (count < 0) ? 0 : count;
         }
-
-        THREAD_FUNC_RET
     }
 
     String mDumpFile;

--- a/src/hx/Telemetry.cpp
+++ b/src/hx/Telemetry.cpp
@@ -8,7 +8,8 @@
 #include <hx/Telemetry.h>
 #include <hx/OS.h>
 #include <mutex>
-
+#include <thread>
+#include <chrono>
 
 namespace hx
 {
@@ -67,7 +68,9 @@ public:
    
         gThreadRefCount += 1;
         if (gThreadRefCount == 1) {
-            HxCreateDetachedThread(ProfileMainLoop, 0);
+            std::thread thread(ProfileMainLoop);
+
+            thread.detach();
         }
     }
 
@@ -284,26 +287,16 @@ private:
     int GetNameIdx(const char *fullName);
     int ComputeCallStackId();
 
-    static THREAD_FUNC_TYPE ProfileMainLoop(void *)
+    static void ProfileMainLoop()
     {
         int millis = 1;
 
-        while (gThreadRefCount > 0) { 
-#ifdef HX_WINDOWS
-            Sleep(millis);
-#else
-            struct timespec t;
-            struct timespec tmp;
-            t.tv_sec = 0;
-            t.tv_nsec = millis * 1000000;
-            nanosleep(&t, &tmp);
-#endif
+        while (gThreadRefCount > 0) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(millis));
 
             int count = gProfileClock + 1;
             gProfileClock = (count < 0) ? 0 : count;
         }
-
-        THREAD_FUNC_RET
     }
 
     StackContext *stack;

--- a/src/hx/Thread.cpp
+++ b/src/hx/Thread.cpp
@@ -1,5 +1,7 @@
 #include <hxcpp.h>
 
+#if (HXCPP_API_LEVEL<500)
+
 #include <hx/Thread.h>
 #include <time.h>
 #include <hx/thread/ConditionVariable.hpp>
@@ -421,4 +423,4 @@ int _hx_atomic_dec(::cpp::Pointer<cpp::AtomicInt> inPtr )
    return _hx_atomic_sub(inPtr, 1);
 }
 
-
+#endif

--- a/src/hx/Thread.cpp
+++ b/src/hx/Thread.cpp
@@ -406,6 +406,8 @@ int __hxcpp_GetCurrentThreadNumber()
 	return hx::thread::Thread_obj::id();
 }
 
+#endif
+
 // --- Atomic ---
 
 bool _hx_atomic_exchange_if(::cpp::Pointer<cpp::AtomicInt> inPtr, int test, int  newVal )
@@ -422,5 +424,3 @@ int _hx_atomic_dec(::cpp::Pointer<cpp::AtomicInt> inPtr )
 {
    return _hx_atomic_sub(inPtr, 1);
 }
-
-#endif

--- a/src/hx/Thread.cpp
+++ b/src/hx/Thread.cpp
@@ -156,11 +156,7 @@ Dynamic __hxcpp_deque_pop(Dynamic q,bool block)
 
 // --- Thread ----------------------------------------------------------
 
-#if (HXCPP_API_LEVEL>=500)
-Dynamic __hxcpp_thread_create(hx::Callable<void()> inStart)
-#else
 Dynamic __hxcpp_thread_create(Dynamic inStart)
-#endif
 {
 	return hx::thread::Thread_obj::create(inStart);
 }

--- a/src/hx/cppia/GlobalBuiltin.cpp
+++ b/src/hx/cppia/GlobalBuiltin.cpp
@@ -1,6 +1,10 @@
 #include <hxcpp.h>
 #include "Cppia.h"
 
+#if (HXCPP_API_LEVEL>=500)
+#include <hx/thread/Thread.hpp>
+#endif
+
 namespace hx
 {
 
@@ -382,17 +386,11 @@ CppiaExpr *createGlobalBuiltin(CppiaExpr *src, String function, Expressions &ioE
    {
       if (ioExpressions.size()==1)
 #if (HXCPP_API_LEVEL>=500)
-         return new ObjectBuiltin1<Callable<void(void)>, Dynamic, __hxcpp_thread_create>(src, ioExpressions);
+          return new ObjectBuiltin1<hx::Callable<void(void)>, hx::thread::Thread, hx::thread::Thread_obj::create>(src, ioExpressions);
 #else
-         return new ObjectBuiltin1<Dynamic, Dynamic, __hxcpp_thread_create>(src, ioExpressions);
+          return new ObjectBuiltin1<Dynamic, Dynamic, __hxcpp_thread_create>(src, ioExpressions);
 #endif
    }
-   if (function==HX_CSTRING("__hxcpp_thread_send") )
-   {
-      if (ioExpressions.size()==2)
-         return new VoidBuiltin2<Dynamic,Dynamic,__hxcpp_thread_send>(src,ioExpressions);
-   }
-
 
    printf("Unknown function : %s(%d)\n", function.out_str(), (int)ioExpressions.size() );
    throw (HX_CSTRING("Unknown global:") + function).utf8_str();

--- a/src/hx/gc/Immix.cpp
+++ b/src/hx/gc/Immix.cpp
@@ -4516,10 +4516,9 @@ public:
       }
    }
 
-   static THREAD_FUNC_TYPE SThreadLoop( void *inInfo )
+   static void SThreadLoop( void *inInfo )
    {
       sGlobalAlloc->ThreadLoop((int)(size_t)inInfo);
-      THREAD_FUNC_RET;
    }
 
    void CreateWorker(int inId)
@@ -4537,7 +4536,9 @@ public:
 
          sThreadSleeping[inId] = false;
 
-         HxCreateDetachedThread(SThreadLoop, info);
+         std::thread thread(SThreadLoop, info);
+
+         thread.detach();
       #endif
    }
 

--- a/src/hx/gc/Immix.cpp
+++ b/src/hx/gc/Immix.cpp
@@ -8,6 +8,7 @@
 #include "GcRegCapture.h"
 #include <hx/Unordered.h>
 #include <mutex>
+#include <thread>
 #include <condition_variable>
 
 #ifdef EMSCRIPTEN

--- a/test/native/Native.hx
+++ b/test/native/Native.hx
@@ -18,6 +18,8 @@ class Native
 			new tests.TestNativeEnum(),
 
 			#if (haxe_ver>=5)
+            new tests.TestScratch(),
+
             new tests.marshalling.classes.TestLocalValueType(),
             new tests.marshalling.classes.TestClassValueType(),
             new tests.marshalling.classes.TestInterfaceValueType(),

--- a/test/native/tests/TestScratch.hx
+++ b/test/native/tests/TestScratch.hx
@@ -1,0 +1,53 @@
+package tests;
+
+import cpp.Scratch;
+import utest.Test;
+import utest.Assert;
+
+using haxe.Int64;
+
+class TestScratch extends Test {
+	function test_zeroed_small_alloc() {
+		final size  = 16;
+		final alloc = Scratch.alloc(size);
+
+		Assert.equals(size, alloc.view.length.toInt());
+
+		for (i in 0...size.toInt()) {
+			Assert.equals(0, alloc.view[i]);
+		}
+	}
+
+	function test_zeroed_large_alloc() {
+		final size  = 100_000;
+		final alloc = Scratch.alloc(size);
+
+		Assert.equals(size, alloc.view.length.toInt());
+
+		for (i in 0...size.toInt()) {
+			Assert.equals(0, alloc.view[i]);
+		}
+	}
+
+	function test_contents_wiped() {
+		{
+			final size  = 16;
+			final alloc = Scratch.alloc(size);
+
+			Assert.equals(size, alloc.view.length.toInt());
+
+			alloc.view.fill(7);
+		}
+
+		{
+			final size  = 16;
+			final alloc = Scratch.alloc(size);
+
+			Assert.equals(size, alloc.view.length.toInt());
+
+			for (i in 0...size.toInt()) {
+				Assert.equals(0, alloc.view[i]);
+			}
+		}
+	}
+}

--- a/toolchain/haxe-target-threads.xml
+++ b/toolchain/haxe-target-threads.xml
@@ -1,0 +1,30 @@
+﻿<xml>
+  <depend name="${HXCPP}/src/hx/thread/ThreadImpl.hpp"/>
+
+  <file name="src/hx/thread/RecursiveMutex.cpp"/>
+  <file name="src/hx/thread/ConditionVariable.cpp"/>
+  <file name="src/hx/thread/ThreadImpl.cpp"/>
+  <file name="src/hx/thread/ThreadLocal.cpp"/>
+  <file name="src/hx/thread/Scratch.cpp"/>
+
+  <section if="windows">
+    <file name="src/hx/thread/CountingSemaphore.win32.cpp"/>
+    <file name="src/hx/thread/ThreadImpl.win32.cpp"/>
+  </section>
+
+  <section if="apple">
+    <file name="src/hx/thread/CountingSemaphore.apple.cpp"/>
+    <file name="src/hx/thread/ThreadImpl.noop.cpp"/>
+  </section>
+
+  <section if="linux||android">
+    <file name="src/hx/thread/CountingSemaphore.posix.cpp"/>
+    <file name="src/hx/thread/ThreadImpl.noop.cpp"/>
+  </section>
+
+  <section unless="windows||apple||linux||android">
+    <file name="src/hx/thread/CountingSemaphore.unsupported.cpp"/>
+    <file name="src/hx/thread/ThreadImpl.noop.cpp"/>
+  </section>
+
+</xml>

--- a/toolchain/haxe-target.xml
+++ b/toolchain/haxe-target.xml
@@ -213,27 +213,33 @@
   <file name = "src/cpp/encoding/Utf8.cpp"/>
   <file name = "src/cpp/encoding/Utf16.cpp"/>
 
-  <file name="src/hx/thread/RecursiveMutex.cpp"/>
-  <file name="src/hx/thread/ConditionVariable.cpp"/>
-  <file name="src/hx/thread/ThreadImpl.cpp"/>
-  <file name="src/hx/thread/ThreadLocal.cpp"/>
-  <file name="src/hx/thread/Scratch.cpp"/>
-  
-  <section if="windows">
-    <file name="src/hx/thread/CountingSemaphore.win32.cpp"/>
-    <file name="src/hx/thread/ThreadImpl.win32.cpp"/>
+  <section unless="HXCPP_THREAD_XML">
+    <file name="src/hx/thread/RecursiveMutex.cpp"/>
+    <file name="src/hx/thread/ConditionVariable.cpp"/>
+    <file name="src/hx/thread/ThreadImpl.cpp"/>
+    <file name="src/hx/thread/ThreadLocal.cpp"/>
+    <file name="src/hx/thread/Scratch.cpp"/>
+
+    <section if="windows">
+      <file name="src/hx/thread/CountingSemaphore.win32.cpp"/>
+      <file name="src/hx/thread/ThreadImpl.win32.cpp"/>
+    </section>
+    <section unless="windows">
+      <file name="src/hx/thread/ThreadImpl.noop.cpp"/>
+    </section>
+    <section if="apple">
+      <file name="src/hx/thread/CountingSemaphore.apple.cpp"/>
+    </section>
+    <section if="linux||android">
+      <file name="src/hx/thread/CountingSemaphore.posix.cpp"/>
+    </section>
+    <section unless="windows||apple||linux||android">
+      <file name="src/hx/thread/CountingSemaphore.unsupported.cpp"/>
+    </section>
   </section>
-  <section unless="windows">
-    <file name="src/hx/thread/ThreadImpl.noop.cpp"/>
-  </section>
-  <section if="apple">
-    <file name="src/hx/thread/CountingSemaphore.apple.cpp"/>
-  </section>
-  <section if="linux||android">
-    <file name="src/hx/thread/CountingSemaphore.posix.cpp"/>
-  </section>
-  <section unless="windows||apple||linux||android">
-    <file name="src/hx/thread/CountingSemaphore.unsupported.cpp"/>
+
+  <section if="HXCPP_THREAD_XML">
+    <include name="${HXCPP_THREAD_XML}"/>
   </section>
 
   <addTwice if="linux||android" />

--- a/toolchain/haxe-target.xml
+++ b/toolchain/haxe-target.xml
@@ -8,6 +8,7 @@
 
 <!-- Use value from Build.xml file unless one is specified from the haxe defines -->
 <set name="hxcpp_api_level" value="${HXCPP_API_LEVEL}" unless="hxcpp_api_level" if="HXCPP_API_LEVEL"  />
+<set name="HXCPP_THREAD_XML" value="${HXCPP}/toolchain/haxe-target-threads.xml" unless="HXCPP_THREAD_XML"/>
 
 <!-- You can override the exes an "exe" section on your own .hxcpp_config -->
 <!-- You can use replace="1" to change the compiler, or omit to add flags -->
@@ -213,34 +214,7 @@
   <file name = "src/cpp/encoding/Utf8.cpp"/>
   <file name = "src/cpp/encoding/Utf16.cpp"/>
 
-  <section unless="HXCPP_THREAD_XML">
-    <file name="src/hx/thread/RecursiveMutex.cpp"/>
-    <file name="src/hx/thread/ConditionVariable.cpp"/>
-    <file name="src/hx/thread/ThreadImpl.cpp"/>
-    <file name="src/hx/thread/ThreadLocal.cpp"/>
-    <file name="src/hx/thread/Scratch.cpp"/>
-
-    <section if="windows">
-      <file name="src/hx/thread/CountingSemaphore.win32.cpp"/>
-      <file name="src/hx/thread/ThreadImpl.win32.cpp"/>
-    </section>
-    <section unless="windows">
-      <file name="src/hx/thread/ThreadImpl.noop.cpp"/>
-    </section>
-    <section if="apple">
-      <file name="src/hx/thread/CountingSemaphore.apple.cpp"/>
-    </section>
-    <section if="linux||android">
-      <file name="src/hx/thread/CountingSemaphore.posix.cpp"/>
-    </section>
-    <section unless="windows||apple||linux||android">
-      <file name="src/hx/thread/CountingSemaphore.unsupported.cpp"/>
-    </section>
-  </section>
-
-  <section if="HXCPP_THREAD_XML">
-    <include name="${HXCPP_THREAD_XML}"/>
-  </section>
+  <include name="${HXCPP_THREAD_XML}"/>
 
   <addTwice if="linux||android" />
   <cache value="1" project="hxcpp_runtime" asLibrary="true" />


### PR DESCRIPTION
This contains various bits of cleanup related to the c++11 threading changes from the last few merges.

- All the old `__hxcpp_` functions are now excluded unless building for haxe 4 (it's a shame we can't conditionally remove that old Thread.cpp file from the build xml).
- Various internal uses of `HxCreateDetachedThread` have been replaced with a detached `std::thread` so that function can be removed.
- `std::this_thread::sleep_for` is now used internally instead of `#ifdef`'s for various OS'
- You can use the `HXCPP_THREAD_XML` define to point to a build xml file which will provide implementations for the `hx::thread` api instead of the built in one.
- Added a few tests for the `Scratch` type which was added in the typed thread PR.

I've put some more thoughts on the structure of these threading changes in this issue https://github.com/HaxeFoundation/hxcpp/issues/1279