### PR TITLE
Use std::atomic in the GC

### DIFF
--- a/include/hx/GC.h
+++ b/include/hx/GC.h
@@ -3,6 +3,7 @@
 
 #include <hx/Tls.h>
 #include <stdio.h>
+#include <atomic>
 
 // Under the current scheme (as defined by HX_HCSTRING/HX_CSTRING in hxcpp.h)
 //  each constant string data is prepended with a 4-byte header that says the string
@@ -154,7 +155,7 @@ void  GCSetFinalizer( hx::Object *, hx::finalizer f );
 // This automatically gets checked when you call "new", but if you are in long-running
 //  loop with no new call, you might starve another thread if you to not check this.
 //  0xffffffff = pause requested
-extern int gPauseForCollect;
+extern std::atomic_uint gPauseForCollect;
 
 
 // Minimum total memory - used + buffer for new objects

--- a/src/hx/gc/Immix.cpp
+++ b/src/hx/gc/Immix.cpp
@@ -266,7 +266,7 @@ static int sgSpamCollects = 0;
 #endif
 
 #if defined(HXCPP_DEBUG) || defined(HXCPP_GC_DEBUG_ALWAYS_MOVE)
-volatile int sgAllocsSinceLastSpam = 0;
+static std::atomic_int sgAllocsSinceLastSpam{};
 #endif
 
 #ifdef ANDROID
@@ -1487,7 +1487,7 @@ void GCOnNewPointer(void *inPtr)
 
    #ifdef HXCPP_GC_DEBUG_ALWAYS_MOVE
    hx::sgPointerMoved.erase(inPtr);
-   _hx_atomic_add(&sgAllocsSinceLastSpam, 1);
+   sgAllocsSinceLastSpam++;
    #endif
 }
 
@@ -6629,7 +6629,7 @@ void *InternalNew(size_t inSize,bool inIsObject)
       //GCLOG("InternalNew spam\n");
       CollectFromThisThread(false,false);
    }
-   _hx_atomic_add(&sgAllocsSinceLastSpam, 1);
+   sgAllocsSinceLastSpam++;
    #endif
 
    if (inSize>=IMMIX_LARGE_OBJ_SIZE)
@@ -6740,7 +6740,7 @@ void *InternalRealloc(size_t inFromSize, void *inData, size_t inSize, bool inExp
       //GCLOG("InternalNew spam\n");
       CollectFromThisThread(false,false);
    }
-   _hx_atomic_add(&sgAllocsSinceLastSpam, 1);
+   sgAllocsSinceLastSpam++;
    #endif
 
    void* new_data{};

