### PR TITLE
Fix a cppia Bool constant stored as a number in an Any array under the JIT

### DIFF
--- a/src/hx/cppia/Cppia.cpp
+++ b/src/hx/cppia/Cppia.cpp
@@ -4805,6 +4805,8 @@ struct DataVal : public CppiaExprWithValue
    }
    const char *getName() HXCPP_OVERRIDE { return "DataVal"; }
 
+   bool isBoolInt() HXCPP_OVERRIDE { return ExprTypeIsBool<T>::value; }
+
    ExprType getType() HXCPP_OVERRIDE { return (ExprType)ExprTypeOf<T>::value; }
 
    void        runVoid(CppiaCtx *ctx) HXCPP_OVERRIDE {  }

--- a/test/cppia/Client.hx
+++ b/test/cppia/Client.hx
@@ -14,6 +14,23 @@ class ClientFoo implements IFoo {
    }
 }
 
+class ClientBoolConst {
+
+   public static function constToDynamic():String {
+      var d:Dynamic = true;
+
+      return Std.string(d);
+   }
+
+   public static function anyArrayWithConsts():Array<Any> {
+      return [true, false];
+   }
+
+   public static function anyArrayWithComparison(i:Int):Array<Any> {
+      return [i > 1];
+   }
+}
+
 class Client
 {
    public static var clientBool0 = true;

--- a/test/cppia/cases/TestCommon.hx
+++ b/test/cppia/cases/TestCommon.hx
@@ -59,6 +59,43 @@ class TestCommon extends Test {
         Assert.equals(2, Common.callbackSet, 'Bad cppia closure');
     }
 
+    function callBoolConst(name:String, args:Array<Dynamic>):Dynamic {
+        final cls = Type.resolveClass('ClientBoolConst');
+
+        if (!Assert.notNull(cls, 'Unable to resolve ClientBoolConst')) {
+            return null;
+        }
+
+        return Reflect.callMethod(null, Reflect.field(cls, name), args);
+    }
+
+    @:depends(testStatus)
+    function testBoolConstToDynamic() {
+        Assert.equals('true', callBoolConst('constToDynamic', []),
+            'Bool constant boxed as a number');
+    }
+
+    @:depends(testStatus)
+    function testBoolConstInAnyArray() {
+        final arr:Array<Any> = callBoolConst('anyArrayWithConsts', []);
+
+        if (Assert.notNull(arr, 'No array returned')) {
+            Assert.isTrue(Std.isOfType(arr[0], Bool), 'Bool constant did not store as a Bool');
+            Assert.isTrue(Std.isOfType(arr[1], Bool), 'Bool constant did not store as a Bool');
+            Assert.equals('true', Std.string(arr[0]), 'Bool constant stored in an Any array as a number');
+            Assert.equals('false', Std.string(arr[1]), 'Bool constant stored in an Any array as a number');
+        }
+    }
+
+    @:depends(testStatus)
+    function testBoolComparisonInAnyArray() {
+        final arr:Array<Any> = callBoolConst('anyArrayWithComparison', [3]);
+
+        if (Assert.notNull(arr, 'No array returned')) {
+            Assert.equals('true', Std.string(arr[0]), 'Bool comparison stored in an Any array as a number');
+        }
+    }
+
     @:depends(testStatus)
     function testInterfaceCalling() {
         final obj : IFoo = Type.createInstance(Type.resolveClass('ClientFoo'), []);


### PR DESCRIPTION
### The problem

Same script, different answers depending on whether the JIT is on. A bool constant in an
`Array<Any>` comes back out as a number:

```haxe
var a:Array<Any> = [true, false];

Std.string(a[0]);         // "true" interpreted, "1" jitted
Std.isOfType(a[0], Bool); // true interpreted, false jitted
```

It really is an `Int` sitting in the array, so type checks against `Bool` fail and it serialises as a
number. It's still truthy, so `if (a[0])` keeps working, which is why this can sit there unnoticed
until something trips over it.

### Why

`ArrayDef::genCode` asks each item whether it's a bool to pick the store:

```cpp
case etInt:
   items[i]->genCode(compiler, sJitArg2, etInt );
   if (items[i]->isBoolInt())
      compiler->callNative((void *)varraySetBool,array,i,sJitArg2.as(jtInt));
   else
      compiler->callNative((void *)varraySetInt,array,i,sJitArg2.as(jtInt));
```

Constants live in `DataVal<T>`, and `getType` says `etInt` for a bool, so `isBoolInt` is the only
thing that can tell one apart from a number. `DataVal` never overrode it, so it answered false and
the element went in through `varraySetInt`.

Everything else carrying a bool already does this. `CppiaBoolExpr` returns true outright,
`MemReference` gets it from `ExprTypeIsBool`, and the call and cast expressions read their signature.
`DataVal` was just missed.

The interpreter fills the same array through `runObject`, which boxes a `Dynamic` from the real
`bool`, so it was never wrong.

### The fix

One override in `src/hx/cppia/Cppia.cpp`:

```cpp
bool isBoolInt() HXCPP_OVERRIDE { return ExprTypeIsBool<T>::value; }
```

This only affects array literals. `var d:Dynamic = true` already boxed correctly, since that path
never asks `isBoolInt`.

### Test

`test/cppia` covers it. `ClientBoolConst` in `Client.hx` returns the arrays and
`cases/TestCommon.hx` checks what comes back.

```
cd test/cppia
haxe compile-host.hxml
haxe compile-client.hxml
cd bin && ./CppiaHost.exe client.cppia -jit
```

The `-jit` matters, and `RunTests.hx` already runs the suite both ways. It passes in both.

Without the fix, `testBoolConstInAnyArray` fails under `-jit` and passes interpreted.

One thing worth knowing if you touch these tests: 
They hand the array back to the host on purpose.
Write it the obvious way, reading the array back in the same function, and the analyzer replaces it
with locals. No array gets built and the test quietly checks nothing. Took me a couple of runs to
notice. `testBoolComparisonInAnyArray` is there as a control, since a comparison in the same slot
already answers `isBoolInt` and passes either way.

### Reproducing by hand

```haxe
class Script {
   public static function run():Array<Any> {
      return [true, false];
   }

   public static function main():Void {}
}
```

Built with `haxe -m Script --cppia script.cppia` and loaded from a host built with
`-D scriptable --dce no`, calling `cpp.cppia.Host.enableJit(true)` before
`cpp.cppia.Module.fromData(bytes).boot()`, then reading `Std.string(arr[0])`.

| | result |
| --- | --- |
| before, JIT on | `1` |
| after, JIT on | `true` |
| either way, JIT off | `true` |

Wheter there's a better fix for this I'm not sure, if there is, please point it out and I'll fix it up.