### PR TITLE
size_t for gc globals

### DIFF
--- a/include/hx/GC.h
+++ b/include/hx/GC.h
@@ -159,13 +159,13 @@ extern std::atomic_uint gPauseForCollect;
 
 
 // Minimum total memory - used + buffer for new objects
-extern int sgMinimumWorkingMemory;
+extern size_t sgMinimumWorkingMemory;
 
 // Minimum free memory - not counting used memory
-extern int sgMinimumFreeSpace;
+extern size_t sgMinimumFreeSpace;
 
 // Also ensure that the free memory is larger than this amount of used memory
-extern int sgTargetFreeSpacePercentage;
+extern size_t sgTargetFreeSpacePercentage;
 
 
 extern HXCPP_EXTERN_CLASS_ATTRIBUTES int gByteMarkID;

--- a/src/hx/gc/GcCommon.cpp
+++ b/src/hx/gc/GcCommon.cpp
@@ -27,14 +27,14 @@ extern void __hxt_new_string(void* result, int size);
 namespace hx
 {
 #if defined(HX_MACOS) || defined(HX_WINDOWS) || defined(HX_LINUX) || defined(__ORBIS__)
-int sgMinimumWorkingMemory       = 20*1024*1024;
-int sgMinimumFreeSpace           = 10*1024*1024;
+size_t sgMinimumWorkingMemory       = 20*1024*1024;
+size_t sgMinimumFreeSpace           = 10*1024*1024;
 #else
-int sgMinimumWorkingMemory       = 8*1024*1024;
-int sgMinimumFreeSpace           = 4*1024*1024;
+size_t sgMinimumWorkingMemory       = 8*1024*1024;
+size_t sgMinimumFreeSpace           = 4*1024*1024;
 #endif
 // Once you use more than the minimum, this kicks in...
-int sgTargetFreeSpacePercentage  = 100;
+size_t sgTargetFreeSpacePercentage  = 100;
 
 
 
@@ -44,30 +44,36 @@ int sgTargetFreeSpacePercentage  = 100;
 // Called internally before and GC operations
 void CommonInitAlloc()
 {
+    // It is probably safe to use something like strtoull for parsing the size_t values as I'm sure every reasonable implementation treats them as uint64_t.
+    // But just to be pedantic let's use sscanf which is the only "official" way to do this in C++11.
+    // C++17 gives us std::charconv but I haven't twisted enough arms yet to have 17 be the minimum version.
+
    #if !defined(HX_WINRT) && !defined(__SNC__) && !defined(__ORBIS__)
-   const char *minimumWorking = getenv("HXCPP_MINIMUM_WORKING_MEMORY");
+   const char *minimumWorking{ getenv("HXCPP_MINIMUM_WORKING_MEMORY") };
    if (minimumWorking)
    {
-      int mem =  atoi(minimumWorking);
-      if (mem>0)
-         sgMinimumWorkingMemory = mem;
+       if (1 != std::sscanf(minimumWorking, "%zu", &sgMinimumWorkingMemory))
+       {
+           hx::CriticalError(HX_CSTRING("Failed to parse number from HXCPP_MINIMUM_WORKING_MEMORY environment variable"));
+       }
    }
 
-   const char *minimumFreeSpace = getenv("HXCPP_MINIMUM_FREE_SPACE");
+   const char* minimumFreeSpace{ getenv("HXCPP_MINIMUM_FREE_SPACE") };
    if (minimumFreeSpace)
    {
-      int mem =  atoi(minimumFreeSpace);
-      if (mem>0)
-         sgMinimumFreeSpace = mem;
+       if (1 != std::sscanf(minimumFreeSpace, "%zu", &sgMinimumFreeSpace))
+       {
+           hx::CriticalError(HX_CSTRING("Failed to parse number from HXCPP_MINIMUM_FREE_SPACE environment variable"));
+       }
    }
 
-
-   const char *targetFree = getenv("HXCPP_TARGET_FREE_SPACE");
+   const char* targetFree{ getenv("HXCPP_TARGET_FREE_SPACE") };
    if (targetFree)
    {
-      int percent =  atoi(targetFree);
-      if (percent>0)
-         sgTargetFreeSpacePercentage = percent;
+       if (1 != std::sscanf(targetFree, "%zu", &sgTargetFreeSpacePercentage))
+       {
+           hx::CriticalError(HX_CSTRING("Failed to parse number from HXCPP_TARGET_FREE_SPACE environment variable"));
+       }
    }
    #endif
 }

--- a/src/hx/gc/Immix.cpp
+++ b/src/hx/gc/Immix.cpp
@@ -97,7 +97,6 @@ void DebuggerTrap()
 
 static bool sgAllocInit = 0;
 static bool sgInternalEnable = true;
-static void *sgObject_root = 0;
 // With virtual inheritance, stack pointers can point to the middle of an object
 #ifdef _MSC_VER
 // MSVC optimizes by taking the address of an initernal data member
@@ -5126,13 +5125,13 @@ public:
          else
          {
             size_t mem = mRowsInUse<<IMMIX_LINE_BITS;
-            size_t targetFree = std::max((size_t)hx::sgMinimumFreeSpace, mem/100 * (size_t)hx::sgTargetFreeSpacePercentage );
-            targetFree = std::min(targetFree, (size_t)sgMaximumFreeSpace );
-            sWorkingMemorySize = std::max( mem + targetFree, (size_t)hx::sgMinimumWorkingMemory);
+            size_t targetFree = std::max(hx::sgMinimumFreeSpace, mem / 100 * hx::sgTargetFreeSpacePercentage );
+            targetFree = std::min(targetFree, sgMaximumFreeSpace );
+            sWorkingMemorySize = std::max( mem + targetFree, hx::sgMinimumWorkingMemory);
 
             size_t allMem = GetWorkingMemory();
             // 8 Meg too much?
-            size_t allowExtra = std::max( (size_t)8*1024*1024, sWorkingMemorySize*5/4 );
+            size_t allowExtra = std::max(size_t{ 8 } * 1024 * 1024, sWorkingMemorySize * 5 / 4);
 
             if ( allMem > sWorkingMemorySize + allowExtra )
             {
@@ -5176,9 +5175,9 @@ public:
                if (doRelease)
                {
                   size_t mem = mRowsInUse<<IMMIX_LINE_BITS;
-                  size_t targetFree = std::max((size_t)hx::sgMinimumFreeSpace, bytesInUse/100 *hx::sgTargetFreeSpacePercentage );
-                  targetFree = std::min(targetFree, (size_t)sgMaximumFreeSpace );
-                  size_t targetMem = std::max( mem + targetFree, (size_t)hx::sgMinimumWorkingMemory) +
+                  size_t targetFree = std::max(hx::sgMinimumFreeSpace, bytesInUse/100 *hx::sgTargetFreeSpacePercentage );
+                  targetFree = std::min(targetFree, sgMaximumFreeSpace );
+                  size_t targetMem = std::max( mem + targetFree, hx::sgMinimumWorkingMemory) +
                                         (2<<(IMMIX_BLOCK_GROUP_BITS+IMMIX_BLOCK_BITS));
 
                   if (inForceCompact)
@@ -5225,14 +5224,14 @@ public:
       size_t mem = mRowsInUse<<IMMIX_LINE_BITS;
       size_t baseMem = full ? bytesInUse : mem;
       #ifdef HXCPP_GC_DYNAMIC_SIZE
-      size_t targetFree = std::max((size_t)hx::sgMinimumFreeSpace, (size_t)(baseMem * profileCollectSummary.spaceFactor ) );
+      size_t targetFree = std::max(hx::sgMinimumFreeSpace, baseMem * profileCollectSummary.spaceFactor );
       #else
-      size_t targetFree = std::max((size_t)hx::sgMinimumFreeSpace, baseMem/100 *hx::sgTargetFreeSpacePercentage );
+      size_t targetFree = std::max(hx::sgMinimumFreeSpace, baseMem / 100 *hx::sgTargetFreeSpacePercentage );
       #endif
-      targetFree = std::min(targetFree, (size_t)sgMaximumFreeSpace );
+      targetFree = std::min(targetFree, sgMaximumFreeSpace );
       // Only adjust if non-generational
       if (!generational)
-         sWorkingMemorySize = std::max( mem + targetFree, (size_t)hx::sgMinimumWorkingMemory);
+         sWorkingMemorySize = std::max( mem + targetFree, hx::sgMinimumWorkingMemory);
 
       #if defined(SHOW_FRAGMENTATION) || defined(SHOW_MEM_EVENTS)
       GCLOG("Target memory %s, using %s\n",  formatBytes(sWorkingMemorySize).c_str(), formatBytes(mem).c_str() );
@@ -6556,9 +6555,6 @@ void InitAlloc()
    sgFinalizers = new FinalizerList();
    sFinalizerLock = new std::mutex();
    sGCRootLock = new std::mutex();
-   hx::Object tmp;
-   void **stack = *(void ***)(&tmp);
-   sgObject_root = stack[0];
 
    //GCLOG("__root pointer %p\n", sgObject_root);
    gMainThreadContext =  new LocalAllocator();

--- a/src/hx/gc/Immix.cpp
+++ b/src/hx/gc/Immix.cpp
@@ -6556,7 +6556,6 @@ void InitAlloc()
    sFinalizerLock = new std::mutex();
    sGCRootLock = new std::mutex();
 
-   //GCLOG("__root pointer %p\n", sgObject_root);
    gMainThreadContext =  new LocalAllocator();
 
    tlsStackContext = gMainThreadContext;


### PR DESCRIPTION
This updates those global `sg` variables to be `size_t`. I think looking at switching QuickVec to being `size_t` based will be the thing to tackle next as there's lots of questionable implicit conversions going on with `size` and the likes.