### PR TITLE
Fix weak-key hash ephemeron semantics

### DIFF
--- a/src/hx/Hash.h
+++ b/src/hx/Hash.h
@@ -270,6 +270,7 @@ struct HashRoot : public Object
     HX_IS_INSTANCE_OF enum { _hx_ClassId = hx::clsIdHash };
 
    virtual void updateAfterGc() = 0;
+   virtual bool markWeakValues(MarkContext *__inCtx) = 0;
 
    inline int getSize() { return size; }
 };
@@ -351,6 +352,46 @@ struct Hash : public HashBase< typename ELEMENT::Key >
    bool TIsWeakRefValid(T &) { return true; }
    bool TIsWeakRefValid(Dynamic &key) { return IsWeakRefValid(key.mPtr); }
    bool TIsWeakRefValid(String &key) { return IsWeakRefValid(key.raw_ptr()); }
+
+   template<typename T>
+   bool TMarkWeakValue(T &, MarkContext *) { return false; }
+   bool TMarkWeakValue(Dynamic &inValue, MarkContext *__inCtx)
+   {
+      hx::Object *value = inValue.mPtr;
+      if (!value || (((unsigned int *)value)[-1] & hx::gPrevMarkIdMask))
+         return false;
+
+      HX_MARK_MEMBER(inValue);
+      return true;
+   }
+   bool TMarkWeakValue(String &inValue, MarkContext *__inCtx)
+   {
+      const HX_CHAR *value = inValue.raw_ptr();
+      if (!value || (((unsigned int *)value)[-1] & hx::gPrevMarkIdMask))
+         return false;
+
+      HX_MARK_MEMBER(inValue);
+      return true;
+   }
+
+   bool markWeakValues(MarkContext *__inCtx) HXCPP_OVERRIDE
+   {
+      if (!Element::WeakKeys || !Element::ManageKeys)
+         return false;
+
+      bool marked = false;
+      for(int b=0;b<bucketCount;b++)
+      {
+         Element *element = bucket[b];
+         while(element)
+         {
+            if (TIsWeakRefValid(element->key))
+               marked = TMarkWeakValue(element->value, __inCtx) || marked;
+            element = element->next;
+         }
+      }
+      return marked;
+   }
 
 
    void updateAfterGc() HXCPP_OVERRIDE
@@ -787,8 +828,8 @@ struct Hash : public HashBase< typename ELEMENT::Key >
          if (!Hash::Element::WeakKeys)
          {
             HX_MARK_MEMBER(inElem->key);
+            HX_MARK_MEMBER(inElem->value);
          }
-         HX_MARK_MEMBER(inElem->value);
       }
    };
 

--- a/src/hx/gc/Immix.cpp
+++ b/src/hx/gc/Immix.cpp
@@ -4772,6 +4772,32 @@ public:
 
       hx::FindZombies(mMarker);
 
+      // Weak-key hashes are ephemerons: a value is reachable only when both
+      // the hash and its key are reachable. Values marked here may in turn
+      // make keys in other weak hashes reachable, so iterate to a fixed point.
+      bool markedWeakValue;
+      do
+      {
+         markedWeakValue = false;
+         mMarker.init();
+         for(int i=0;i<hx::sWeakHashList.size();i++)
+         {
+            hx::HashRoot *hash = hx::sWeakHashList[i];
+            if (hx::IsWeakRefValid(hash))
+               markedWeakValue = hash->markWeakValues(&mMarker) || markedWeakValue;
+         }
+         if (markedWeakValue)
+         {
+            #ifdef HX_MULTI_THREAD_MARKING
+            mMarker.releaseJobs();
+            StartThreadJobs(tpjMark, MAX_GC_THREADS, true);
+            #else
+            mMarker.processMarkStack();
+            #endif
+         }
+      }
+      while(markedWeakValue);
+
       hx::RunFinalizers();
 
       #ifdef HXCPP_GC_VERIFY

--- a/test/haxe/TestWeakHash.hx
+++ b/test/haxe/TestWeakHash.hx
@@ -9,6 +9,12 @@ class WeakObjectData
    public function toString() return "Data " + id;
 }
 
