### PR TITLE
Fix large object marking regression

### DIFF
--- a/src/hx/gc/Immix.cpp
+++ b/src/hx/gc/Immix.cpp
@@ -5665,10 +5665,9 @@ void MarkConservative(int *inBottom, int *inTop,hx::MarkContext *__inCtx)
          {
             if (mem==memLarge)
             {
-               unsigned char& rMark{ reinterpret_cast<unsigned char*>(potentialObject)[HX_ENDIAN_MARK_ID_BYTE] };
-               int mark{ rMark };
-               if (mark!=gByteMarkID)
-                  mark = gByteMarkID;
+               unsigned char& mark{ reinterpret_cast<unsigned char*>(potentialObject)[HX_ENDIAN_MARK_ID_BYTE] };
+               if (mark != gByteMarkID)
+                  mark = static_cast<unsigned char>(gByteMarkID);
             }
             else
             {

--- a/test/haxe/gc/TestGC.hx
+++ b/test/haxe/gc/TestGC.hx
@@ -137,4 +137,15 @@ class TestGC extends Test {
 			Assert.isFalse( untyped __global__.__hxcpp_is_const_string(string) );
    }
    #end
+
+	public function testLargeAlloc() {
+		var largeString = {
+			var bytes = Bytes.alloc(4000);
+			bytes.fill(0, bytes.length, "a".code);
+			bytes.toString();
+		};
+		Assert.equals("aaaaa", largeString.substr(0, 5));
+		Gc.run(true);
+		Assert.equals("aaaaa", largeString.substr(0, 5));
+	}
 }


### PR DESCRIPTION
The temporary int variable introduced in ecda9430111dbefd1f2dba0eb33921b89dad9765 means that the write occurs to the local variable instead of to the mark byte via the reference to the header. This meant the gc would fail to mark any large objects and they would be collected immediately.

Found this because it caused the docgen haxe ci to crash while parsing a large xml file, because the string containing the file would get collected and turn into garbage:

https://github.com/HaxeFoundation/haxe/actions/runs/34024627810/job/101464156746?pr=13030#step:9:636
> \+ cpp/Dox -i ../../xmldoc -ex microsoft -ex javax -theme /home/runner/haxelib/dox/git//themes/default
Parsing ../../xmldoc/macro.xml
/home/runner/work/_temp/64a7f018-fabe-40cf-8455-895113584800.sh: line 13:  4404 Segmentation fault      (core dumped) cpp/Dox -i ../../xmldoc -ex microsoft -ex javax -theme $(haxelib libpath dox)/themes/default