### PR TITLE
Avoid disabling warnings globally

### DIFF
--- a/include/Array.h
+++ b/include/Array.h
@@ -395,9 +395,18 @@ public:
 
 #if (HXCPP_API_LEVEL < 500) || defined(CPPIA_JIT)
 
+   #if defined(__GNUC__) || defined(__clang__)
+      #pragma GCC diagnostic push
+      #pragma GCC diagnostic ignored "-Winvalid-offsetof"
+   #endif
+
    static inline int baseOffset() { return (int)offsetof(ArrayBase,mBase); }
    static inline int allocOffset() { return (int)offsetof(ArrayBase,mAlloc); }
    static inline int lengthOffset() { return (int)offsetof(ArrayBase,length); }
+
+   #if defined(__GNUC__) || defined(__clang__)
+      #pragma GCC diagnostic pop
+   #endif
 
 #endif
 

--- a/include/Array.h
+++ b/include/Array.h
@@ -393,9 +393,13 @@ public:
 
    mutable int length;
 
+#if (HXCPP_API_LEVEL < 500) || defined(CPPIA_JIT)
+
    static inline int baseOffset() { return (int)offsetof(ArrayBase,mBase); }
    static inline int allocOffset() { return (int)offsetof(ArrayBase,mAlloc); }
    static inline int lengthOffset() { return (int)offsetof(ArrayBase,length); }
+
+#endif
 
 protected:
    mutable int mAlloc;

--- a/src/hx/CFFI.cpp
+++ b/src/hx/CFFI.cpp
@@ -1007,6 +1007,11 @@ value query_root(gcroot) { return 0; }
 void destroy_root(gcroot) { }
 
 
