### PR TITLE
Fix haxe 4 compile time regressions

### DIFF
--- a/include/cpp/Pointer.h
+++ b/include/cpp/Pointer.h
@@ -215,7 +215,10 @@ public:
       hx::Object *obj = inVariant.asObject();
       ptr = obj  ? (T*)inVariant.valObject->__GetHandle() : 0;
    }
+
+#if (HXCPP_API_LEVEL >= 500)
    inline Pointer(const ::cpp::marshal::PointerReference<T>);
+#endif
 
    template<typename O>
    inline Pointer( const O *inValue ) : ptr( (T*) inValue) { }
@@ -512,12 +515,13 @@ public:
       return AutoCast(base->GetBase());
    }
 
-
+#if (HXCPP_API_LEVEL >= 500)
     template<typename T>
     inline static Pointer<T> addressOf(const ::cpp::marshal::ValueReference<T>&);
 
     template<typename T>
     inline static Pointer<T*> addressOf(const ::cpp::marshal::PointerReference<T>&);
+#endif
 
    template<typename T>
 	inline static Pointer<T> addressOf(T &value)  { return Pointer<T>(&value); }

--- a/include/cpp/marshal/Definitions.inc
+++ b/include/cpp/marshal/Definitions.inc
@@ -189,30 +189,6 @@ namespace cpp
             void set(int64_t index, K value);
         };
 
-        template<class T>
-        struct View final
-        {
-            ::cpp::Pointer<T> ptr;
-            int64_t length;
-
-            View(::cpp::Pointer<T> _ptr, int64_t _length);
-
-            void clear() const;
-            void fill(T value) const;
-            bool isEmpty() const;
-            View<T> slice(int64_t index) const;
-            View<T> slice(int64_t index, int64_t length) const;
-            void copyTo(const View<T>& destination) const;
-            bool tryCopyTo(const View<T>& destination) const;
-            template<class K> View<K> reinterpret() const;
-            int compare(const View<T>& inRHS) const;
-
-            bool operator==(const View<T>& inRHS) const;
-            bool operator!=(const View<T>& inRHS) const;
-
-            T& operator[] (int64_t index) const;
-        };
-
         class RootHandle
         {
             ::hx::Object** object;

--- a/include/cpp/marshal/View.hpp
+++ b/include/cpp/marshal/View.hpp
@@ -1,6 +1,37 @@
 #pragma once
 
-#include "Definitions.inc"
+#include <stddef.h>
+#include <cpp/Pointer.h>
+
+namespace cpp {
+namespace marshal {
+
+template<class T>
+struct View final {
+    ::cpp::Pointer<T> ptr;
+    int64_t length;
+
+    View(::cpp::Pointer<T> _ptr, int64_t _length);
+
+    void clear() const;
+    void fill(T value) const;
+    bool isEmpty() const;
+    View<T> slice(int64_t index) const;
+    View<T> slice(int64_t index, int64_t length) const;
+    void copyTo(const View<T>& destination) const;
+    bool tryCopyTo(const View<T>& destination) const;
+    template<class K> View<K> reinterpret() const;
+    int compare(const View<T>& inRHS) const;
+
+    bool operator==(const View<T>& inRHS) const;
+    bool operator!=(const View<T>& inRHS) const;
+
+    T& operator[] (int64_t index) const;
+};
+
+};
+};
+
 #include <cstring>
 #include <cmath>
 

--- a/include/hx/LessThanEq.h
+++ b/include/hx/LessThanEq.h
@@ -246,6 +246,8 @@ struct CompareTraits< T * >
    inline static bool isNull(T *inValue) { return !inValue; }
 };
 
+#if (HXCPP_API_LEVEL>=500)
+
 template <typename T>
 struct CompareTraits< cpp::marshal::ValueReference<T> >
 {
@@ -273,6 +275,8 @@ struct CompareTraits< cpp::marshal::PointerReference<T> >
     inline static int getDynamicCompareType(const ::Dynamic&) { return type; }
     inline static bool isNull(const ::cpp::marshal::PointerReference<T>& ref) { return nullptr == ref.ptr || nullptr == *ref.ptr; }
 };
+
+#endif
 
 template<typename T1>
 hx::Object *GetExistingObject(const T1 &v1)
