### PR TITLE
Flakey Weak Hash Test and CI Update

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -200,6 +200,8 @@ jobs:
         if: inputs.haxe == 'latest'
         id: haxe_sha
         shell: bash
+        working-directory:
+          ${{env.GITHUB_WORKSPACE}}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -196,12 +196,16 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
+      - name: setup
+        uses: ./.github/workflows/setup
+        with:
+          haxe: ${{ inputs.haxe }}
       - name: Get Haxe commit SHA
         if: inputs.haxe == 'latest'
         id: haxe_sha
         shell: bash
         working-directory:
-          ${{env.GITHUB_WORKSPACE}}
+          ${{github.workspace}}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -225,10 +229,6 @@ jobs:
           repository: HaxeFoundation/haxe
           path: haxe
           ref: ${{ inputs.haxe }}
-      - name: setup
-        uses: ./.github/workflows/setup
-        with:
-          haxe: ${{ inputs.haxe }}
       - name: install haxe libs
         run: haxelib install compile-cpp.hxml --always
         # haxe 4 tests don't build with latest utest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -196,10 +196,24 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
+      - name: Get Haxe commit SHA
+        if: inputs.haxe == 'latest'
+        id: haxe_sha
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          version=$(haxe --version)
+          short_sha=${version##*+}
+          full_sha=$(gh api repos/HaxeFoundation/haxe/commits/$short_sha --jq '.sha')
+          echo "Haxe version: $version"
+          echo "sha=$full_sha" >> "$GITHUB_OUTPUT"
+          echo "Commit SHA: $short_sha, Full SHA: $full_sha"
       - name: checkout haxe (latest)
         if: inputs.haxe == 'latest'
         uses: actions/checkout@v4
         with:
+          ref: ${{ steps.haxe_sha.outputs.sha }}
           repository: HaxeFoundation/haxe
           path: haxe
       - name: checkout haxe (stable)

--- a/test/haxe/TestWeakHash.hx
+++ b/test/haxe/TestWeakHash.hx
@@ -52,21 +52,6 @@ class TestWeakHash extends Test
       Assert.isTrue(oddFound<=2, "Too many odd values retained " + oddFound);
       Assert.isTrue(valid>=expect && valid<expect+2, "WeakHash invalid range "+ expect + "..." + valid + "..." + (expect+2));
    }
-   function deepCheckMap(inDepth:Int, map:WeakMap<WeakObjectData,Int>, expect:Int)
-   {
-      if (inDepth<1)
-         checkMap(map,expect);
-      else
-         deepCheckMap(inDepth-1, map, expect);
-   }
-
-   function deepClearRetained(inRecurse:Int)
-   {
-      if (inRecurse>0)
-         deepClearRetained(inRecurse-1);
-      else
-         retained = [];
-   }
 
    public function test()
    {
@@ -74,7 +59,7 @@ class TestWeakHash extends Test
 
       final sema = new sys.thread.Semaphore(0);
       sys.thread.Thread.create(() -> {
-         map = createMapDeep(20,1000);
+         map = createMap(1000);
          sema.release();
       });
       sema.acquire();

--- a/test/haxe/TestWeakHash.hx
+++ b/test/haxe/TestWeakHash.hx
@@ -78,7 +78,10 @@ class TestWeakHash extends Test
          sema.release();
       });
       sema.acquire();
-      
+
+      // Give the thread enough time to exit and unregister itself from the GC
+      Sys.sleep(1);
+
       cpp.vm.Gc.run(true);
       deepCheckMap(10,map,500);
       deepClearRetained(10);

--- a/test/haxe/TestWeakHash.hx
+++ b/test/haxe/TestWeakHash.hx
@@ -70,7 +70,15 @@ class TestWeakHash extends Test
 
    public function test()
    {
-      final map = createMapDeep(20,1000);
+      var map : WeakMap<WeakObjectData,Int> = null;
+
+      final sema = new sys.thread.Semaphore(0);
+      sys.thread.Thread.create(() -> {
+         map = createMapDeep(20,1000);
+         sema.release();
+      });
+      sema.acquire();
+      
       cpp.vm.Gc.run(true);
       deepCheckMap(10,map,500);
       deepClearRetained(10);

--- a/test/haxe/TestWeakHash.hx
+++ b/test/haxe/TestWeakHash.hx
@@ -83,10 +83,38 @@ class TestWeakHash extends Test
       Sys.sleep(1);
 
       cpp.vm.Gc.run(true);
-      deepCheckMap(10,map,500);
-      deepClearRetained(10);
+
+      final sema = new sys.thread.Semaphore(0);
+      sys.thread.Thread.create(() -> {
+         checkMap(map,500);
+         sema.release();
+      });
+      sema.acquire();
+
+      // Give the thread enough time to exit and unregister itself from the GC
+      Sys.sleep(1);
+
+      final sema = new sys.thread.Semaphore(0);
+      sys.thread.Thread.create(() -> {
+         retained = [];
+         sema.release();
+      });
+      sema.acquire();
+
+      // Give the thread enough time to exit and unregister itself from the GC
+      Sys.sleep(1);
+
       cpp.vm.Gc.run(true);
-      checkMap(map,0);
+
+      final sema = new sys.thread.Semaphore(0);
+      sys.thread.Thread.create(() -> {
+         checkMap(map,0);
+         sema.release();
+      });
+      sema.acquire();
+
+      // Give the thread enough time to exit and unregister itself from the GC
+      Sys.sleep(1);
       
       Assert.pass();
    }


### PR DESCRIPTION
Another VS/MSVC release, another failing GC test due to new optimisations. The weak hash tests were using a "create a really deep call stack" trick to try and prevent compilers optimising away function calls which would then cause GC objects to be visible on the stack and prevented from being collected.

Other tests were doing similar things and I switched those to have the objects be created on a thread after MSVC could work around that, I've now done the same thing with the weak hash tests to get it passing again.

I've also included a CI fix to make sure for nightly haxe it downloads the test suite for the exact nightly being used as opposed to the latest commit. I would have put this as a separate merge but the CI will fail without it.