### PR TITLE
Fix string hashing for utf16 strings

### DIFF
--- a/include/hxString.h
+++ b/include/hxString.h
@@ -228,8 +228,8 @@ public:
          #ifdef HXCPP_PARANOID
          unsigned int result = calcHash();
 
-         unsigned int have = (((unsigned int *)__s)[-1] & HX_GC_CONST_ALLOC_BIT) ?
-                ((unsigned int *)__s)[-2] :  *((unsigned int *)(__s+length+1) );
+         unsigned int have = (((unsigned int *)__s)[-1] & HX_GC_CONST_ALLOC_BIT) ? ((unsigned int *)__s)[-2] :
+                             isUTF16Encoded() ? *((unsigned int *)(__w+length+1)) : *((unsigned int *)(__s+length+1));
 
          if ( have != result )
          {
@@ -245,6 +245,13 @@ public:
             return  ((emscripten_align1_int*)__s)[-2];
             #else
             return  ((unsigned int *)__s)[-2];
+            #endif
+         }
+         if (isUTF16Encoded()) {
+            #ifdef __EMSCRIPTEN__
+            return *((emscripten_align1_int *)(__w+length+1));
+            #else
+            return *((unsigned int *)(__w+length+1));
             #endif
          }
         #ifdef __EMSCRIPTEN__

--- a/src/String.cpp
+++ b/src/String.cpp
@@ -932,9 +932,10 @@ unsigned int String::calcSubHash(int start, int inLen) const
    if (isUTF16Encoded())
    {
       const char16_t *w = __w + start;
-      for(int i=0;i<inLen;i++)
+      const char16_t *end = w + inLen;
+      while (w < end)
       {
-         int c = w[i];
+         int c = Char16Advance(w, false);
          if( c <= 0x7F )
          {
             ADD_HASH(c);
@@ -977,9 +978,11 @@ unsigned int String::calcHash() const
    #ifdef HX_SMART_STRINGS
    if (isUTF16Encoded())
    {
-      for(int i=0;i<length;i++)
+      const char16_t *w = __w;
+      const char16_t *end = w + length;
+      while (w < end)
       {
-         int c = __w[i];
+         int c = Char16Advance(w, false);
          if( c <= 0x7F )
          {
             ADD_HASH(c);

--- a/test/haxe/TestStringHash.hx
+++ b/test/haxe/TestStringHash.hx
@@ -80,4 +80,21 @@ class TestStringHash extends Test
       Assert.pass();
    }
 
+   public function testUnicode()
+   {
+		for (literal in ["á", "👍"]) {
+			var fromBytes = haxe.io.Bytes.ofString(literal).toString();
+
+			Assert.equals(literal, fromBytes);
+
+			var m = new Map<String, Int>();
+			m[literal] = 1;
+
+			Assert.isTrue(m.exists(literal));
+			Assert.isTrue(m.exists(fromBytes));
+
+			Assert.equals(1, m[literal]);
+			Assert.equals(1, m[fromBytes]);
+      }
+   }
 }

--- a/test/haxe/TestStringHash.hx
+++ b/test/haxe/TestStringHash.hx
@@ -83,17 +83,22 @@ class TestStringHash extends Test
    public function testUnicode()
    {
 		for (literal in ["á", "👍"]) {
+			var fromJson:String = haxe.Json.parse('\"$literal\"');
 			var fromBytes = haxe.io.Bytes.ofString(literal).toString();
 
+			Assert.equals(literal, fromJson);
+			Assert.equals(fromJson, fromBytes);
 			Assert.equals(literal, fromBytes);
 
 			var m = new Map<String, Int>();
 			m[literal] = 1;
 
 			Assert.isTrue(m.exists(literal));
+			Assert.isTrue(m.exists(fromJson));
 			Assert.isTrue(m.exists(fromBytes));
 
 			Assert.equals(1, m[literal]);
+			Assert.equals(1, m[fromJson]);
 			Assert.equals(1, m[fromBytes]);
       }
    }


### PR DESCRIPTION
Closes #1375.

`String::hash` was broken for (non-literal) utf16 strings because it didn't handle the `isUTF16Encoded()` case.
`String::calcHash` also did not handle surrogate pairs correctly, and instead iterated on individual code units.

During hashing, invalid utf16 code units are replaced with the replacement character (`Char16Advance` with `throwOnErr = false`). This avoids introducing exceptions to code that wasn't throwing before, however, it means two different invalid utf16 strings can have hashes that collide. This seems to be an ok compromise.