@@ -437,6 +441,8 @@ inline bool TestLessEq(const T1 &v1, const T2 &v2)
 template<typename T1, typename T2>
 bool IsEq(const T1 &v1, const T2 &v2) { return TestLessEq<false,true,T1,T2>(v1,v2); }
 
+#if (HXCPP_API_LEVEL>=500)
+
 template<typename T1, typename T2>
 bool IsEq(const ::cpp::marshal::ValueReference<T1>& v1, const ::cpp::marshal::ValueReference<T2>& v2) { return v1 == v2; }
 
@@ -459,14 +465,20 @@ bool IsEq(const ::cpp::marshal::PointerReference<T1>& v1, const ::cpp::marshal::
     return *v1.ptr == *v2.ptr;
 }
 
+#endif
+
 template<typename T1, typename T2>
 bool IsNotEq(const T1 &v1, const T2 &v2) { return TestLessEq<false,false,T1,T2>(v1,v2); }
+
+#if (HXCPP_API_LEVEL>=500)
 
 template<typename T1, typename T2>
 bool IsNotEq(const ::cpp::marshal::ValueReference<T1>& v1, const ::cpp::marshal::ValueReference<T2>& v2) { return v1 != v2; }
 
 template<typename T1, typename T2>
 bool IsNotEq(const ::cpp::marshal::PointerReference<T1>& v1, const ::cpp::marshal::PointerReference<T2>& v2) { return IsEq(v1, v2) == false; }
+
+#endif
 
 template<typename T1, typename T2>
 bool IsLess(const T1 &v1, const T2 &v2) { return TestLessEq<true,false,T1,T2>(v1,v2); }

--- a/include/hx/zip/Zip.hpp
+++ b/include/hx/zip/Zip.hpp
@@ -4,6 +4,8 @@
 #include <hxcpp.h>
 #endif
 
+#include <cpp/marshal/View.hpp>
+
 HX_DECLARE_CLASS2(hx, zip, Zip)
 
 namespace hx

--- a/include/hxString.h
+++ b/include/hxString.h
@@ -47,8 +47,10 @@ public:
    static String create(const char16_t *inPtr,int inLen=-1);
    static String create(const char *inPtr,int inLen=-1);
 
+#if (HXCPP_API_LEVEL >= 500)
    static String create(const ::cpp::marshal::View<char>& buffer);
    static String create(const ::cpp::marshal::View<char16_t>& buffer);
+#endif
 
    // Uses non-gc memory and wont ever be collected
    static ::String createPermanent(const char *inUtf8, int inLen);
@@ -174,8 +176,10 @@ public:
    const wchar_t *wchar_str(hx::IStringAlloc *inBuffer = 0) const;
    const char16_t *wc_str(hx::IStringAlloc *inBuffer = 0, int *outCharLength = 0) const;
 
+#if (HXCPP_API_LEVEL >= 500)
    bool wc_str(::cpp::marshal::View<char16_t> buffer, int* outCharLength = nullptr) const;
    bool utf8_str(::cpp::marshal::View<char> buffer, int* outByteLength = nullptr) const;
+#endif
 
    const char *__CStr() const { return utf8_str(); };
    const wchar_t *__WCStr() const { return wchar_str(0); }

--- a/include/hxcpp.h
+++ b/include/hxcpp.h
@@ -261,6 +261,7 @@ namespace hx { template<typename O> class ObjectPtr; }
 namespace cpp { template<typename S,typename H> class Struct; }
 namespace cpp { template<typename T> class Pointer; }
 namespace cpp { template<typename T> class Function; }
+#if (HXCPP_API_LEVEL>=500)
 namespace cpp { namespace marshal { template<class T> class Boxed_obj; } }
 namespace cpp { namespace marshal { template<class T> using Boxed =::hx::ObjectPtr<Boxed_obj<T>>; } }
 namespace cpp { namespace marshal { template<class T> class ValueType; } }
@@ -268,6 +269,7 @@ namespace cpp { namespace marshal { template<class T> class ValueReference; } }
 namespace cpp { namespace marshal { template<class T> class PointerType; } }
 namespace cpp { namespace marshal { template<class T> class PointerReference; } }
 namespace cpp { namespace marshal { template<class T> struct View; } }
