### PR TITLE
Prune duplicate/removed defines

### DIFF
--- a/toolchain/blackberry-toolchain.xml
+++ b/toolchain/blackberry-toolchain.xml
@@ -39,7 +39,6 @@
 	<cppflag value="-lang-c++"/>
 	<include name="toolchain/common-defines.xml" />
 	<flag value="-DHXCPP_LOAD_DEBUG" if="HXCPP_LOAD_DEBUG"/>
-	<flag value="-DHXCPP_MULTI_THREADED" if="HXCPP_MULTI_THREADED"/>
 	<flag value="-fpic"/>
 	<flag value="-fPIC"/>
 	<cppflag value="-frtti"/>

--- a/toolchain/common-defines.xml
+++ b/toolchain/common-defines.xml
@@ -7,7 +7,6 @@
  <flag value="-DHXCPP_ARMV7" if="HXCPP_ARMV7"/>
  <flag value="-DHXCPP_M64" if="HXCPP_M64||HXCPP_ARM64||HXCPP_X86_64"/>
  <flag value="-DHXCPP_VISIT_ALLOCS" tag="haxe" />
- <flag value="-Dhaxe_210" if="haxe_210" tag="haxe" />
  <flag value="-DHXCPP_FLOAT32" if="HXCPP_FLOAT32" tag="haxe" />
  <flag value="-DHXCPP_CHECK_POINTER" if="HXCPP_CHECK_POINTER" tag="haxe" />
  <flag value="-DHXCPP_STACK_TRACE" if="HXCPP_STACK_TRACE" tag="haxe" />

--- a/toolchain/emscripten-toolchain.xml
+++ b/toolchain/emscripten-toolchain.xml
@@ -99,7 +99,6 @@
   <flag value="-fPIC" if="HXCPP_EMSCRIPTEN_FPIC" />
   <flag value="-DEMSCRIPTEN"/>
   <flag value="-DHXCPP_JS_PRIME" if="HXCPP_JS_PRIME" />
-  <flag value="-DHXCPP_MULTI_THREADED" if="HXCPP_MULTI_THREADED"/>
   <flag value="-DHXCPP_BIG_ENDIAN" if="HXCPP_BIG_ENDIAN"/>
   <flag value="-Wno-overflow" />
   <cppflag value="-Wno-invalid-offsetof" />

--- a/toolchain/linux-toolchain.xml
+++ b/toolchain/linux-toolchain.xml
@@ -51,7 +51,6 @@
   <include name="toolchain/common-defines.xml" />
   <flag value="-m32" unless="noM32"/>
   <flag value="-m64" if="HXCPP_M64" unless="noM64" />
-  <flag value="-DHXCPP_M64" if="HXCPP_M64"/>
   <flag value="-I${HXCPP}/include"/>
   <objdir value="obj/linux${OBJEXT}/"/>
   <outflag value="-o"/>

--- a/toolchain/linux-toolchain.xml
+++ b/toolchain/linux-toolchain.xml
@@ -47,7 +47,6 @@
   <cppflag value="-Wno-invalid-offsetof" />
   <flag value="-DHX_LINUX"/>
   <flag value="-DRASPBERRYPI=RASPBERRYPI" if="rpi"/>
-  <flag value="-DHXCPP_MULTI_THREADED" if="HXCPP_MULTI_THREADED"/>
   <flag value="-DHXCPP_BIG_ENDIAN" if="HXCPP_BIG_ENDIAN"/>
   <include name="toolchain/common-defines.xml" />
   <flag value="-m32" unless="noM32"/>

--- a/toolchain/mingw-toolchain.xml
+++ b/toolchain/mingw-toolchain.xml
@@ -43,7 +43,6 @@
   <flag value="-DHXCPP_BIG_ENDIAN" if="HXCPP_BIG_ENDIAN"/>
   <flag value="-m32" unless="HXCPP_M64"/>
   <flag value="-m64" if="HXCPP_M64"/>
-  <flag value="-DHXCPP_M64" if="HXCPP_M64"/>
   <flag value="-I${HXCPP}/include"/>
   <objdir value="obj/mingw${OBJEXT}/"/>
   <outflag value="-o"/>


### PR DESCRIPTION
The first two were an oversight in: d40311269ffdd1b5c06134348e4284dfcbbdeac9

- `HXCPP_MULTI_THREADED` - All references to it were removed in 2015: 69ccf6f7c1f087793f42b28ffa170d5d180e4fd8. Since then it has had no effect. It was partially removed in b9210d8d908bebd468d8333269cfc9ce116efb2d, but it still remained in individual toolchains.

- `HXCPP_M64` - It is already set via common-defines.xml, so it does not need to be added explicitly by linux and mingw toolchains.

- `haxe_210` - An artifact from the haxe 2 days, which has had no effect since 2229740ef5006d0c1951fc70f1fc5844fc6dd3b1