### PR TITLE
Fix cppia JIT "Bad move target" converting an int subtraction to a string

### DIFF
--- a/src/hx/cppia/ArrayBuiltin.cpp
+++ b/src/hx/cppia/ArrayBuiltin.cpp
@@ -1482,7 +1482,7 @@ struct ArrayBuiltin : public ArrayBuiltinBase
                   if (destType!=etInt || isMemoryVal(inDest))
                   {
                      compiler->move(sJitTemp1.as(jtInt),sJitTemp1.atReg(sJitTemp0,1).as(jtShort));
-                     compiler->convert(sJitTemp1,etInt, inDest, destType);
+                     compiler->convert(sJitTemp1.as(jtInt),etInt, inDest, destType);
                   }
                   else
                      compiler->move( inDest.as(jtInt),  sJitTemp1.atReg(sJitTemp0).as(jtShort) );

--- a/src/hx/cppia/Cppia.cpp
+++ b/src/hx/cppia/Cppia.cpp
@@ -6818,7 +6818,7 @@ struct OpSub : public BinOp
          else
          {
             compiler->sub(sJitTemp1.as(jtInt),lval,sJitTemp0,false);
-            compiler->convert(sJitTemp1,etInt, inDest, destType);
+            compiler->convert(sJitTemp1.as(jtInt),etInt, inDest, destType);
          }
       }
       else

--- a/src/hx/cppia/CppiaCompiler.cpp
+++ b/src/hx/cppia/CppiaCompiler.cpp
@@ -898,7 +898,7 @@ public:
                {
                   if (inSrc.uses(SLJIT_R1))
                   {
-                     move(sJitArg0, inSrc);
+                     move(sJitArg0.as(jtInt), inSrc.as(jtInt));
                      add( sJitTemp1, inTarget.getReg(), inTarget.offset );
                      callNative( (void *)intToStr, sJitArg0.as(jtInt), sJitTemp1.as(jtPointer));
                   }
@@ -917,7 +917,7 @@ public:
             case etObject:
                if (inSrc.uses(SLJIT_R1))
                {
-                  move(sJitArg0, inSrc);
+                  move(sJitArg0.as(jtPointer), inSrc.as(jtPointer));
                   add( sJitTemp1, inTarget.getReg(), inTarget.offset );
                   callNative( (void *)objToStr, sJitArg0.as(jtPointer), sJitTemp1.as(jtPointer) );
                }
@@ -944,7 +944,7 @@ public:
             case etObject:
                if (inSrc==sJitTemp1)
                {
-                  move(sJitArg0, inSrc);
+                  move(sJitArg0.as(jtPointer), inSrc.as(jtPointer));
                   makeAddress(sJitTemp1,inTarget);
                   callNative( (void *)objToFloat, sJitArg0.as(jtPointer), sJitTemp1.as(jtPointer));
                }

--- a/src/hx/cppia/CppiaCompiler.cpp
+++ b/src/hx/cppia/CppiaCompiler.cpp
@@ -942,24 +942,24 @@ public:
                break;
 
             case etObject:
-               if (inSrc==sJitTemp1)
                {
-                  move(sJitArg0.as(jtPointer), inSrc.as(jtPointer));
-                  makeAddress(sJitTemp1,inTarget);
-                  callNative( (void *)objToFloat, sJitArg0.as(jtPointer), sJitTemp1.as(jtPointer));
-               }
-               else
-               {
+                  JitVal src = inSrc.as(jtPointer);
+                  if (inSrc.uses(SLJIT_R1))
+                  {
+                     move(sJitArg0.as(jtPointer), src);
+                     src = sJitArg0.as(jtPointer);
+                  }
+
                   if (isMemoryVal(inTarget))
                   {
                      makeAddress(sJitTemp1,inTarget);
-                     callNative( (void *)objToFloat, inSrc.as(jtPointer), sJitTemp1.as(jtPointer) );
+                     callNative( (void *)objToFloat, src, sJitTemp1.as(jtPointer) );
                   }
                   else
                   {
                      JitTemp temp(this,jtFloat);
                      makeAddress(sJitTemp1,temp);
-                     callNative( (void *)objToFloat, inSrc.as(jtPointer), sJitTemp1.as(jtPointer) );
+                     callNative( (void *)objToFloat, src, sJitTemp1.as(jtPointer) );
                      move(inTarget,temp);
                   }
                }

--- a/test/cppia/Client.hx
+++ b/test/cppia/Client.hx
@@ -14,6 +14,16 @@ class ClientFoo implements IFoo {
    }
 }
 
