### PR TITLE
Use fallback ThreadImpl for mingw

### DIFF
--- a/toolchain/haxe-target-threads.xml
+++ b/toolchain/haxe-target-threads.xml
@@ -9,7 +9,8 @@
 
   <section if="windows">
     <file name="src/hx/thread/CountingSemaphore.win32.cpp"/>
-    <file name="src/hx/thread/ThreadImpl.win32.cpp"/>
+    <file name="src/hx/thread/ThreadImpl.win32.cpp" unless="mingw" />
+    <file name="src/hx/thread/ThreadImpl.noop.cpp" if="mingw" />
   </section>
 
   <section if="apple">

--- a/toolchain/haxe-target.xml
+++ b/toolchain/haxe-target.xml
@@ -172,7 +172,6 @@
   <depend name="${HXCPP}/src/hx/Unicase.h"/>
   <depend name="${HXCPP}/src/hx/gc/GcRegCapture.h"/>
   <depend name="${HXCPP}/src/hx/thread/ThreadImpl.hpp"/>
-  <compilerflag value="-D_CRT_SECURE_NO_DEPRECATE"/>
 
   <compilerflag value="-DHX_UNDEFINE_H" />
 


### PR DESCRIPTION
Possibly a regression from: #1336.

Mingw is has a pthread handle as `std::thread::native_handle_type` so it cannot be used in APIs that expect `HANDLE`:
```
Error: /.../hxcpp/src/hx/thread/ThreadImpl.win32.cpp: In member function ‘virtual String hx::thread::ThreadImpl_obj::getName()’:
/.../hxcpp/src/hx/thread/ThreadImpl.win32.cpp:14:52: error: invalid conversion from ‘std::thread::native_handle_type’ {aka ‘long long unsigned int’} to ‘HANDLE’ {aka ‘void*’} [-fpermissive]
   14 |         auto result = GetThreadDescription(native->handle, &buffer);
      |                                            ~~~~~~~~^~~~~~
      |                                                    |
      |                                                    std::thread::native_handle_type {aka long long unsigned int}
In file included from /usr/x86_64-w64-mingw32/include/winbase.h:29,
                 from /usr/x86_64-w64-mingw32/include/windows.h:70,
                 from /.../hxcpp/src/hx/thread/ThreadImpl.win32.cpp:2:
/usr/x86_64-w64-mingw32/include/processthreadsapi.h:367:58: note: initializing argument 1 of ‘HRESULT GetThreadDescription(HANDLE, WCHAR**)’
  367 |   WINBASEAPI HRESULT WINAPI GetThreadDescription (HANDLE hThread, PWSTR *ppszThreadDescription);
      |                                                   ~~~~~~~^~~~~~~
/.../hxcpp/src/hx/thread/ThreadImpl.win32.cpp: In member function ‘virtual void hx::thread::ThreadImpl_obj::setName(const String&)’:
/.../hxcpp/src/hx/thread/ThreadImpl.win32.cpp:39:52: error: invalid conversion from ‘std::thread::native_handle_type’ {aka ‘long long unsigned int’} to ‘HANDLE’ {aka ‘void*’} [-fpermissive]
   39 |         auto result = SetThreadDescription(native->handle, name.wchar_str(&buffer));
      |                                            ~~~~~~~~^~~~~~
      |                                                    |
      |                                                    std::thread::native_handle_type {aka long long unsigned int}
/usr/x86_64-w64-mingw32/include/processthreadsapi.h:366:58: note: initializing argument 1 of ‘HRESULT SetThreadDescription(HANDLE, PCWSTR)’
  366 |   WINBASEAPI HRESULT WINAPI SetThreadDescription (HANDLE hThread, PCWSTR lpThreadDescription);
      |                                                   ~~~~~~~^~~~~~~
/.../hxcpp/src/hx/thread/ThreadImpl.win32.cpp: In constructor ‘hx::thread::ThreadImpl_obj::Native::Native()’:
/.../hxcpp/src/hx/thread/ThreadImpl.win32.cpp:55:81: error: invalid conversion from ‘HANDLE’ {aka ‘void*’} to ‘std::thread::native_handle_type’ {aka ‘long long unsigned int’} [-fpermissive]
   55 | hx::thread::ThreadImpl_obj::Native::Native() : thread(), handle(GetCurrentThread()) {}
      |                                                                 ~~~~~~~~~~~~~~~~^~
      |                                                                                 |
      |                                                                                 HANDLE {aka void*}
```