### PR TITLE
[tool] Implement exe linker for android clang toolchain

### DIFF
--- a/test/std/testAndroid.hxml
+++ b/test/std/testAndroid.hxml
@@ -3,7 +3,8 @@
 -D exe_link
 -L hx4compat
 -L utest
---cmd adb push arm32/Test /storage/ext_sd
---cmd adb push Test.hx /storage/ext_sd
---cmd adb shell "cd /storage/ext_sd && ./Test"
---cpp arm32
+--cpp arm64
+--cmd adb push arm64/Test-64 /data/local/tmp
+--cmd adb push Test.hx /data/local/tmp
+--cmd adb shell "cd /data/local/tmp && ./Test-64"
+--cmd adb shell "rm /data/local/tmp/Test{-64,.hx}"

--- a/toolchain/android-toolchain-clang.xml
+++ b/toolchain/android-toolchain-clang.xml
@@ -106,7 +106,25 @@
   <prefix value="lib"/>
   <lib name="-llog"/>
   <ext value=".so"/>
-    
+
 </linker>
-    
+
+<linker id="exe" exe="clang++" >
+
+  <exe name="clang++" />
+
+  <ext value="" />
+  <outflag value="-o" />
+  <prefix value="" />
+
+  <flag value="--target=${ABITRIPLE}${HXCPP_ANDROID_PLATFORM}" />
+
+  <flag value="-Wl,--no-undefined" unless="HXCPP_ALLOW_UNDEFINED" />
+
+  <flag value="-static-libstdc++" />
+
+  <lib name="-llog" />
+
+</linker>
+
 </xml>

--- a/tools/hxcpp/BuildTool.hx
+++ b/tools/hxcpp/BuildTool.hx
@@ -148,6 +148,10 @@ class BuildTool
             m32 = arch=="x86";
             arm64 = arch=="arm64";
          }
+         else if (mDefines.exists("android"))
+         {
+            arm64 = true;
+         }
          else
          {
             var hostArch = getArch();


### PR DESCRIPTION
This implements the exe linker for android (for the modern clang toolchain), so it is possible to generate executables to run in the android shell. For example, this restores the std test hxml for android to a working state.

Closes #1016.