+class ClientUntypedMove {
+
+   public static function subtractIndexed():String {
+      var a:Int = 2;
+      var ints:Array<Int> = [7,8,9];
+
+      return "" + (ints[a - 1] - ints[0]);
+   }
+}
+
 class Client
 {
    public static var clientBool0 = true;

--- a/test/cppia/Client.hx
+++ b/test/cppia/Client.hx
@@ -14,13 +14,45 @@ class ClientFoo implements IFoo {
    }
 }
 
-class ClientUntypedMove {
+class ClientJitConvert {
 
-   public static function subtractIndexed():String {
+   public static function subtractToString():String {
       var a:Int = 2;
-      var ints:Array<Int> = [7,8,9];
 
-      return "" + (ints[a - 1] - ints[0]);
+      return "" + (a - 1);
+   }
+
+   public static function subtractToFloat():Float {
+      var a:Int = 7;
+
+      return (a - 2) / 2;
+   }
+
+   public static function subtractToDynamic():Dynamic {
+      var a:Int = 9;
+
+      return a - 4;
+   }
+
+   public static function dynamicToString():String {
+      var d:Dynamic = "hello";
+      var s:String = d;
+
+      return s + "!";
+   }
+
+   public static function dynamicToFloat():Float {
+      var d:Dynamic = 2.5;
+      var f:Float = d;
+
+      return f + 1;
+   }
+
+   public static function dynamicToFloatInRegister():Float {
+      var d:Dynamic = 1.5;
+      var m:Float = 2;
+
+      return m * d;
    }
 }
 

--- a/test/cppia/cases/TestCommon.hx
+++ b/test/cppia/cases/TestCommon.hx
@@ -59,14 +59,44 @@ class TestCommon extends Test {
         Assert.equals(2, Common.callbackSet, 'Bad cppia closure');
     }
 
-    @:depends(testStatus)
-    function testUntypedRegisterMove() {
-        final cls = Type.resolveClass('ClientUntypedMove');
+    function callConvert(name:String):Dynamic {
+        final cls = Type.resolveClass('ClientJitConvert');
 
-        if (Assert.notNull(cls, 'Unable to resolve ClientUntypedMove')) {
-            Assert.equals('1', Std.string(Reflect.callMethod(null, Reflect.field(cls, 'subtractIndexed'), [])),
-                'Subtracting two array elements into a string did not answer');
+        if (!Assert.notNull(cls, 'Unable to resolve ClientJitConvert')) {
+            return null;
         }
+
+        return Reflect.callMethod(null, Reflect.field(cls, name), []);
+    }
+
+    @:depends(testStatus)
+    function testSubtractionToString() {
+        Assert.equals('1', callConvert('subtractToString'), 'Int subtraction into a string did not answer');
+    }
+
+    @:depends(testStatus)
+    function testSubtractionToFloat() {
+        Assert.floatEquals(2.5, callConvert('subtractToFloat'), 'Int subtraction into a float did not answer');
+    }
+
+    @:depends(testStatus)
+    function testSubtractionToDynamic() {
+        Assert.equals(5, callConvert('subtractToDynamic'), 'Int subtraction into a dynamic did not answer');
+    }
+
+    @:depends(testStatus)
+    function testDynamicToString() {
+        Assert.equals('hello!', callConvert('dynamicToString'), 'Dynamic into a string did not answer');
+    }
+
+    @:depends(testStatus)
+    function testDynamicToFloat() {
+        Assert.floatEquals(3.5, callConvert('dynamicToFloat'), 'Dynamic into a float did not answer');
+    }
+
+    @:depends(testStatus)
+    function testDynamicToFloatInRegister() {
+        Assert.floatEquals(3.0, callConvert('dynamicToFloatInRegister'), 'Dynamic into a float register did not answer');
     }
 
     @:depends(testStatus)

--- a/test/cppia/cases/TestCommon.hx
+++ b/test/cppia/cases/TestCommon.hx
@@ -60,6 +60,16 @@ class TestCommon extends Test {
     }
 
     @:depends(testStatus)
+    function testUntypedRegisterMove() {
+        final cls = Type.resolveClass('ClientUntypedMove');
+
+        if (Assert.notNull(cls, 'Unable to resolve ClientUntypedMove')) {
+            Assert.equals('1', Std.string(Reflect.callMethod(null, Reflect.field(cls, 'subtractIndexed'), [])),
+                'Subtracting two array elements into a string did not answer');
+        }
+    }
+
+    @:depends(testStatus)
     function testInterfaceCalling() {
         final obj : IFoo = Type.createInstance(Type.resolveClass('ClientFoo'), []);
 


### PR DESCRIPTION
Remake of #1366

### The problem

With the JIT on, a cppia module containing an ordinary integer expression fails to load:

```
Error : Bad move target
```

The failure is at module boot, because JIT compilation runs over the whole module there, so one
expression takes the entire module down. cppia with jit off runs the same code correctly.

### Why

`OpSub::genCode` hands `convert` a bare `sJitTemp1`, where `OpMult::genCode` right above it passes
`sJitTemp1.as(jtInt)`:

```cpp
compiler->sub(sJitTemp1.as(jtInt), lval, sJitTemp0, false);
compiler->convert(sJitTemp1, etInt, inDest, destType);
```

Inside `convert`, the `etInt` to `etString` case moves that untyped source into an untyped
`sJitArg0`:

```cpp
if (inSrc.uses(SLJIT_R1))
{
   move(sJitArg0, inSrc);
   ...
```

Neither side has a width. `getCommonType(jtAny, jtAny)` returns `jtAny`, which `move()` rejects with
`setError("Bad move target")`. That is thrown, caught in `CppiaModule`, and re-raised as the load
error above.

Only a String destination trips it. `etFloat` goes through `SLJIT_CONV_F64_FROM_S32` and `etObject`
through `intToObj`, and neither of those calls `move`. `"" + (a * b)` does not trip it either, since
`OpMult` types its source.

### The fix

One token in `src/hx/cppia/Cppia.cpp`, so `OpSub` matches `OpMult`:

```cpp
compiler->convert(sJitTemp1.as(jtInt), etInt, inDest, destType);
```

That alone fixes the crash with `CppiaCompiler.cpp` untouched. Three other things ride along:

- The 2-byte `ArrayBuiltin` read has the same omission against its byte-sized sibling. Nothing
  instantiates `ArrayBuiltin` with a 2-byte element, so that block never compiles. Consistency only.
- `CppiaCompiler.cpp` still gets the three widths, as hardening rather than as the fix. `convert` is
  handed `inSrcType` and every other move in it already types both sides from that, so these three
  were the ones that had been missed.
- The `etObject` to `etFloat` branch guarded on `inSrc==sJitTemp1`, but `JitVal::operator==` compares
  `type`, so only a bare untyped `sJitTemp1` ever matched. A typed `R1` source fell through to a path
  where `makeAddress` stomps `R1` before `objToFloat` reads it. It guards on `inSrc.uses(SLJIT_R1)`
  now, like the `etObject` to `etString` branch above it. Nothing produces that shape today either,
  so this is correctness on an unreachable path.

### Test

`test/cppia` covers it. `ClientJitConvert` in `Client.hx` holds the cases and `cases/TestCommon.hx`
checks the answers: the crash itself, both of the other `OpSub` destinations, and the three `convert`
paths touched here.

```
cd test/cppia
haxe compile-host.hxml
haxe compile-client.hxml
cd bin && ./CppiaHost.exe client.cppia -jit
```

The `-jit` matters, and `RunTests.hx` already runs the suite both ways. 27/27 either way.

Without the fix the `-jit` run fails at `setupClass failed: Bad move target` and exits 1, since the
module never loads. The same build without `-jit` reports `ALL TESTS OK`.

Worth saying plainly: the tests cannot isolate the hardening from the `OpSub` fix. With either one in
place nothing hands `convert` an untyped register, so no Haxe code can tell them apart. Reverting
`CppiaCompiler.cpp` completely with `OpSub` fixed still passes everything. To check the new cases are
not vacuous I dropped a line from the branch I rewrote, and exactly one test failed.

Since this is all in the JIT, I also checked it moves no generated code. Master and this branch were
built as two hosts and run against the same `client.cppia`, dumping the sljit LIR through
`sljit_compiler_verbose`: 2601 lines each, zero differences once the pointer immediates that shift
under ASLR are normalised. That follows from `getData` never reading `type` and `getTarget` reading it
only to choose between `maxFTempCount` and `maxTempCount`, where `jtAny`, `jtInt` and `jtPointer` all
take the same branch.

### Reproducing by hand

```haxe
class Script {
   public static function run():String {
      var a:Int = 2;

      return "" + (a - 1);
   }

   public static function main():Void {}
}
```

Built with `haxe -m Script --cppia script.cppia` and loaded from a host built with
`-D scriptable --dce no`, calling `cpp.cppia.Host.enableJit(true)` before
`cpp.cppia.Module.fromData(bytes).boot()`.

| | result |
| --- | --- |
| before, JIT on | `Error : Bad move target` at boot |
| after, JIT on | `1` |
| either way, JIT off | `1` |

<details>
<summary>Pre-edit description:</summary>

### The problem

With the JIT on, a cppia module containing an ordinary integer expression fails to load:

```
Error : Bad move target
```

The failure is at module boot, because JIT compilation runs over the whole module there, so one
expression takes the entire module down. cppia with jit off runs the same code correctly.

### Why

`CppiaCompiler::convert` moves between two untyped registers in three places, for example when
converting an `Int` to a `String`:

```cpp
if (inSrc.uses(SLJIT_R1))
{
   move(sJitArg0, inSrc);
   ...
```

Neither side is given a width. When both operands are untyped, `getCommonType(jtAny, jtAny)` returns
`jtAny`, which `move()` rejects with `setError("Bad move target")`. That is thrown, caught in
`CppiaModule`, and re-raised as the load error above.

It needs both conditions at once, which is why it is easy to miss: the source has to be in `R1` and
untyped. An expression like `"" + (a * b)` reaches the branch but with a typed source, and
`"" + ints[0]` has an untyped source but does not reach the branch.

### The fix

In `src/hx/cppia/CppiaCompiler.cpp`, give both sides a width:

```cpp
move(sJitArg0.as(jtInt), inSrc.as(jtInt));          // the etString case, from etInt
move(sJitArg0.as(jtPointer), inSrc.as(jtPointer));  // the two etObject cases
```

### Test

`test/cppia` covers it. `ClientUntypedMove` in `Client.hx` subtracts one array element from another
into a string, and `testUntypedRegisterMove` in `cases/TestCommon.hx` checks the answer.

```
cd test/cppia
haxe compile-host.hxml
haxe compile-client.hxml
cd bin && ./CppiaHost.exe client.cppia -jit
```

The `-jit` matters, and `RunTests.hx` already runs the suite both ways.

Without the fix, the `-jit` run fails at `setupClass failed: Bad move target` and exits 1, since the
module never loads. The same build without `-jit` reports `ALL TESTS OK`.

### Reproducing by hand

```haxe
class Script {
   public static function run():String {
      var a:Int = 2;
      var ints:Array<Int> = [7,8,9];

      return "" + (ints[a - 1] - ints[0]);
   }

   public static function main():Void {}
}
```

Built with `haxe -m Script --cppia script.cppia` and loaded from a host built with
`-D scriptable --dce no`, calling `cpp.cppia.Host.enableJit(true)` before
`cpp.cppia.Module.fromData(bytes).boot()`.

| | result |
| --- | --- |
| before, JIT on | `Error : Bad move target` at boot |
| after, JIT on | `1` |
| either way, JIT off | `1` |

</details>
