### PR TITLE
Fix crash with HXCPP_CATCH_SEGV on android x86_64

### DIFF
--- a/src/String.cpp
+++ b/src/String.cpp
@@ -2459,12 +2459,7 @@ public:
    double __ToDouble() const HXCPP_OVERRIDE
    {
       if (!mValue.raw_ptr()) return 0;
-
-      #ifdef HX_ANDROID
-      return strtod(mValue.utf8_str(),0);
-      #else
       return atof(mValue.utf8_str());
-      #endif
    }
    int __length() const HXCPP_OVERRIDE { return mValue.length; }
 

--- a/src/hx/AndroidCompat.cpp
+++ b/src/hx/AndroidCompat.cpp
@@ -9,7 +9,7 @@
 // These functions are inlined prior to android-ndk-platform-21, which means they
 // are missing from the libc functions on those phones, and you will get link errors.
 
-#if (HXCPP_ANDROID_PLATFORM>=21) && !defined(HXCPP_ARM64)
+#if HXCPP_ANDROID_PLATFORM>=21
 extern "C" {
 
 
@@ -43,7 +43,7 @@ __sighandler_t bsd_signal(int s, __sighandler_t f)
 {
  if (bsd_signal_func == 0)
  {
-   // For now (up to Android 7.0) this is always available 
+   // For now (up to Android 7.0) this is always available
    bsd_signal_func = (bsd_signal_func_t) dlsym(RTLD_DEFAULT, "bsd_signal");
 
    if (bsd_signal_func == 0)

--- a/src/hx/AndroidCompat.cpp
+++ b/src/hx/AndroidCompat.cpp
@@ -9,7 +9,7 @@
 // These functions are inlined prior to android-ndk-platform-21, which means they
 // are missing from the libc functions on those phones, and you will get link errors.
 
-#if HXCPP_ANDROID_PLATFORM>=21
+#if (HXCPP_ANDROID_PLATFORM>=21) && !defined(HXCPP_M64)
 extern "C" {
 
 
@@ -43,7 +43,7 @@ __sighandler_t bsd_signal(int s, __sighandler_t f)
 {
  if (bsd_signal_func == 0)
  {
-   // For now (up to Android 7.0) this is always available
+   // For now (up to Android 7.0) this is always available 
    bsd_signal_func = (bsd_signal_func_t) dlsym(RTLD_DEFAULT, "bsd_signal");
 
    if (bsd_signal_func == 0)

--- a/src/hx/AndroidCompat.cpp
+++ b/src/hx/AndroidCompat.cpp
@@ -1,3 +1,5 @@
+#if (HXCPP_ANDROID_PLATFORM>=21) && !defined(HXCPP_M64)
+
 #include <hxcpp.h>
 #include <limits>
 #include <stdlib.h>
@@ -6,7 +8,6 @@
 #include <dlfcn.h>
 #include <android/log.h>
 
-#if (HXCPP_ANDROID_PLATFORM>=21) && !defined(HXCPP_M64)
 extern "C" {
 
 // These functions are inlined prior to android-ndk-platform-21, which means they

--- a/src/hx/AndroidCompat.cpp
+++ b/src/hx/AndroidCompat.cpp
@@ -6,12 +6,13 @@
 #include <dlfcn.h>
 #include <android/log.h>
 
-// These functions are inlined prior to android-ndk-platform-21, which means they
-// are missing from the libc functions on those phones, and you will get link errors.
-
 #if (HXCPP_ANDROID_PLATFORM>=21) && !defined(HXCPP_M64)
 extern "C" {
 
+// These functions are inlined prior to android-ndk-platform-21, which means they
+// are missing from the libc functions on those older versions.
+// If platform 21+ binaries are included in a build targetting an older platform,
+// this file adds those missing symbols so the platform 21+ objects link without errors.
 
 char * stpcpy(char *dest, const char *src)
 {
@@ -33,8 +34,11 @@ double atof(const char *nptr)
 {
     return (strtod(nptr, 0));
 }
-// extern __sighandler_t bsd_signal(int, __sighandler_t);
 
+// For bsd_signal, the problem was that it was missing from libc versions for platform 21
+// and above, until it was restored in ndk r13 for compatibilty.
+
+#ifdef HXCPP_ANDROID_COMPAT_BSD_SIGNAL
 
 typedef __sighandler_t (*bsd_signal_func_t)(int, __sighandler_t);
 bsd_signal_func_t bsd_signal_func = 0;
@@ -43,7 +47,7 @@ __sighandler_t bsd_signal(int s, __sighandler_t f)
 {
  if (bsd_signal_func == 0)
  {
-   // For now (up to Android 7.0) this is always available 
+   // For now (up to Android 7.0) this is always available
    bsd_signal_func = (bsd_signal_func_t) dlsym(RTLD_DEFAULT, "bsd_signal");
 
    if (bsd_signal_func == 0)
@@ -65,5 +69,8 @@ __sighandler_t signal(int s, __sighandler_t f)
 }
 
 }
+
+#endif
+
 #endif
 

--- a/src/hx/StdLibs.cpp
+++ b/src/hx/StdLibs.cpp
@@ -32,12 +32,6 @@ typedef int64_t __int64;
 #include <clocale>
 #include <mutex>
 
-
-#ifdef HX_ANDROID
-#define rand() lrand48()
-#define srand(x) srand48(x)
-#endif
-
 #ifdef HX_WINRT
 #define PRINTF WINRT_PRINTF
 #elif defined(TIZEN)

--- a/src/hx/cppia/Cppia.cpp
+++ b/src/hx/cppia/Cppia.cpp
@@ -11,11 +11,6 @@
 #include <stdlib.h>
 
 
-#ifdef HX_ANDROID
-  #define atof(x) strtod(x,0)
-#endif
-
-
 // Really microsoft?
 #ifdef interface
   #undef interface

--- a/src/hx/libs/mysql/Mysql.cpp
+++ b/src/hx/libs/mysql/Mysql.cpp
@@ -29,10 +29,6 @@
 #include "mysql.h"
 #include <string.h>
 
-#ifdef HX_ANDROID
-#define atof(x) strtod((x),0)
-#endif
-
 /**
    <doc>
    <h1>MySQL</h1>

--- a/toolchain/android-toolchain-gcc.xml
+++ b/toolchain/android-toolchain-gcc.xml
@@ -131,6 +131,7 @@
   <flag value="-DANDROID=ANDROID"/>
   <flag value="-DHX_ANDROID"/>
   <flag value="-DHXCPP_ANDROID_PLATFORM=${HXCPP_ANDROID_PLATFORM}"/>
+  <flag value="-DHXCPP_ANDROID_COMPAT_BSD_SIGNAL" unless="NDKV13+"/>
   <!-- todo <flag value="-Werror"/> -->
   <flag value="-Wa,--noexecstack"/>
   <flag value="-O2" unless="debug || HXCPP_OPTIMIZE_FOR_SIZE || HXCPP_OPTIMIZE_FOR_FAST"/>

--- a/toolchain/haxe-target.xml
+++ b/toolchain/haxe-target.xml
@@ -199,7 +199,7 @@
   <file name = "src/hx/Profiler.cpp" if="HXCPP_PROFILER" />
   <file name = "src/hx/Thread.cpp"/>
   <file name = "src/hx/RunLibs.cpp" if="static_link||dll_link"/>
-  <file name = "src/hx/AndroidCompat.cpp" if="android"/>
+  <file name = "src/hx/AndroidCompat.cpp" if="android" unless="HXCPP_ARM64||HXCPP_X86_64" />
 
   <file name = "src/Array.cpp"/>
   <file name = "src/hx/Class.cpp"/>

--- a/toolchain/haxe-target.xml
+++ b/toolchain/haxe-target.xml
@@ -199,7 +199,7 @@
   <file name = "src/hx/Profiler.cpp" if="HXCPP_PROFILER" />
   <file name = "src/hx/Thread.cpp"/>
   <file name = "src/hx/RunLibs.cpp" if="static_link||dll_link"/>
-  <file name = "src/hx/AndroidCompat.cpp" if="android" unless="HXCPP_ARM64||HXCPP_X86_64" />
+  <file name = "src/hx/AndroidCompat.cpp" if="android"/>
 
   <file name = "src/Array.cpp"/>
   <file name = "src/hx/Class.cpp"/>


### PR DESCRIPTION
This compat code was added in c91637a76c8b2045902a6825f4cdd71fb80a5006 to work around an [ndk compatibility issue](https://github.com/android/ndk/issues/160) when linking files that target platform 21 with older object files.

64 bit architectures (arm64 and x86_64) have only ever been supported with platform 21 and above, so this fix should be excluded from there. Keeping it enabled results in an error on x86_64 android builds that define HXCPP_CATCH_SEGV, because bsd_signal does not exist, so when hxcpp attempts to call signal there is a crash with the message: `"bsd_signal symbol not found!"`

Checking HXCPP_M64 instead of just HXCPP_ARM64 ensures that all 64-bit architectures are covered:
https://github.com/HaxeFoundation/hxcpp/blob/10f73c52cb4c82e72df20d012216b1592eff8d28/toolchain/common-defines.xml#L8