### PR TITLE
[tests] Check memcmp for ofArray for empty array

### DIFF
--- a/test/native/tests/TestPtr.hx
+++ b/test/native/tests/TestPtr.hx
@@ -222,6 +222,7 @@ class TestPtr extends Test
       var emptyInt:Array<Int> = [];
       cpp.Pointer.ofArray( emptyInt );
       Assert.equals( 0, emptyInt.length );
+      Assert.equals( 0, emptyInt.memcmp([]) );
    }
 
    public function testArrayAccess() {


### PR DESCRIPTION
This ensures the original reported case (#933) is also covered by the regression test.

Follow up to #1262. Closes #934.