+#if defined(__clang__)
+#  pragma clang diagnostic push
+#  pragma clang diagnostic ignored "-Wreturn-type-c-linkage"
+#endif
+
 String alloc_hxs_wchar(const wchar_t *ptr,int size)
 {
    return String::create(ptr,size);
@@ -1021,6 +1026,10 @@ String alloc_hxs_utf8(const char *ptr,int size)
 {
    return String::create(ptr,size);
 }
+
+#if defined(__clang__)
+#  pragma clang diagnostic pop
+#endif
 
 const char * hxs_utf8(const String &string,hx::IStringAlloc *alloc)
 {

--- a/toolchain/android-toolchain-clang.xml
+++ b/toolchain/android-toolchain-clang.xml
@@ -72,7 +72,6 @@
   <flag value="-O2" unless="debug"/>
   
   <!-- Warning Supression -->
-  <flag value="-Wno-invalid-offsetof" />
   <flag value="-Wno-return-type-c-linkage" />
   <flag value="-Wno-parentheses" />
   <flag value="-Wno-inconsistent-missing-override" unless="HXCPP_WARN_INCONSISTENT_OVERRIDE" />

--- a/toolchain/android-toolchain-clang.xml
+++ b/toolchain/android-toolchain-clang.xml
@@ -72,7 +72,6 @@
   <flag value="-O2" unless="debug"/>
   
   <!-- Warning Supression -->
-  <flag value="-Wno-return-type-c-linkage" />
   <flag value="-Wno-parentheses" />
   <flag value="-Wno-inconsistent-missing-override" unless="HXCPP_WARN_INCONSISTENT_OVERRIDE" />
   

--- a/toolchain/android-toolchain-gcc.xml
+++ b/toolchain/android-toolchain-gcc.xml
@@ -89,7 +89,6 @@
   <flag value="-fstack-protector"/>
   <flag value="-fno-short-enums"/>
   <flag value="-Wno-overflow" />
-  <cppflag value="-Wno-invalid-offsetof" />
   <cppflag value="-frtti"/>
   <flag value="-D_LINUX_STDDEF_H "/> <!-- Avoid compiler including 2 version of file -->
   <flag value="-Wno-psabi" />

--- a/toolchain/appletvos-toolchain.xml
+++ b/toolchain/appletvos-toolchain.xml
@@ -37,7 +37,6 @@
   <flag value="-Wno-null-dereference" unless="HXCPP_GCC"/>
   <flag value="-Wno-unused-value" />
   <flag value="-Wno-overflow" />
-  <cppflag value="-Wno-invalid-offsetof" />
   <flag value="-Wno-bool-conversion" unless="HXCPP_GCC"/>
   <!-- Removed for iOS 8 -->
   <!-- <flag value="-fvisibility=hidden"/> -->

--- a/toolchain/appletvsim-toolchain.xml
+++ b/toolchain/appletvsim-toolchain.xml
@@ -27,7 +27,6 @@
   <flag value="-Wno-trigraphs"/>
   <flag value="-fno-stack-protector"/>
   <flag value="-Wno-overflow" />
-  <cppflag value="-Wno-invalid-offsetof" />
   <flag value="-fpascal-strings"/>
   <flag value="-fasm-blocks"/>
   <flag value="-Wreturn-type"/>

--- a/toolchain/common-defines.xml
+++ b/toolchain/common-defines.xml
@@ -52,6 +52,5 @@
  <flag value='-DHXCPP_TRACY_ON_DEMAND' if="HXCPP_TRACY_ON_DEMAND" tag="haxe"/>
  <flag value='-DHXCPP_TRACY_INCLUDE_CALLSTACKS' if="HXCPP_TRACY_INCLUDE_CALLSTACKS" tag="haxe"/>
 
- <mmflag value='-Wno-invalid-offsetof' />
  <mmflag value='-Wno-format-security' />
 </xml>

--- a/toolchain/emscripten-toolchain.xml
+++ b/toolchain/emscripten-toolchain.xml
@@ -102,7 +102,6 @@
   <flag value="-DHXCPP_MULTI_THREADED" if="HXCPP_MULTI_THREADED"/>
   <flag value="-DHXCPP_BIG_ENDIAN" if="HXCPP_BIG_ENDIAN"/>
   <flag value="-Wno-overflow" />
-  <cppflag value="-Wno-invalid-offsetof" />
   <cppflag value="-Wno-return-type-c-linkage" />
   <flag value="-Wno-parentheses" />
   <flag value="-Wno-unknown-warning-option" />

--- a/toolchain/emscripten-toolchain.xml
+++ b/toolchain/emscripten-toolchain.xml
@@ -102,7 +102,6 @@
   <flag value="-DHXCPP_MULTI_THREADED" if="HXCPP_MULTI_THREADED"/>
   <flag value="-DHXCPP_BIG_ENDIAN" if="HXCPP_BIG_ENDIAN"/>
   <flag value="-Wno-overflow" />
-  <cppflag value="-Wno-return-type-c-linkage" />
   <flag value="-Wno-parentheses" />
   <flag value="-Wno-unknown-warning-option" />
   <flag value="-Wno-null-dereference" />

--- a/toolchain/gcw0-toolchain.xml
+++ b/toolchain/gcw0-toolchain.xml
@@ -30,7 +30,6 @@
 	<flag value="-fPIC"/>
 	<cppflag value="-frtti"/>
 	<cppflag value="-std=c++11" />
-   <cppflag value="-Wno-invalid-offsetof" />
    <flag value="-g" if="HXCPP_DEBUG_LINK"/>
 	<!-- <flag value="-fPIE" /> -->
 	<flag value="--sysroot=${GCW0_PLATFORM}" />

--- a/toolchain/iphoneos-toolchain.xml
+++ b/toolchain/iphoneos-toolchain.xml
@@ -51,8 +51,6 @@
   <flag value="-Wno-unused-value" />
   <flag value="-Wno-overflow" />
   <flag value="-Wno-trigraphs"/>
-  <cppflag value="-Wno-return-type-c-linkage" />
-  <mmflag value="-Wno-return-type-c-linkage" />
   <flag value="-Wno-bool-conversion" unless="HXCPP_GCC"/>
   <!-- Removed for iOS 8 -->
   <!-- <flag value="-fvisibility=hidden"/> -->

--- a/toolchain/iphoneos-toolchain.xml
+++ b/toolchain/iphoneos-toolchain.xml
@@ -51,7 +51,6 @@
   <flag value="-Wno-unused-value" />
   <flag value="-Wno-overflow" />
   <flag value="-Wno-trigraphs"/>
-  <cppflag value="-Wno-invalid-offsetof" />
   <cppflag value="-Wno-return-type-c-linkage" />
   <mmflag value="-Wno-return-type-c-linkage" />
   <flag value="-Wno-bool-conversion" unless="HXCPP_GCC"/>

--- a/toolchain/iphonesim-toolchain.xml
+++ b/toolchain/iphonesim-toolchain.xml
@@ -28,8 +28,6 @@
   <flag value="-Wno-trigraphs"/>
   <flag value="-fno-stack-protector"/>
   <flag value="-Wno-overflow" />
-  <cppflag value="-Wno-return-type-c-linkage" />
-  <mmflag value="-Wno-return-type-c-linkage" />
   <flag value="-fpascal-strings"/>
   <flag value="-fasm-blocks"/>
   <flag value="-Wreturn-type"/>

--- a/toolchain/iphonesim-toolchain.xml
+++ b/toolchain/iphonesim-toolchain.xml
@@ -28,7 +28,6 @@
   <flag value="-Wno-trigraphs"/>
   <flag value="-fno-stack-protector"/>
   <flag value="-Wno-overflow" />
-  <cppflag value="-Wno-invalid-offsetof" />
   <cppflag value="-Wno-return-type-c-linkage" />
   <mmflag value="-Wno-return-type-c-linkage" />
   <flag value="-fpascal-strings"/>

--- a/toolchain/linux-toolchain.xml
+++ b/toolchain/linux-toolchain.xml
@@ -44,7 +44,6 @@
   <flag value="-fpic"/>
   <flag value="-fPIC"/>
   <flag value="-Wno-overflow" />
-  <cppflag value="-Wno-invalid-offsetof" />
   <flag value="-DHX_LINUX"/>
   <flag value="-DRASPBERRYPI=RASPBERRYPI" if="rpi"/>
   <flag value="-DHXCPP_MULTI_THREADED" if="HXCPP_MULTI_THREADED"/>

--- a/toolchain/mac-toolchain.xml
+++ b/toolchain/mac-toolchain.xml
@@ -40,7 +40,6 @@
   <flag value="-Wno-format-extra-args" />
   <flag value="-Wno-overflow" />
   <flag value="-fsanitize=thread" if="HXCPP_THREAD_SANITIZE" />
-  <cppflag value="-Wno-invalid-offsetof" />
   <cppflag value="-Wno-return-type-c-linkage" />
   <mmflag value="-Wno-return-type-c-linkage" />
 

--- a/toolchain/mac-toolchain.xml
+++ b/toolchain/mac-toolchain.xml
@@ -40,8 +40,6 @@
   <flag value="-Wno-format-extra-args" />
   <flag value="-Wno-overflow" />
   <flag value="-fsanitize=thread" if="HXCPP_THREAD_SANITIZE" />
-  <cppflag value="-Wno-return-type-c-linkage" />
-  <mmflag value="-Wno-return-type-c-linkage" />
 
   <flag value="-Wno-bool-conversion" if="HXCPP_CLANG"/>
   <flag value="-fobjc-arc" if="OBJC_ARC" />

--- a/toolchain/mingw-toolchain.xml
+++ b/toolchain/mingw-toolchain.xml
@@ -34,7 +34,6 @@
   <flag value="-c"/>
   <cppflag value="-frtti"/>
   <flag value="-Wno-overflow" />
-  <cppflag value="-Wno-invalid-offsetof" />
   <flag value="-g" if="HXCPP_DEBUG_LINK"/>
   <flag value="-O2" unless="debug||O3"/>
   <flag value="-O3" if="O3"/>

--- a/toolchain/watchos-toolchain.xml
+++ b/toolchain/watchos-toolchain.xml
@@ -37,7 +37,6 @@
   <flag value="-Wno-trigraphs"/>
   <flag value="-fno-stack-protector"/>
   <flag value="-Wno-overflow" />
-  <cppflag value="-Wno-invalid-offsetof" />
   <flag value="-fpascal-strings"/>
   <flag value="-fasm-blocks"/>
   <flag value="-Wreturn-type"/>

--- a/toolchain/watchsimulator-toolchain.xml
+++ b/toolchain/watchsimulator-toolchain.xml
@@ -37,7 +37,6 @@
   <flag value="-Wno-trigraphs"/>
   <flag value="-fno-stack-protector"/>
   <flag value="-Wno-overflow" />
-  <cppflag value="-Wno-invalid-offsetof" />
   <flag value="-fpascal-strings"/>
   <flag value="-fasm-blocks"/>
   <flag value="-Wreturn-type"/>


### PR DESCRIPTION
Instead of disabling `invalid-offsetof` and `return-type-c-linkage` errors globally, we can just disable them for the offending regions. This simplifies maintenance of the toolchains and reduces the scope of the flags.