### PR TITLE
Fix cppia JIT "Bad move target" on untyped register moves

### DIFF
--- a/src/hx/cppia/CppiaCompiler.cpp
+++ b/src/hx/cppia/CppiaCompiler.cpp
@@ -898,7 +898,7 @@ public:
                {
                   if (inSrc.uses(SLJIT_R1))
                   {
-                     move(sJitArg0, inSrc);
+                     move(sJitArg0.as(jtInt), inSrc.as(jtInt));
                      add( sJitTemp1, inTarget.getReg(), inTarget.offset );
                      callNative( (void *)intToStr, sJitArg0.as(jtInt), sJitTemp1.as(jtPointer));
                   }
@@ -917,7 +917,7 @@ public:
             case etObject:
                if (inSrc.uses(SLJIT_R1))
                {
-                  move(sJitArg0, inSrc);
+                  move(sJitArg0.as(jtPointer), inSrc.as(jtPointer));
                   add( sJitTemp1, inTarget.getReg(), inTarget.offset );
                   callNative( (void *)objToStr, sJitArg0.as(jtPointer), sJitTemp1.as(jtPointer) );
                }
@@ -944,7 +944,7 @@ public:
             case etObject:
                if (inSrc==sJitTemp1)
                {
-                  move(sJitArg0, inSrc);
+                  move(sJitArg0.as(jtPointer), inSrc.as(jtPointer));
                   makeAddress(sJitTemp1,inTarget);
                   callNative( (void *)objToFloat, sJitArg0.as(jtPointer), sJitTemp1.as(jtPointer));
                }

--- a/test/cppia/Client.hx
+++ b/test/cppia/Client.hx
@@ -14,6 +14,16 @@ class ClientFoo implements IFoo {
    }
 }
 
+class ClientUntypedMove {
+
+   public static function subtractIndexed():String {
+      var a:Int = 2;
+      var ints:Array<Int> = [7,8,9];
+
+      return "" + (ints[a - 1] - ints[0]);
+   }
+}
+
 class Client
 {
    public static var clientBool0 = true;

--- a/test/cppia/cases/TestCommon.hx
+++ b/test/cppia/cases/TestCommon.hx
@@ -60,6 +60,16 @@ class TestCommon extends Test {
     }
 
     @:depends(testStatus)
+    function testUntypedRegisterMove() {
+        final cls = Type.resolveClass('ClientUntypedMove');
+
+        if (Assert.notNull(cls, 'Unable to resolve ClientUntypedMove')) {
+            Assert.equals('1', Std.string(Reflect.callMethod(null, Reflect.field(cls, 'subtractIndexed'), [])),
+                'Subtracting two array elements into a string did not answer');
+        }
+    }
+
+    @:depends(testStatus)
     function testInterfaceCalling() {
         final obj : IFoo = Type.createInstance(Type.resolveClass('ClientFoo'), []);
 


### PR DESCRIPTION
Any binary subtraction inside a ternary that is converted to String or object triggers it. 
Multiplication, division, unary minus and addition are unaffected, as is hoisting the subtraction into a local first.

`CppiaCompiler::convert` moved between two registers without giving either a type in three places. 
`move()` decides what to emit from `getCommonType()`, and `getCommonType(jtAny, jtAny)` returns `jtAny`, which the
switch answers with `setError("Bad move target")`.

All three sites are guarded by `inSrc.uses(SLJIT_R1)` or `inSrc==sJitTemp1`, so they are only reached when the source value happens to live in R1.
`OpAdd::genCode` leaves its int result in `sJitTemp0` and misses the guard, while `OpSub::genCode` uses `sJitTemp1` and hits it, which is why addition compiles and subtraction does not.

### Reproducable steps
```haxe
class Repro {
    static function f(a:Int, b:Int, flag:Bool):String {
        return "x" + (flag ? 0 : a - b);
    }
    public static function main() Sys.println(f(5, 3, false));
}
```

### Run
```
haxe -main Repro -cppia repro.cppia
haxe -main cpp.cppia.Host -D scriptable -dce no -cpp host
host/Host.exe -jit repro.cppia    Error : Bad move target
host/Host.exe      repro.cppia    x2
```