### PR TITLE
Give a cppia member field declared Bool its boolean storage

### DIFF
--- a/src/hx/cppia/CppiaVars.cpp
+++ b/src/hx/cppia/CppiaVars.cpp
@@ -180,14 +180,17 @@ void CppiaVar::linkVarTypes(CppiaModule &cppia, int &ioOffset)
       AlignOffset(exprType, ioOffset);
       offset = ioOffset;
       
-      switch(exprType)
+      storeType = typeId==0 ? fsObject : fieldStorageFromType(type);
+
+      switch(storeType)
       {
-         case etInt: ioOffset += sizeof(int); storeType=fsInt; break;
-         case etFloat: ioOffset += sizeof(Float);storeType=fsFloat;  break;
-         case etString: ioOffset += sizeof(String);storeType=fsString;  break;
-         case etObject: ioOffset += sizeof(hx::Object *);storeType=fsObject;  break;
-         case etVoid:
-         case etNull:
+         case fsBool: ioOffset += sizeof(int); break;
+         case fsByte: ioOffset += sizeof(int); break;
+         case fsInt: ioOffset += sizeof(int); break;
+         case fsFloat: ioOffset += sizeof(Float); break;
+         case fsString: ioOffset += sizeof(String); break;
+         case fsObject: ioOffset += sizeof(hx::Object *); break;
+         case fsUnknown:
             break;
       }
    }

--- a/src/hx/cppia/CppiaVars.cpp
+++ b/src/hx/cppia/CppiaVars.cpp
@@ -182,17 +182,7 @@ void CppiaVar::linkVarTypes(CppiaModule &cppia, int &ioOffset)
       
       storeType = typeId==0 ? fsObject : fieldStorageFromType(type);
 
-      switch(storeType)
-      {
-         case fsBool: ioOffset += sizeof(int); break;
-         case fsByte: ioOffset += sizeof(int); break;
-         case fsInt: ioOffset += sizeof(int); break;
-         case fsFloat: ioOffset += sizeof(Float); break;
-         case fsString: ioOffset += sizeof(String); break;
-         case fsObject: ioOffset += sizeof(hx::Object *); break;
-         case fsUnknown:
-            break;
-      }
+      ioOffset += sTypeSize[exprType];
    }
 }
 

--- a/test/cppia/Client.hx
+++ b/test/cppia/Client.hx
@@ -14,6 +14,15 @@ class ClientFoo implements IFoo {
    }
 }
 
