### PR TITLE
Add support for LLVM-based MSVC builds

### DIFF
--- a/docs/build_xml/Defines.md
+++ b/docs/build_xml/Defines.md
@@ -91,3 +91,5 @@ Defines affecting target architecture.
 | *HXCPP_MINGW*           | Compile for windows using mingw |
 | *NO_AUTO_MSVC*          | Do not detect msvc location, use the one already in the executable path |
 | *HXCPP_WINXP_COMPAT*    | Remain compatible with Windows XP. Disables condition variables. No effect on ARM. |
+| *HXCPP_MSVC_LLVM*       | Compile for windows using the LLVM-based MSVC toolchain |
+| *HXCPP_MSVC_ROOT*       | Set the root for MSVC libraries and headers |

--- a/src/hx/libs/regexp/pcre2_sources.xml
+++ b/src/hx/libs/regexp/pcre2_sources.xml
@@ -3,7 +3,7 @@
   <compilerflag value="-DPCRE2_STATIC" />
   <compilerflag value="-DSUPPORT_UNICODE" />
   <compilerflag value="-I${PCRE_DIR}" />
-  <compilerflag value="-std=c99" unless="MSVC_VER" />
+  <compilerflag value="-std=c99" unless="isMsvc" />
 
   <file name="${PCRE_DIR}/pcre2_auto_possess.c" />
   <file name="${PCRE_DIR}/pcre2_chartables.c" />

--- a/toolchain/msvc-toolchain.xml
+++ b/toolchain/msvc-toolchain.xml
@@ -3,7 +3,27 @@
 
 <!-- WINDOWS TOOLS -->
 
+<set name="TOOLS_EXE_SUFFIX" value=".exe" />
 
+<section if="HXCPP_MSVC_LLVM" >
+
+  <set name="CL_EXE" value="clang-cl${TOOLS_EXE_SUFFIX}" />
+  <set name="LINK_EXE" value="lld-link${TOOLS_EXE_SUFFIX}" />
+  <set name="LIB_EXE" value="llvm-lib${TOOLS_EXE_SUFFIX}" />
+  <set name="RC_EXE" value="llvm-rc${TOOLS_EXE_SUFFIX}" />
+  <set name="MT_EXE" value="llvm-mt${TOOLS_EXE_SUFFIX}" />
+
+</section>
+
+<section unless="HXCPP_MSVC_LLVM">
+
+  <set name="CL_EXE" value="cl${TOOLS_EXE_SUFFIX}" />
+  <set name="LINK_EXE" value="link${TOOLS_EXE_SUFFIX}" />
+  <set name="LIB_EXE" value="lib${TOOLS_EXE_SUFFIX}" />
+  <set name="RC_EXE" value="rc${TOOLS_EXE_SUFFIX}" />
+  <set name="MT_EXE" value="mt${TOOLS_EXE_SUFFIX}" />
+
+</section>
 
 <set name="USE_PRECOMPILED_HEADERS" value="msvc" unless="NO_PRECOMPILED_HEADERS" />
 
@@ -52,8 +72,10 @@
 <unset name="HXCPP_FAST_LINK" if="HXCPP_FAST_LINK" unless="MSVC19"/>
 
 <compiler id="MSVC" exe="cl.exe" if="windows">
+  <exe name="${CL_EXE}" />
   <flag value="-nologo"/>
 
+  <pchflag value="/TP" />
 
   <!-- Newer options -->
   <!-- <flag value = "/analyze-" if="MSVC17+" /> -->
@@ -107,18 +129,26 @@
   <flag value="-wd4996"/>
   <outflag value="-Fo"/>
   <ext value=".obj"/>
-  <asmExe value="ml64.exe" if="HXCPP_M64" />
-  <asmExe value="ml.exe" unless="HXCPP_M64" />
+
+  <section if="HXCPP_MSVC_LLVM">
+    <asmExe value="llvm-ml${TOOLS_EXE_SUFFIX}" />
+  </section>
+  <section unless="HXCPP_MSVC_LLVM">
+    <asmExe value="ml64.exe" if="HXCPP_M64" />
+    <asmExe value="ml.exe" unless="HXCPP_M64" />
+  </section>
+
   <objdir value="${MSVC_OBJ_DIR}" />
 
-  <rcexe name="rc.exe" />
+  <rcexe name="${RC_EXE}" />
   <rcext value=".res" />
   <rcflag value="-nologo" />
 
-  <getversion value="cl.exe"/>
+  <getversion value="${CL_EXE}" unless="HXCPP_MSVC_LLVM"/>
 </compiler>
 
 <linker id="dll" exe="link.exe" if="windows">
+  <exe name="${LINK_EXE}" />
   <flag value="-nologo"/>
   <flag value="-machine:${MACHINE}"/>
   <flag value="-dll"/>