--- a/src/hx/gc/Immix.cpp
+++ b/src/hx/gc/Immix.cpp
@@ -1501,10 +1501,10 @@ struct MarkInfo
 
 struct GlobalChunks
 {
-   volatile MarkChunk *processList;
-   std::atomic_int     processListPopLock;
-   volatile MarkChunk *freeList;
-   std::atomic_int     freeListPopLock;
+   std::atomic<MarkChunk*> processList;
+   std::atomic_int         processListPopLock;
+   std::atomic<MarkChunk*> freeList;
+   std::atomic_int         freeListPopLock;
 
    GlobalChunks()
    {
@@ -1518,9 +1518,9 @@ struct GlobalChunks
    {
       while(true)
       {
-         MarkChunk *head = (MarkChunk *)processList;
+         MarkChunk* head{ processList };
          inChunk->next = head;
-         if (_hx_atomic_compare_exchange_cast_ptr(&processList, head, inChunk) == head)
+         if (processList.compare_exchange_strong(head, inChunk))
             break;
       }
 
@@ -1531,9 +1531,9 @@ struct GlobalChunks
    {
       while(true)
       {
-         MarkChunk *head = (MarkChunk *)processList;
+         MarkChunk* head{ processList };
          inChunk->next = head;
-         if (_hx_atomic_compare_exchange_cast_ptr(&processList, head, inChunk) == head)
+         if (processList.compare_exchange_strong(head, inChunk))
             break;
       }
 
@@ -1576,14 +1576,14 @@ struct GlobalChunks
 
    void addLocked(MarkChunk *inChunk)
    {
-      inChunk->next = (MarkChunk *)processList;
-      processList = (volatile MarkChunk *)inChunk;
+      inChunk->next = processList;
+      processList = inChunk;
    }
 
    void copyPointers( QuickVec<hx::Object *> &outPointers,bool andFree=false)
    {
-      int size = 0;
-      for(MarkChunk *c =(MarkChunk *)processList; c; c=c->next )
+      int size{ 0 };
+      for (MarkChunk* c{ processList }; c; c = c->next)
          size += c->count;
 
       outPointers.setSize(size);
@@ -1592,19 +1592,19 @@ struct GlobalChunks
       {
          while(processList)
          {
-            MarkChunk *c = (MarkChunk *)processList;
+            MarkChunk* c{ processList };
             processList = c->next;
 
             for(int i=0;i<c->count;i++)
                outPointers[idx++] = c->stack[i];
             c->count = 0;
-            c->next = (MarkChunk *)freeList;
+            c->next = freeList;
             freeList = c;
          }
       }
       else
       {
-         for(MarkChunk *c = (MarkChunk *)processList; c; c=c->next )
+         for (MarkChunk* c{ processList }; c; c = c->next)
          {
             for(int i=0;i<c->count;i++)
                outPointers[idx++] = c->stack[i];
@@ -1639,9 +1639,9 @@ struct GlobalChunks
    {
       while(true)
       {
-         MarkChunk *head = (MarkChunk *)freeList;
+         MarkChunk* head{ freeList };
          inChunk->next = head;
-         if (_hx_atomic_compare_exchange_cast_ptr(&freeList, head, inChunk) == head)
+         if (freeList.compare_exchange_strong(head, inChunk))
             return;
       }
    }
@@ -1663,14 +1663,14 @@ struct GlobalChunks
 
       while(true)
       {
-         MarkChunk *head = (MarkChunk *)processList;
+         MarkChunk* head{ processList };
          if (!head)
          {
             processListPopLock = 0;
             return 0;
          }
          MarkChunk *next = head->next;
-         if (_hx_atomic_compare_exchange_cast_ptr(&processList, head, next) == head)
+         if (processList.compare_exchange_strong(head, next))
          {
             processListPopLock = 0;
 
@@ -1747,14 +1747,14 @@ struct GlobalChunks
 
       while(true)
       {
-         MarkChunk *head = (MarkChunk *)freeList;
+         MarkChunk* head{ freeList };
          if (!head)
          {
             freeListPopLock = 0;
             return new MarkChunk;
          }
-         MarkChunk *next = head->next;
-         if (_hx_atomic_compare_exchange_cast_ptr(&freeList, head, next) == head)
+         MarkChunk* next{ head->next };
+         if (freeList.compare_exchange_strong(head, next))
          {
             freeListPopLock = 0;
 

--- a/src/hx/gc/Immix.cpp
+++ b/src/hx/gc/Immix.cpp
@@ -738,7 +738,7 @@ struct BlockDataInfo
    #ifdef HXCPP_GC_GENERATIONAL
    bool         mHasSurvivor;
    #endif
-   volatile int mZeroLock;
+   std::atomic_int mZeroLock;
 
 
    BlockDataInfo(int inGid, BlockData *inData)
@@ -850,7 +850,8 @@ struct BlockDataInfo
       if (mZeroed)
          return false;
 
-      if (_hx_atomic_compare_exchange(&mZeroLock, 0,1) == 0)
+      int expected{ 0 };
+      if (mZeroLock.compare_exchange_strong(expected, 1))
          return zeroAndUnlock();
 
       return false;
@@ -3387,7 +3388,8 @@ public:
              if (!info->mOwned && info->mMaxHoleSize>=inRequiredBytes)
              {
                 // Acquire the zero-lock
-                if (_hx_atomic_compare_exchange(&info->mZeroLock, 0, 1) == 0)
+                int expected{ 0 };
+                if (info->mZeroLock.compare_exchange_strong(expected, 1))
                 {
                    // Acquire ownership...
                    if (info->mOwned)

--- a/src/hx/gc/Immix.cpp
+++ b/src/hx/gc/Immix.cpp
@@ -4315,7 +4315,7 @@ public:
    {
       while(!sgThreadPoolAbort)
       {
-         int blockId = _hx_atomic_add(&mThreadJobId, 1);
+         size_t blockId{ mThreadJobId.fetch_add(1) };
          if (blockId>=mAllBlocks.size())
             break;
 
@@ -4330,7 +4330,7 @@ public:
    {
       while(!sgThreadPoolAbort)
       {
-         int blockId = _hx_atomic_add(&mThreadJobId, 1);
+         size_t blockId{ mThreadJobId.fetch_add(1) };
          if (blockId>=mAllBlocks.size())
             break;
 
@@ -4343,7 +4343,7 @@ public:
    {
       while(!sgThreadPoolAbort)
       {
-         int blockId = _hx_atomic_add(&mThreadJobId, 1);
+         size_t blockId{ mThreadJobId.fetch_add(1) };
          if (blockId>=mAllBlocks.size())
             break;
 
@@ -4358,7 +4358,7 @@ public:
    {
       while(!sgThreadPoolAbort)
       {
-         int blockId = _hx_atomic_add(&mThreadJobId, 1);
+         size_t blockId{ mThreadJobId.fetch_add(1) };
          if (blockId>=mAllBlocks.size())
             break;
 
@@ -4372,7 +4372,7 @@ public:
    {
       while(!sgThreadPoolAbort)
       {
-         int zeroListId = _hx_atomic_add(&mThreadJobId, 1);
+         size_t zeroListId{ mThreadJobId.fetch_add(1) };
          if (zeroListId>=mZeroList.size())
             break;
 
@@ -4398,7 +4398,7 @@ public:
          spinCount = 0;
 
          // Look at next block...
-         int zeroListId = _hx_atomic_add(&mThreadJobId, 1);
+         size_t zeroListId{ mThreadJobId.fetch_add(1) };
          if (zeroListId>=mZeroList.size())
          {
             // Done, so sleep...
@@ -5570,7 +5570,7 @@ public:
    hx::MarkContext mMarker;
 
    volatile int mNextFreeBlockOfSize[BLOCK_OFSIZE_COUNT];
-   volatile int mThreadJobId;
+   std::atomic_size_t mThreadJobId;
 
    BlockList mAllBlocks;
    BlockList mFreeBlocks;

--- a/src/hx/gc/Immix.cpp
+++ b/src/hx/gc/Immix.cpp
@@ -213,7 +213,7 @@ static int sThreadMarkCountData[MAX_GC_THREADS+1];
 static int sThreadArrayMarkCountData[MAX_GC_THREADS+1];
 static int *sThreadMarkCount = sThreadMarkCountData + 1;
 static int *sThreadArrayMarkCount = sThreadArrayMarkCountData + 1;
-static int sThreadChunkPushCount;
+static std::atomic_int sThreadChunkPushCount;
 static int sThreadChunkWakes;
 static std::atomic_int sSpinCount = 0;
 static int sThreadZeroWaits = 0;
@@ -1506,39 +1506,33 @@ struct GlobalChunks
    std::atomic<MarkChunk*> freeList;
    std::atomic_int         freeListPopLock;
 
-   GlobalChunks()
-   {
-      processList = 0;
-      freeList = 0;
-      freeListPopLock = 0;
-      processListPopLock = 0;
-   }
+   GlobalChunks() : processList(), processListPopLock(), freeList(), freeListPopLock() {}
 
    MarkChunk *pushJobNoWake(MarkChunk *inChunk)
    {
-      while(true)
+      MarkChunk* head{};
+
+      do
       {
-         MarkChunk* head{ processList };
+         head = processList;
          inChunk->next = head;
-         if (processList.compare_exchange_strong(head, inChunk))
-            break;
-      }
+      } while (false == processList.compare_exchange_strong(head, inChunk));
 
       return alloc();
    }
 
    MarkChunk *pushJob(MarkChunk *inChunk,bool inAndAlloc)
    {
-      while(true)
+      MarkChunk* head{};
+
+      do
       {
-         MarkChunk* head{ processList };
+         head = processList;
          inChunk->next = head;
-         if (processList.compare_exchange_strong(head, inChunk))
-            break;
-      }
+      } while (false == processList.compare_exchange_strong(head, inChunk));
 
       #ifdef PROFILE_THREAD_USAGE
-      _hx_atomic_add(&sThreadChunkPushCount, 1);
+      sThreadChunkPushCount++;
       #endif
 
       if (MAX_GC_THREADS>1 && sLazyThreads)
@@ -1637,13 +1631,13 @@ struct GlobalChunks
 
    inline void release(MarkChunk *inChunk)
    {
-      while(true)
+      MarkChunk* head{};
+
+      do
       {
-         MarkChunk* head{ freeList };
+         head = freeList;
          inChunk->next = head;
-         if (freeList.compare_exchange_strong(head, inChunk))
-            return;
-      }
+      } while (false == freeList.compare_exchange_strong(head, inChunk));
    }
 
 

--- a/src/hx/gc/Immix.cpp
+++ b/src/hx/gc/Immix.cpp
@@ -413,7 +413,7 @@ static void CollectFromThisThread(bool inMajor,bool inForceCompact);
 
 namespace hx
 {
-int gPauseForCollect = 0x00000000;
+std::atomic_uint gPauseForCollect{ 0x00000000 };
 
 StackContext *gMainThreadContext = 0;
 
@@ -4823,7 +4823,8 @@ public:
       #ifndef HXCPP_SINGLE_THREADED_APP
       // If we set the flag from 0 -> 0xffffffff then we are the collector
       //  otherwise, someone else is collecting at the moment - so wait...
-      if (_hx_atomic_compare_exchange((volatile int *)&hx::gPauseForCollect, 0, 0xffffffff) != 0)
+      unsigned int expected{ 0 };
+      if (false == hx::gPauseForCollect.compare_exchange_strong(expected, std::numeric_limits<unsigned int>::max()))
       {
          if (inLocked)
          {

--- a/src/hx/gc/Immix.cpp
+++ b/src/hx/gc/Immix.cpp
@@ -4407,7 +4407,7 @@ public:
          if (info->tryZero())
          {
             // We zeroed it, so increase queue count
-            _hx_atomic_add(&mZeroListQueue, 1);
+            mZeroListQueue++;
             #ifdef PROFILE_THREAD_USAGE
             sThreadBlockZeroCount++;
             #endif
@@ -4421,7 +4421,7 @@ public:
    void onZeroedBlockDequeued()
    {
       // Wake the thread?
-      if (_hx_atomic_sub(&mZeroListQueue, 1)<sMinZeroQueueSize && !sRunningThreads)
+      if (mZeroListQueue.fetch_sub(1) < sMinZeroQueueSize && !sRunningThreads)
       {
          if (mZeroListQueue + mThreadJobId < mZeroList.size())
          {
@@ -5573,7 +5573,7 @@ public:
    BlockList mAllBlocks;
    BlockList mFreeBlocks;
    BlockList mZeroList;
-   volatile int mZeroListQueue;
+   std::atomic_int mZeroListQueue;
 
    LargeList mLargeList;
    std::mutex mLargeListLock;

--- a/src/hx/gc/Immix.cpp
+++ b/src/hx/gc/Immix.cpp
@@ -219,7 +219,7 @@ static int sSpinCount = 0;
 static int sThreadZeroWaits = 0;
 static int sThreadZeroPokes = 0;
 static int sThreadBlockZeroCount = 0;
-static volatile int sThreadZeroMisses = 0;
+static std::atomic_int sThreadZeroMisses{};
 #endif
 
 enum { MARK_BYTE_MASK = 0x0f };
@@ -3415,7 +3415,7 @@ public:
                          else
                          {
                             if (!info->mZeroed)
-                               _hx_atomic_add(&sThreadZeroMisses, 1);
+                                sThreadZeroMisses++;
                          }
                          #endif
                        }

--- a/src/hx/gc/Immix.cpp
+++ b/src/hx/gc/Immix.cpp
@@ -215,7 +215,7 @@ static int *sThreadMarkCount = sThreadMarkCountData + 1;
 static int *sThreadArrayMarkCount = sThreadArrayMarkCountData + 1;
 static int sThreadChunkPushCount;
 static int sThreadChunkWakes;
-static int sSpinCount = 0;
+static std::atomic_int sSpinCount = 0;
 static int sThreadZeroWaits = 0;
 static int sThreadZeroPokes = 0;
 static int sThreadBlockZeroCount = 0;
@@ -1502,9 +1502,9 @@ struct MarkInfo
 struct GlobalChunks
 {
    volatile MarkChunk *processList;
-   volatile int       processListPopLock;
+   std::atomic_int     processListPopLock;
    volatile MarkChunk *freeList;
-   volatile int       freeListPopLock;
+   std::atomic_int     freeListPopLock;
 
    GlobalChunks()
    {
@@ -1652,11 +1652,12 @@ struct GlobalChunks
       if (inChunk)
          release(inChunk);
 
-      while(_hx_atomic_compare_exchange(&processListPopLock, 0, 1) != 0)
+      int expected{ 0 };
+      while(false == processListPopLock.compare_exchange_strong(expected, 1))
       {
          // Spin
          #ifdef PROFILE_THREAD_USAGE
-         _hx_atomic_add(&sSpinCount, 1);
+         sSpinCount++;
          #endif
       }
 
@@ -1735,11 +1736,12 @@ struct GlobalChunks
 
    inline MarkChunk *alloc()
    {
-      while(_hx_atomic_compare_exchange(&freeListPopLock, 0, 1) != 0)
+      int expected{ 0 };
+      while(false == freeListPopLock.compare_exchange_strong(expected, 1))
       {
          // Spin
          #ifdef PROFILE_THREAD_USAGE
-         _hx_atomic_add(&sSpinCount, 1);
+         sSpinCount++;
          #endif
       }
 


### PR DESCRIPTION
Replace the vast majority of our custom atomic stuff with C++11 `std::atomic`. There are still three remaining uses of our old CAS function as it does atomic operations in the middle of a chunk of bytes. To do this with standard C++ we'd need to use `std::atomic_ref`, which was only added in C++20...