### PR TITLE
Fix fragged rows signed-ness regression

### DIFF
--- a/src/hx/gc/Immix.cpp
+++ b/src/hx/gc/Immix.cpp
@@ -6288,11 +6288,9 @@ public:
 
                return buffer;
             }
-            if (mFraggedRows)
+            if (mFraggedRows && spaceEnd > spaceStart)
             {
-               size_t frag{ spaceEnd - spaceStart };
-               if (frag>0)
-                  *mFraggedRows += int{ static_cast<int>(frag >> IMMIX_LINE_BITS) };
+               *mFraggedRows += static_cast<int>((spaceEnd - spaceStart) >> IMMIX_LINE_BITS);
             }
          #endif
 


### PR DESCRIPTION
Fixes a behavioural regression in 952b6ac5ea90e3ac43f15b24d715e0f54dc4dde4, which caused the GC to continue allocating more blocks due to `sWorkingMemorySize` becoming corrupted.

The problem is that if spaceStart is greater than spaceEnd, `spaceEnd - spaceStart` would give a very large `size_t` instead of a negative `int`, and therefore `frag > 0` was true and `mFraggedRows` got updated to a random value. This had a domino effect on various variables before corrupting `sWorkingMemorySize`.

https://github.com/HaxeFoundation/hxcpp/blob/f05b21ce5b4ad514c8eb0181529e0b941c7827ba/src/hx/gc/Immix.cpp#L6293-L6296

https://github.com/HaxeFoundation/hxcpp/blob/f05b21ce5b4ad514c8eb0181529e0b941c7827ba/src/hx/gc/Immix.cpp#L877

https://github.com/HaxeFoundation/hxcpp/blob/f05b21ce5b4ad514c8eb0181529e0b941c7827ba/src/hx/gc/Immix.cpp#L5043

https://github.com/HaxeFoundation/hxcpp/blob/f05b21ce5b4ad514c8eb0181529e0b941c7827ba/src/hx/gc/Immix.cpp#L5225

https://github.com/HaxeFoundation/hxcpp/blob/f05b21ce5b4ad514c8eb0181529e0b941c7827ba/src/hx/gc/Immix.cpp#L5235

https://github.com/HaxeFoundation/hxcpp/blob/f05b21ce5b4ad514c8eb0181529e0b941c7827ba/src/hx/gc/Immix.cpp#L3607-L3611

I haven't looked into whether it even makes sense for spaceStart to be bigger than spaceEnd, but for now this brings back the old logic by skipping the update in that case.