@@ -142,6 +172,7 @@
 </linker>
 
 <linker id="exe" exe="link.exe" unless="winrt">
+  <exe name="${LINK_EXE}" />
   <fromfile value="@"/>
   <flag value="-nologo"/>
   <flag value="-machine:${MACHINE}"/>
@@ -166,6 +197,7 @@
 
 
 <manifest exe="mt.exe" >
+  <exe name="${MT_EXE}" />
   <flag value="-nologo"/>
   <flag value="-manifest"/>
   <outPre value="-outputresource:" />
@@ -175,6 +207,7 @@
 
 
 <linker id="exe" exe="link.exe" if="winrt">
+  <exe name="${LINK_EXE}" />
   <fromfile value="@"/>
   <flag value="-nologo"/>
   <flag value="-machine:${MACHINE}"/>
@@ -197,6 +230,7 @@
 </linker>
 
 <linker id="static_link" exe="lib.exe" if="windows">
+  <exe name="${LIB_EXE}" />
   <flag value="-LTCG" if="HXCPP_OPTIMIZE_LINK" unless="debug || HXCPP_LTCG_INCREMENTAL"/>
   <flag value="-LTCG:INCREMENTAL" if="HXCPP_LTCG_INCREMENTAL" unless="debug"/>
   <fromfile value="@"/>

--- a/toolchain/msvc-toolchain.xml
+++ b/toolchain/msvc-toolchain.xml
@@ -3,7 +3,7 @@
 
 <!-- WINDOWS TOOLS -->
 
-<set name="TOOLS_EXE_SUFFIX" value=".exe" />
+<set name="TOOLS_EXE_SUFFIX" value=".exe" unless="linux_host" />
 
 <section if="HXCPP_MSVC_LLVM" >
 
@@ -74,6 +74,11 @@
 <compiler id="MSVC" exe="cl.exe" if="windows">
   <exe name="${CL_EXE}" />
   <flag value="-nologo"/>
+
+  <section if="HXCPP_MSVC_LLVM HXCPP_MSVC_ROOT">
+    <flag value="-winsysroot" />
+    <flag value="${HXCPP_MSVC_ROOT}" />
+  </section>
 
   <pchflag value="/TP" />
 
@@ -150,6 +155,7 @@
 <linker id="dll" exe="link.exe" if="windows">
   <exe name="${LINK_EXE}" />
   <flag value="-nologo"/>
+  <flag value="-winsysroot:${HXCPP_MSVC_ROOT}" if="HXCPP_MSVC_LLVM HXCPP_MSVC_ROOT" />
   <flag value="-machine:${MACHINE}"/>
   <flag value="-dll"/>
   <flag value="-debug:full" if="HXCPP_DEBUG_LINK" unless="HXCPP_FAST_LINK"/>
@@ -175,6 +181,7 @@
   <exe name="${LINK_EXE}" />
   <fromfile value="@"/>
   <flag value="-nologo"/>
+  <flag value="-winsysroot:${HXCPP_MSVC_ROOT}" if="HXCPP_MSVC_LLVM HXCPP_MSVC_ROOT" />
   <flag value="-machine:${MACHINE}"/>
   <flag value="-debug" if="HXCPP_DEBUG_LINK||HXCPP_PDB_FILE" unless="HXCPP_FAST_LINK"/>
   <flag value="-debug:fastlink" if="HXCPP_FAST_LINK HXCPP_DEBUG_LINK"/>
@@ -199,6 +206,7 @@
 <manifest exe="mt.exe" >
   <exe name="${MT_EXE}" />
   <flag value="-nologo"/>
+  <flag value="-winsysroot:${HXCPP_MSVC_ROOT}" if="HXCPP_MSVC_LLVM HXCPP_MSVC_ROOT" />
   <flag value="-manifest"/>
   <outPre value="-outputresource:" />
   <outPost value=";1" />
@@ -210,6 +218,7 @@
   <exe name="${LINK_EXE}" />
   <fromfile value="@"/>
   <flag value="-nologo"/>
+  <flag value="-winsysroot:${HXCPP_MSVC_ROOT}" if="HXCPP_MSVC_LLVM HXCPP_MSVC_ROOT" />
   <flag value="-machine:${MACHINE}"/>
   <flag value="-debug" if="HXCPP_DEBUG_LINK" unless="HXCPP_FAST_LINK"/>
   <flag value="-debug:fastlink" if="HXCPP_FAST_LINK HXCPP_DEBUG_LINK"/>
@@ -235,6 +244,7 @@
   <flag value="-LTCG:INCREMENTAL" if="HXCPP_LTCG_INCREMENTAL" unless="debug"/>
   <fromfile value="@"/>
   <flag value="-nologo"/>