+class WeakValueData
+{
+   public var key:WeakObjectData;
+   public function new(inKey:WeakObjectData) key = inKey;
+}
+
 class TestWeakHash extends Test
 {
    var retained:Array<WeakObjectData>;
@@ -102,6 +108,97 @@ class TestWeakHash extends Test
       Sys.sleep(1);
       
       Assert.pass();
+   }
+
+   public function testDeadKeyReleasesValueCycle()
+   {
+      var result:{
+         map:WeakMap<WeakObjectData,WeakValueData>,
+         key:cpp.vm.WeakRef<WeakObjectData>,
+         value:cpp.vm.WeakRef<WeakValueData>
+      } = null;
+
+      final sema = new sys.thread.Semaphore(0);
+      sys.thread.Thread.create(() -> {
+         var map = new WeakMap<WeakObjectData,WeakValueData>();
+         var key = new WeakObjectData(1);
+         var value = new WeakValueData(key);
+         map.set(key,value);
+         result = {
+            map: map,
+            key: new cpp.vm.WeakRef(key),
+            value: new cpp.vm.WeakRef(value)
+         };
+         sema.release();
+      });
+      sema.acquire();
+
+      // Ensure no conservative reference remains on the terminated thread stack.
+      Sys.sleep(1);
+      cpp.vm.Gc.run(true);
+
+      Assert.isNull(result.key.get());
+      Assert.isNull(result.value.get());
+      Assert.isFalse(result.map.keys().hasNext());
+   }
+
+   public function testLiveKeyRetainsValue()
+   {
+      var map:WeakMap<WeakObjectData,WeakValueData> = null;
+      var value:cpp.vm.WeakRef<WeakValueData> = null;
+
+      final sema = new sys.thread.Semaphore(0);
+      sys.thread.Thread.create(() -> {
+         map = new WeakMap<WeakObjectData,WeakValueData>();
+         var key = new WeakObjectData(2);
+         var mapValue = new WeakValueData(key);
+         retained = [key];
+         map.set(key,mapValue);
+         value = new cpp.vm.WeakRef(mapValue);
+         sema.release();
+      });
+      sema.acquire();
+
+      Sys.sleep(1);
+      cpp.vm.Gc.run(true);
+
+      Assert.notNull(value.get());
+      Assert.notNull(map.get(retained[0]));
+   }
+
+   public function testEphemeronsReachFixedPoint()
+   {
+      var maps:{
+         upstream:WeakMap<WeakObjectData,WeakObjectData>,
+         downstream:WeakMap<WeakObjectData,WeakObjectData>
+      } = null;
+      var value:cpp.vm.WeakRef<WeakObjectData> = null;
+
+      final sema = new sys.thread.Semaphore(0);
+      sys.thread.Thread.create(() -> {
+         // Register downstream first so it is visited before upstream. A
+         // single pass would skip it before upstream makes its key reachable.
+         var downstream = new WeakMap<WeakObjectData,WeakObjectData>();
+         var upstream = new WeakMap<WeakObjectData,WeakObjectData>();
+         var rootKey = new WeakObjectData(3);
+         var linkKey = new WeakObjectData(4);
+         var finalValue = new WeakObjectData(5);
+         downstream.set(linkKey,finalValue);
+         upstream.set(rootKey,linkKey);
+         retained = [rootKey];
+         maps = {upstream: upstream, downstream: downstream};
+         value = new cpp.vm.WeakRef(finalValue);
+         sema.release();
+      });
+      sema.acquire();
+
+      Sys.sleep(1);
+      cpp.vm.Gc.run(true);
+
+      var linkKey = maps.upstream.get(retained[0]);
+      Assert.notNull(linkKey);
+      Assert.notNull(maps.downstream.get(linkKey));
+      Assert.notNull(value.get());
    }
 
 }


### PR DESCRIPTION
## Problem

hxcpp currently marks every value stored in a weak-key hash during the normal
marking phase, regardless of whether its key is still reachable.

This does not implement ephemeron semantics. In particular, if a value directly
or indirectly references its own key, the following cycle becomes permanently
reachable:

```text
WeakMap -> value -> weak key
```

The key is consequently never removed from the map, and the complete object
graph remains alive indefinitely. This can cause substantial heap growth and
increasing GC pause times in long-running applications.

## Fix

This change treats weak-key hashes as ephemerons:

- weak keys and their values are omitted from ordinary hash traversal;
- after the strongly reachable graph and zombies have been marked, live weak
  hashes are scanned;
- a value is marked only when its corresponding key is reachable;
- newly marked values are processed using the regular parallel marker;
- weak hashes are scanned to a fixed point because a value may make a key in
  another weak hash reachable.

Dead weak keys are then removed by the existing post-GC cleanup.

## Tests

The hxcpp native test suite now covers:

- collecting a dead key/value cycle after the first full GC;
- retaining a value while its key remains alive;
- propagating reachability through a chain of ephemerons until a fixed point.

## Minimal reproduction

[HxcppWeakMapEphemeronRepro.zip](https://github.com/user-attachments/files/30377241/HxcppWeakMapEphemeronRepro.zip)
It creates 4,000 unreachable keys.
Each mapped value references its key and owns a 64 KiB payload. One additional
key is intentionally retained as a correctness check.

Before this change:

```text
baselineMiB=0.1
afterFirstGcMiB=250.8 entries=4001
afterSecondGcMiB=250.8 entries=4001
retainedDeltaMiB=250.7
FAIL: dead weak keys and their values are still retained
```

After this change:

```text
baselineMiB=0.1
afterFirstGcMiB=0.2 entries=1
afterSecondGcMiB=0.2 entries=1
retainedDeltaMiB=0.1
PASS: only the live key and its value remain
```

## Real-world validation

The issue was originally identified in a long-running Haxe/OpenFL application.
In comparable six-minute sessions, this change produced the following results:

| Metric | Before | After |
|---|---:|---:|
| Peak live hxcpp heap | 1,130 MiB | 840 MiB |
| Final live hxcpp heap | 1,000 MiB | 687 MiB |
| Peak RSS | 2,393 MiB | 1,837 MiB |
| Median GC pause | 95.7 ms | 51.9 ms |
| p95 GC pause | 131.2 ms | 88.5 ms |
| Total instrumented GC time | 3,455 ms | 2,944 ms |

Heap censuses also showed that object graphs from completed game levels were
released instead of accumulating.