### PR TITLE
[carpet sweep] Add big blocks define

### DIFF
--- a/test/haxe/compile.hxml
+++ b/test/haxe/compile.hxml
@@ -1,5 +1,6 @@
 -m TestMain
 -r TestMain.hx
 -D HXCPP_GC_GENERATIONAL
+-D HXCPP_GC_BIG_BLOCKS
 -L utest
 --cpp bin


### PR DESCRIPTION
Add the big blocks define to avoid the occasional memory exhaustion error on the haxe tests.

https://github.com/HaxeFoundation/hxcpp/issues/1289

I'm not sure if this is the actual solution or a bodge, but the CI will be green I guess...