+class ClientBoolField {
+
+   public var flag:Bool = true;
+
+   public static var staticFlag:Bool = true;
+
+   public function new() {}
+}
+
 class Client
 {
    public static var clientBool0 = true;

--- a/test/cppia/Client.hx
+++ b/test/cppia/Client.hx
@@ -17,10 +17,23 @@ class ClientFoo implements IFoo {
 class ClientBoolField {
 
    public var flag:Bool = true;
+   public var offFlag:Bool = false;
 
    public static var staticFlag:Bool = true;
 
    public function new() {}
+
+   public function readFlag():Bool return flag;
+
+   public function readOffFlag():Bool return offFlag;
+
+   public function flagToString():String return "" + flag;
+
+   public function branchOnFlag():Int return flag ? 10 : 20;
+
+   public function branchOnOffFlag():Int return offFlag ? 10 : 20;
+
+   public function clearFlag():Bool { flag = false; return flag; }
 }
 
 class Client

--- a/test/cppia/Client.hx
+++ b/test/cppia/Client.hx
@@ -17,23 +17,10 @@ class ClientFoo implements IFoo {
 class ClientBoolField {
 
    public var flag:Bool = true;
-   public var offFlag:Bool = false;
 
    public static var staticFlag:Bool = true;
 
    public function new() {}
-
-   public function readFlag():Bool return flag;
-
-   public function readOffFlag():Bool return offFlag;
-
-   public function flagToString():String return "" + flag;
-
-   public function branchOnFlag():Int return flag ? 10 : 20;
-
-   public function branchOnOffFlag():Int return offFlag ? 10 : 20;
-
-   public function clearFlag():Bool { flag = false; return flag; }
 }
 
 class Client

--- a/test/cppia/cases/TestCommon.hx
+++ b/test/cppia/cases/TestCommon.hx
@@ -60,6 +60,18 @@ class TestCommon extends Test {
     }
 
     @:depends(testStatus)
+    function testBoolMemberStorage() {
+        final cls = Type.resolveClass('ClientBoolField');
+
+        if (Assert.notNull(cls, 'Unable to resolve ClientBoolField')) {
+            final obj = Type.createInstance(cls, []);
+
+            Assert.equals('true', Std.string(Reflect.field(obj, 'flag')), 'Member Bool did not read back as a boolean');
+            Assert.equals('true', Std.string(Reflect.field(cls, 'staticFlag')), 'Static Bool did not read back as a boolean');
+        }
+    }
+
+    @:depends(testStatus)
     function testInterfaceCalling() {
         final obj : IFoo = Type.createInstance(Type.resolveClass('ClientFoo'), []);
 

--- a/test/cppia/cases/TestCommon.hx
+++ b/test/cppia/cases/TestCommon.hx
@@ -72,6 +72,47 @@ class TestCommon extends Test {
     }
 
     @:depends(testStatus)
+    function testBoolMemberFromScript() {
+        final cls = Type.resolveClass('ClientBoolField');
+
+        if (Assert.notNull(cls, 'Unable to resolve ClientBoolField')) {
+            final obj = Type.createInstance(cls, []);
+
+            Assert.equals(true, Reflect.callMethod(obj, Reflect.field(obj, 'readFlag'), []),
+                'Script read of a true Bool member failed');
+            Assert.equals(false, Reflect.callMethod(obj, Reflect.field(obj, 'readOffFlag'), []),
+                'Script read of a false Bool member failed');
+            Assert.equals('true', Reflect.callMethod(obj, Reflect.field(obj, 'flagToString'), []),
+                'Bool member did not stringify as a boolean');
+            Assert.equals(10, Reflect.callMethod(obj, Reflect.field(obj, 'branchOnFlag'), []),
+                'Branch on a true Bool member took the wrong arm');
+            Assert.equals(20, Reflect.callMethod(obj, Reflect.field(obj, 'branchOnOffFlag'), []),
+                'Branch on a false Bool member took the wrong arm');
+        }
+    }
+
+    @:depends(testStatus)
+    function testBoolMemberWrite() {
+        final cls = Type.resolveClass('ClientBoolField');
+
+        if (Assert.notNull(cls, 'Unable to resolve ClientBoolField')) {
+            final obj = Type.createInstance(cls, []);
+
+            Assert.equals(false, Reflect.callMethod(obj, Reflect.field(obj, 'clearFlag'), []),
+                'Script write of a Bool member did not stick');
+            Assert.equals('false', Std.string(Reflect.field(obj, 'flag')),
+                'Reflection did not see the script write');
+
+            Reflect.setField(obj, 'flag', true);
+
+            Assert.equals(true, Reflect.callMethod(obj, Reflect.field(obj, 'readFlag'), []),
+                'Script did not see the reflection write');
+            Assert.equals(10, Reflect.callMethod(obj, Reflect.field(obj, 'branchOnFlag'), []),
+                'Branch did not see the reflection write');
+        }
+    }
+
+    @:depends(testStatus)
     function testInterfaceCalling() {
         final obj : IFoo = Type.createInstance(Type.resolveClass('ClientFoo'), []);
 

--- a/test/cppia/cases/TestCommon.hx
+++ b/test/cppia/cases/TestCommon.hx
@@ -66,49 +66,8 @@ class TestCommon extends Test {
         if (Assert.notNull(cls, 'Unable to resolve ClientBoolField')) {
             final obj = Type.createInstance(cls, []);
 
-            Assert.equals('true', Std.string(Reflect.field(obj, 'flag')), 'Member Bool did not read back as a boolean');
-            Assert.equals('true', Std.string(Reflect.field(cls, 'staticFlag')), 'Static Bool did not read back as a boolean');
-        }
-    }
-
-    @:depends(testStatus)
-    function testBoolMemberFromScript() {
-        final cls = Type.resolveClass('ClientBoolField');
-
-        if (Assert.notNull(cls, 'Unable to resolve ClientBoolField')) {
-            final obj = Type.createInstance(cls, []);
-
-            Assert.equals(true, Reflect.callMethod(obj, Reflect.field(obj, 'readFlag'), []),
-                'Script read of a true Bool member failed');
-            Assert.equals(false, Reflect.callMethod(obj, Reflect.field(obj, 'readOffFlag'), []),
-                'Script read of a false Bool member failed');
-            Assert.equals('true', Reflect.callMethod(obj, Reflect.field(obj, 'flagToString'), []),
-                'Bool member did not stringify as a boolean');
-            Assert.equals(10, Reflect.callMethod(obj, Reflect.field(obj, 'branchOnFlag'), []),
-                'Branch on a true Bool member took the wrong arm');
-            Assert.equals(20, Reflect.callMethod(obj, Reflect.field(obj, 'branchOnOffFlag'), []),
-                'Branch on a false Bool member took the wrong arm');
-        }
-    }
-
-    @:depends(testStatus)
-    function testBoolMemberWrite() {
-        final cls = Type.resolveClass('ClientBoolField');
-
-        if (Assert.notNull(cls, 'Unable to resolve ClientBoolField')) {
-            final obj = Type.createInstance(cls, []);
-
-            Assert.equals(false, Reflect.callMethod(obj, Reflect.field(obj, 'clearFlag'), []),
-                'Script write of a Bool member did not stick');
-            Assert.equals('false', Std.string(Reflect.field(obj, 'flag')),
-                'Reflection did not see the script write');
-
-            Reflect.setField(obj, 'flag', true);
-
-            Assert.equals(true, Reflect.callMethod(obj, Reflect.field(obj, 'readFlag'), []),
-                'Script did not see the reflection write');
-            Assert.equals(10, Reflect.callMethod(obj, Reflect.field(obj, 'branchOnFlag'), []),
-                'Branch did not see the reflection write');
+            Assert.same(Type.ValueType.TBool, Type.typeof(Reflect.field(obj, 'flag')), 'Member Bool did not read back as a boolean');
+            Assert.same(Type.ValueType.TBool, Type.typeof(Reflect.field(cls, 'staticFlag')), 'Static Bool did not read back as a boolean');
         }
     }
 


### PR DESCRIPTION
### The problem

A class member declared `Bool` in a cppia module gets an integer slot, so reading it back through
reflection gives you `1` instead of `true`. A static field of the same declared type, in the same
module, gives you `true`:

```
member 1, static true
```

Conditions and comparisons still work, since they are happy with the integer. Anything that looks at
the value itself does not.

### Why

`CppiaVar::linkVarTypes` has two forms:

* The **static** form calls `fieldStorageFromType`, which has a case for `Bool` and returns `fsBool`.
* The **member** form switches on `exprType` instead. By the time it runs, `TypeData::link` has
  already mapped the `Bool` type name to `etInt`, so the field ends up as `fsInt`.

That is why the two fields above disagree.

### The fix

In `src/hx/cppia/CppiaVars.cpp`, the member form now calls `fieldStorageFromType` too:

```cpp
storeType = typeId==0 ? fsObject : fieldStorageFromType(type);

ioOffset += sTypeSize[exprType];
```

The slot is still int sized, so the layout and the `AlignOffset` call above it do not change.

### Test

`test/cppia` covers it. `ClientBoolField` in `Client.hx` holds a `Bool` member and a `Bool` static,
and `testBoolMemberStorage` in `cases/TestCommon.hx` reads both back through `Reflect.field`.

```
cd test/cppia
haxe compile-host.hxml
haxe compile-client.hxml
cd bin && ./CppiaHost.exe client.cppia
```

Without the fix that test fails with `Member Bool did not read back as a boolean`, and the static
assertion beside it still passes, which is the pair that shows the two forms disagreeing. Same result
with or without `-jit`.

### Reproducing by hand

`Script.hx`, built with `haxe -m Script --cppia script.cppia`:

```haxe
class Holder {
   public var flag:Bool = true;
   public static var staticFlag:Bool = true;
   public function new() {}
}

class Script {
   public static function run():String {
      return 'member ' + Std.string(Reflect.field(new Holder(), 'flag'))
         + ', static ' + Std.string(Reflect.field(Holder, 'staticFlag'));
   }

   public static function main():Void {}
}
```

Load it from a host built with `-D scriptable`, using
`cpp.cppia.Module.fromData(bytes).boot()`, and call `Script.run` through reflection.

| | result |
| --- | --- |
| before | `member 1, static true` |
| after | `member true, static true` |

Same result with the JIT on or off, since the storage is decided at link time.

**Let me know if I got anything wrong!**