### PR TITLE
[ci] Release from commit instead of branch name

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -135,7 +135,7 @@ jobs:
           uses: ncipollo/release-action@v1
           with:
             tag: v${{ env.hxcpp_release }}
-            commit: ${{ github.ref }}
+            commit: ${{ github.sha }}
             name: Release ${{ env.hxcpp_release }}
             draft: false
             prerelease: false


### PR DESCRIPTION
The branch may have moved since the package workflow started, so we need to make sure we release from the original commit that triggered the workflow to avoid multiple releases being created from the head of the master branch.

This was meant to be fixed in #1328, but it looks like ref is still the branch name instead of the commit id... the correct field is `sha`:
https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#github-context

NB: To fix the current state, we will also have to manually create a v4.3.158 tag from the latest commit in master and push it.