+  <flag value="-winsysroot:${HXCPP_MSVC_ROOT}" if="HXCPP_MSVC_LLVM HXCPP_MSVC_ROOT" />
   <flag value="-IGNORE:4264" if="winrt" />
   <ext value="${LIBEXT}"/>
   <outflag value="-out:"/>

--- a/tools/hxcpp/BuildTool.hx
+++ b/tools/hxcpp/BuildTool.hx
@@ -2134,9 +2134,14 @@ class BuildTool
          // Cross-compile?
          if(defines.exists("windows"))
          {
-            defines.set("toolchain","mingw");
-            defines.set("mingw", "mingw");
-            defines.set("xcompile","1");
+            if (defines.exists("HXCPP_MSVC_LLVM"))
+               defines.set("toolchain", "msvc");
+            else
+            {
+               defines.set("toolchain","mingw");
+               defines.set("mingw", "mingw");
+            }
+            defines.set("xcompile", "1");
             defines.set("BINDIR", arm64 ? "WindowsArm64" : m64 ? "Windows64":"Windows");
          }
          else

--- a/tools/hxcpp/BuildTool.hx
+++ b/tools/hxcpp/BuildTool.hx
@@ -1525,6 +1525,11 @@ class BuildTool
       return instance.mDefines.get("toolchain")=="msvc";
    }
 
+   public static function isMsvcLlvm()
+   {
+		return isMsvc() && instance.mDefines.exists("HXCPP_MSVC_LLVM");
+   }
+
    public static function isMingw()
    {
       return instance.mDefines.get("toolchain")=="mingw";

--- a/tools/hxcpp/Compiler.hx
+++ b/tools/hxcpp/Compiler.hx
@@ -697,7 +697,7 @@ class Compiler
       mPCH = inPCH;
       createCompilerVersion();
       final regex = ~/clang/i;
-      if (inPCH == null && regex.match(mCompilerVersionString)) {
+      if (inPCH != null && regex.match(mCompilerVersionString) && !BuildTool.isMsvcLlvm()) {
          mPCH = "clang";
       }
       switch (mPCH) {

--- a/tools/hxcpp/Compiler.hx
+++ b/tools/hxcpp/Compiler.hx
@@ -695,7 +695,7 @@ class Compiler
       mPCH = inPCH;
       createCompilerVersion();
       final regex = ~/clang/i;
-      if (inPCH != null && regex.match(mCompilerVersionString)) {
+      if (inPCH == null && regex.match(mCompilerVersionString)) {
          mPCH = "clang";
       }
       switch (mPCH) {

--- a/tools/hxcpp/Compiler.hx
+++ b/tools/hxcpp/Compiler.hx
@@ -640,8 +640,10 @@ class Compiler
       if (mPCH == "msvc")
       {
          args.push( mPCHCreate + header + ".h" );
-         var symbol = "link" + Md5.encode( PathManager.combine(dir, file + mExt) );
-         args.push( "-Yl" + symbol  );
+         if (!BuildTool.isMsvcLlvm()) {
+            var symbol = "link" + Md5.encode( PathManager.combine(dir, file + mExt) );
+            args.push( "-Yl" + symbol  );
+         }
 
          // Create a temp file for including ...
          var tmp_cpp = dir + "/" + file + ".cpp";

--- a/tools/hxcpp/Setup.hx
+++ b/tools/hxcpp/Setup.hx
@@ -781,7 +781,8 @@ class Setup
    public static function setupMSVC(ioDefines:Hash<String>, in64:Bool, inArm64, isWinRT:Bool)
    {
       var detectMsvc = !ioDefines.exists("NO_AUTO_MSVC") &&
-                       !ioDefines.exists("HXCPP_MSVC_CUSTOM");
+                       !ioDefines.exists("HXCPP_MSVC_CUSTOM") &&
+                       !ioDefines.exists("HXCPP_MSVC_ROOT");
 
       if (ioDefines.exists("HXCPP_MSVC_VER"))
       {

--- a/tools/hxcpp/Setup.hx
+++ b/tools/hxcpp/Setup.hx
@@ -901,6 +901,8 @@ class Setup
          }
       }
 
+      if (ioDefines.exists("HXCPP_MSVC_LLVM")) return;
+
       try
       {
          var proc = new Process("cl.exe",[]);


### PR DESCRIPTION
This adds a `-D HXCPP_MSVC_LLVM` flag which allows creating msvc builds using `clang-cl` instead of `cl`.

This is useful for native windows builds, however, it also allows cross-compiling msvc binaries from linux by passing `-D HXCPP_MSVC_ROOT=/path/to/msvc-root` (msvc libs/headers can be downloaded using `xwin` for example).