### PR TITLE
Support for separate Linux ARM architectures

### DIFF
--- a/hxcpp/Builder.hx
+++ b/hxcpp/Builder.hx
@@ -128,6 +128,8 @@ class Builder
                   if (wantLinux32())
                      validArchs.set("m32", ["-D"+target, "-DHXCPP_M32"].concat(staticFlags) );
                   validArchs.set("m64", ["-D"+target, "-DHXCPP_M64"].concat(staticFlags) );
+                  validArchs.set("armv7", ["-D"+target, "-DHXCPP_ARMV7"].concat(staticFlags) );
+                  validArchs.set("arm64", ["-D"+target, "-DHXCPP_ARM64"].concat(staticFlags) );
 
                case "mac":
                   if (wantMac32())

--- a/src/hx/Lib.cpp
+++ b/src/hx/Lib.cpp
@@ -431,7 +431,11 @@ String __hxcpp_get_bin_dir()
 #elif defined(APPLETVOS)
     HX_CSTRING("AppleTVOS");
 #else
-  #ifdef HXCPP_M64
+  #ifdef HXCPP_ARM64
+    HX_CSTRING("LinuxArm64");
+  #elif defined(HXCPP_ARMV7)
+    HX_CSTRING("LinuxArm");
+  #elif defined(HXCPP_M64)
     HX_CSTRING("Linux64");
   #else
     HX_CSTRING("Linux");
@@ -454,7 +458,7 @@ String __hxcpp_get_dll_extension()
     HX_CSTRING(".sim.dylib");
 #elif defined(__APPLE__)
     HX_CSTRING(".dylib");
-#elif defined(ANDROID) || defined(GPH) || defined(WEBOS)  || defined(BLACKBERRY) || defined(__EMSCRIPTEN__) || defined(TIZEN)
+#elif defined(ANDROID) || defined(GPH) || defined(WEBOS) || defined(BLACKBERRY) || defined(__EMSCRIPTEN__) || defined(TIZEN)
     HX_CSTRING(".so");
 #else
     HX_CSTRING(".dso");

--- a/toolchain/linux-toolchain.xml
+++ b/toolchain/linux-toolchain.xml
@@ -30,8 +30,8 @@
 <set name="noM32" value="1" if="HXCPP_NO_M32" />
 <set name="noM32" value="1" if="HXCPP_M64" />
 <set name="noM32" value="1" if="rpi" />
-<set name="noM32" value="1" if="HXCPP_ARM64" />
-<set name="noM64" value="1" if="HXCPP_ARM64" />
+<set name="noM32" value="1" if="HXCPP_ARM64 || HXCPP_ARMV7" />
+<set name="noM64" value="1" if="HXCPP_ARM64 || HXCPP_ARMV7" />
 
 <compiler id="linux" exe="g++" if="linux">
   <exe name="${CXX}" if="CXX" />

--- a/tools/hxcpp/BuildTool.hx
+++ b/tools/hxcpp/BuildTool.hx
@@ -66,6 +66,7 @@ class BuildTool
    var mNvccLinkFlags:Array<String>;
    var mDirtyList:Array<String>;
    var arm64:Bool;
+   var armv7:Bool;
    var m64:Bool;
    var m32:Bool;
    var defaultCStandard:Null<Int>;
@@ -138,8 +139,9 @@ class BuildTool
       m64 = mDefines.exists("HXCPP_M64");
       m32 = mDefines.exists("HXCPP_M32") || mDefines.exists("HXCPP_X86");
       arm64 = mDefines.exists("HXCPP_ARM64");
-      var otherArmArchitecture = mDefines.exists("HXCPP_ARMV6") || mDefines.exists("HXCPP_ARMV7") || mDefines.exists("HXCPP_ARMV7S");
-      if (m64==m32 && !arm64 && !otherArmArchitecture)
+      armv7 = mDefines.exists("HXCPP_ARMV7");
+      var otherArmArchitecture = mDefines.exists("HXCPP_ARMV6") || mDefines.exists("HXCPP_ARMV7S");
+      if (m64==m32 && !arm64 && !armv7 && !otherArmArchitecture)
       {
          var arch = mDefines.get("HXCPP_ARCH");
          if (arch!=null)
@@ -147,6 +149,7 @@ class BuildTool
             m64 = arch=="x86_64";
             m32 = arch=="x86";
             arm64 = arch=="arm64";
+            armv7 = arch=="armv7";
          }
          else if (mDefines.exists("android"))
          {
@@ -160,6 +163,7 @@ class BuildTool
             m64 = hostArch=="m64";
             m32 = hostArch=="m32";
             arm64 = hostArch=="arm64";
+            armv7 = hostArch=="armv7";
          }
 
          mDefines.remove(m32 ? "HXCPP_M64" : "HXCPP_M32");
@@ -2145,7 +2149,7 @@ class BuildTool
             defines.set("toolchain","linux");
             defines.set("linux","linux");
 
-            if (defines.exists("HXCPP_LINUX_ARMV7"))
+            if (armv7 || defines.exists("HXCPP_LINUX_ARMV7"))
             {
                defines.set("noM32","1");
                defines.set("noM64","1");
@@ -2159,7 +2163,7 @@ class BuildTool
                defines.set("HXCPP_ARM64","1");
                m64 = true;
             }
-            defines.set("BINDIR", arm64 ? "LinuxArm64" : m64 ? "Linux64":"Linux");
+            defines.set("BINDIR", arm64 ? "LinuxArm64" : armv7 ? "LinuxArm" : m64 ? "Linux64" : "Linux");
          }
       }
       else if ( (new EReg("mac","i")).match(os) )


### PR DESCRIPTION
Redo of Lily's pr https://github.com/HaxeFoundation/hxcpp/pull/1159

You can finally use the arm architecture flags to able to compile on linux arm instead of only running it on different architectures to able to compile.

It seems lime has some armv7 linux support, but not that much because it's still supports arm64.