### PR TITLE
Restore outPre and outPost manifest tag parsing

### DIFF
--- a/tools/hxcpp/BuildTool.hx
+++ b/tools/hxcpp/BuildTool.hx
@@ -1241,6 +1241,8 @@ class BuildTool
                     if (el.has.name)
                        s.mFlags.push(substitute(el.att.name));
                     s.mFlags.push(substitute(el.att.value));
+                case "outPre" : s.mOutPre = substitute(el.att.value);
+                case "outPost" : s.mOutPost = substitute(el.att.value);
                 case "exe" : s.mExe = substitute((el.att.name));
             }
       }


### PR DESCRIPTION
These were removed in 01ef3fa595cceb6a4e045eff38191f6d6cf1cece, seemingly due to a copy-paste error. They are used for the msvc-toolchain, so they cannot be removed:

https://github.com/HaxeFoundation/hxcpp/blob/ceb70d040f0792f004ccf1ed7eb6fcea01d7f3ff/toolchain/msvc-toolchain.xml#L171-L172

Closes #1193