### PR TITLE
Raise a jitted cppia exception at the boundary back to native code

### DIFF
--- a/src/hx/cppia/CppiaFunction.cpp
+++ b/src/hx/cppia/CppiaFunction.cpp
@@ -508,10 +508,18 @@ void ScriptCallable::runFunction(CppiaCtx *ctx)
    #ifdef CPPIA_JIT
    if (compiled)
    {
+      {
       AutoFrame frame(ctx);
       //printf("Running compiled code...\n");
       compiled(ctx);
       //printf("Done.\n");
+      }
+      if (ctx->exception)
+      {
+         Dynamic caught = ctx->exception;
+         ctx->exception = nullptr;
+         HX_STACK_DO_THROW(caught);
+      }
    }
    else
    #endif
@@ -543,10 +551,18 @@ void ScriptCallable::runFunctionClosure(CppiaCtx *ctx)
    #ifdef CPPIA_JIT
    if (compiled)
    {
+      {
       AutoFrame frame(ctx);
       //printf("Running compiled code...\n");
       compiled(ctx);
       //printf("Done.\n");
+      }
+      if (ctx->exception)
+      {
+         Dynamic caught = ctx->exception;
+         ctx->exception = nullptr;
+         HX_STACK_DO_THROW(caught);
+      }
    }
    else
    #endif
@@ -747,7 +763,13 @@ public:
          AutoFrame frame(ctx);
          function->compiled(ctx);
          }
-         if (!ctx->exception)
+         if (ctx->exception)
+         {
+            Dynamic caught = ctx->exception;
+            ctx->exception = nullptr;
+            HX_STACK_DO_THROW(caught);
+         }
+
          {
             switch(function->returnType)
             {

--- a/test/cppia/Client.hx
+++ b/test/cppia/Client.hx
@@ -14,6 +14,17 @@ class ClientFoo implements IFoo {
    }
 }
 
+class ClientThrower {
+
+   public static function boom():String {
+      throw "boom";
+   }
+
+   public static function fine():String {
+      return "still here";
+   }
+}
+
 class Client
 {
    public static var clientBool0 = true;

--- a/test/cppia/cases/TestCommon.hx
+++ b/test/cppia/cases/TestCommon.hx
@@ -60,6 +60,25 @@ class TestCommon extends Test {
     }
 
     @:depends(testStatus)
+    function testThrowReachesTheCaller() {
+        final cls = Type.resolveClass('ClientThrower');
+
+        if (Assert.notNull(cls, 'Unable to resolve ClientThrower')) {
+            var caught:String = null;
+
+            try {
+                Reflect.callMethod(null, Reflect.field(cls, 'boom'), []);
+            } catch (e:Dynamic) {
+                caught = Std.string(e);
+            }
+
+            Assert.equals('boom', caught, 'The throw did not reach the caller');
+            Assert.equals('still here', Std.string(Reflect.callMethod(null, Reflect.field(cls, 'fine'), [])),
+                'A later call answered null, so the exception was left on the context');
+        }
+    }
+
+    @:depends(testStatus)
     function testInterfaceCalling() {
         final obj : IFoo = Type.createInstance(Type.resolveClass('ClientFoo'), []);
 


### PR DESCRIPTION

### The problem

With the JIT on, a cppia function that throws does not throw. The call returns `null`, and after
that **every call into jitted cppia returns `null` for the rest of the process**, including
functions that are perfectly fine.

### Why

Jitted cppia does not raise C++ exceptions. `ThrowExpr::genCode` writes the value to
`ctx->exception` and calls `addThrow`, which jumps to the function epilogue. Jitted code then checks
`ctx->exception` after every call it makes to other jitted code, so inside jitted code the unwind
works.

The gap is where jitted code returns to native code:

* `ScriptCallable::runFunction` and `ScriptCallable::runFunctionClosure` call `compiled(ctx)` and
  return without checking `ctx->exception` at all.
* The compiled branch of `CppiaClosure::__run` does check it, but only to skip reading a return
  value, and then returns `null()` with the exception still sitting there.

So the caller gets `null` instead of an exception. Worse, `ctx->exception` is never cleared, so the
next jitted function to run bails out at its first `checkException`.

### The fix

In `src/hx/cppia/CppiaFunction.cpp`, all three sites now raise the exception and clear the context:

```cpp
if (ctx->exception)
{
   Dynamic caught = ctx->exception;
   ctx->exception = nullptr;
   HX_STACK_DO_THROW(caught);
}
```

That is the same thing `TryExpr::runVoid` already does to finish its own unwind on the non-jit
path:

```cpp
if (ctx->exception)
   handleException(ctx, ctx->exception);
```

In `runFunction` and `runFunctionClosure` the `AutoFrame` is scoped so the frame is popped before the
throw. `CppiaClosure::__run` already does this a few hundred lines further down.

### Test

`test/cppia` covers it. `ClientThrower` in `Client.hx` has one method that throws and one that
returns a value, and `testThrowReachesTheCaller` in `cases/TestCommon.hx` checks that the throw
arrives and that the second call still answers afterwards.

```
cd test/cppia
haxe compile-host.hxml
haxe compile-client.hxml
cd bin && ./CppiaHost.exe client.cppia -jit
```

The `-jit` matters. `Host.main` already takes that flag, and without it the non-jit path handles
the throw correctly and the test passes whether or not the fix is in.

With the fix reverted and everything else applied, the whole suite run with `-jit` does not complete
at all: no utest output, exit 127. The same build without `-jit` reports `ALL TESTS OK`.

### Reproducing by hand

`Script.hx`, built with `haxe -m Script --cppia script.cppia`:

```haxe
class Script {
   public static function run():String {
      throw 'boom';
   }

   public static function after():String {
      return 'still here';
   }

   public static function main():Void {}
}
```

Load it from a host built with `-D scriptable`, using
`cpp.cppia.Module.fromData(bytes).boot()`, then call `Script.run` and after that `Script.after`
through reflection, each in a `try`/`catch`.

| | `run()` | `after()` |
| --- | --- | --- |
| before, JIT on | returns `null` | returns `null` |
| after, JIT on | throws `boom` | `still here` |
| either way, JIT off | throws `boom` | `still here` |

The second column is the reason this matters. `Script.after` never threw and has nothing wrong with
it. It returned `null` only because the context was still holding the earlier exception.

**Let me know if I got anything wrong!**