### PR TITLE
OSX - Release semaphore on finalisation

### DIFF
--- a/src/hx/thread/CountingSemaphore.apple.cpp
+++ b/src/hx/thread/CountingSemaphore.apple.cpp
@@ -8,7 +8,11 @@ struct hx::thread::CountingSemaphore_obj::Impl
 
 	static void finalise(hx::Object* obj)
 	{
-		delete reinterpret_cast<hx::thread::CountingSemaphore_obj*>(obj)->impl;
+		auto semaphore = reinterpret_cast<hx::thread::CountingSemaphore_obj*>(obj);
+
+		dispatch_release(semaphore->impl->semaphore)
+
+		delete semaphore->impl;
 	}
 };
 

--- a/src/hx/thread/CountingSemaphore.apple.cpp
+++ b/src/hx/thread/CountingSemaphore.apple.cpp
@@ -10,7 +10,7 @@ struct hx::thread::CountingSemaphore_obj::Impl
 	{
 		auto semaphore = reinterpret_cast<hx::thread::CountingSemaphore_obj*>(obj);
 
-		dispatch_release(semaphore->impl->semaphore)
+		dispatch_release(semaphore->impl->semaphore);
 
 		delete semaphore->impl;
 	}


### PR DESCRIPTION
Seems I forgot to release the semaphore in the finaliser.