+#endif
 template<typename ELEM_> class Array_obj;
 template<typename ELEM_> class Array;
 namespace hx {
@@ -360,21 +362,21 @@ typedef PropertyAccessMode PropertyAccess;
 #endif
 #include <hx/StdLibs.h>
 #include <cpp/Pointer.h>
-#include <cpp/marshal/Boxed.hpp>
-#include <cpp/marshal/ValueType.hpp>
-#include <cpp/marshal/PointerType.hpp>
-#include <cpp/marshal/ValueReference.hpp>
-#include <cpp/marshal/PointerReference.hpp>
-#include <cpp/marshal/View.hpp>
-#include <cpp/marshal/Marshal.hpp>
-#include <cpp/marshal/RootHandle.hpp>
-#include <cpp/encoding/Ascii.hpp>
-#include <cpp/encoding/Utf8.hpp>
-#include <cpp/encoding/Utf16.hpp>
 #include <hx/Native.h>
 #include <hx/Operators.h>
 #if (HXCPP_API_LEVEL>=500)
-#include <hx/Invoker.h>
+  #include <cpp/marshal/Boxed.hpp>
+  #include <cpp/marshal/ValueType.hpp>
+  #include <cpp/marshal/PointerType.hpp>
+  #include <cpp/marshal/ValueReference.hpp>
+  #include <cpp/marshal/PointerReference.hpp>
+  #include <cpp/marshal/View.hpp>
+  #include <cpp/marshal/Marshal.hpp>
+  #include <cpp/marshal/RootHandle.hpp>
+  #include <cpp/encoding/Ascii.hpp>
+  #include <cpp/encoding/Utf8.hpp>
+  #include <cpp/encoding/Utf16.hpp>
+  #include <hx/Invoker.h>
 #endif
 // second time ...
 #include <cpp/Variant.h>

--- a/src/String.cpp
+++ b/src/String.cpp
@@ -790,6 +790,8 @@ String String::create(const char *inString,int inLength)
    return String(s,len);
 }
 
+#if (HXCPP_API_LEVEL>=500)
+
 String String::create(const::cpp::marshal::View<char>& buffer)
 {
     auto start = buffer.ptr.ptr;
@@ -825,6 +827,8 @@ String String::create(const cpp::marshal::View<char16_t>& buffer)
 
     return String::create(buffer.ptr.ptr, buffer.length - (end - start) - extra);
 }
+
+#endif
 
 String::String(const Dynamic &inRHS)
 {
@@ -1800,6 +1804,8 @@ const char16_t * String::wc_str(hx::IStringAlloc *inBuffer, int *outCharLength) 
    return str;
 }
 
+#if (HXCPP_API_LEVEL>=500)
+
 bool String::wc_str(::cpp::marshal::View<char16_t> buffer, int* outCharLength) const
 {
 #ifdef HX_SMART_STRINGS
@@ -1921,6 +1927,8 @@ bool String::utf8_str(::cpp::marshal::View<char> buffer, int* outByteLength) con
 
     return true;
 }
+
+#endif
 
 const wchar_t * String::wchar_str(hx::IStringAlloc *inBuffer) const
 {

--- a/src/cpp/encoding/Encodings.cpp
+++ b/src/cpp/encoding/Encodings.cpp
@@ -1,4 +1,6 @@
 #include <hxcpp.h>
+
+#if (HXCPP_API_LEVEL>=500)
 #include <array>
 
 using namespace cpp::marshal;
@@ -652,3 +654,5 @@ inline char32_t cpp::encoding::Utf16::codepoint(const cpp::marshal::View<uint8_t
         return static_cast<char32_t>(first);
     }
 }
+
+#endif

--- a/src/hx/thread/Scratch.cpp
+++ b/src/hx/thread/Scratch.cpp
@@ -1,4 +1,6 @@
 #include <hxcpp.h>
+
+#if (HXCPP_API_LEVEL>=500)
 #include <hx/thread/Scratch.hpp>
 #include "ThreadImpl.hpp"
 
@@ -72,3 +74,5 @@ hx::thread::Scratch& hx::thread::Scratch::operator=(const Scratch& _other)
 
 	return *this;
 }
+
+#endif


### PR DESCRIPTION
In #1277 there was an observed increase in Haxe 4 compile time, probably due to all the marshalling headers being added. This attempts to reverse the regression.